### PR TITLE
fix: create new Pagar.me subscription after scheduled downgrade

### DIFF
--- a/src/modules/payments/pagarme/pagarme.types.ts
+++ b/src/modules/payments/pagarme/pagarme.types.ts
@@ -129,6 +129,13 @@ export type PagarmeSubscription = {
   updated_at: string;
   customer: PagarmeCustomer;
   plan: PagarmePlan;
+  card?: {
+    id: string;
+    last_four_digits: string;
+    brand: string;
+    exp_month: number;
+    exp_year: number;
+  };
   metadata?: Record<string, string>;
 };
 

--- a/src/modules/payments/plan-change/__tests__/execute-scheduled-change.test.ts
+++ b/src/modules/payments/plan-change/__tests__/execute-scheduled-change.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, spyOn, test } from "bun:test";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
+import { BillingProfileFactory } from "@/test/factories/payments/billing-profile.factory";
 import { PlanFactory } from "@/test/factories/payments/plan.factory";
 import { SubscriptionFactory } from "@/test/factories/payments/subscription.factory";
 import { UserFactory } from "@/test/factories/user.factory";
@@ -149,7 +150,7 @@ describe("PlanChangeService.executeScheduledChange", () => {
   // which covers the validation logic. The executeScheduledChange re-validates
   // using the same logic, so we trust the unit tests for that edge case.
 
-  test("should cancel Pagarme subscription before executing change", async () => {
+  test("should cancel old and create new Pagarme subscription on downgrade", async () => {
     const { organizationId } = await UserFactory.createWithOrganization({
       emailVerified: true,
     });
@@ -164,7 +165,16 @@ describe("PlanChangeService.executeScheduledChange", () => {
       currentPlan.id
     );
 
+    // Create billing profile with Pagarme customer ID
+    const pagarmeCustomerId = `cus_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    await BillingProfileFactory.create({
+      organizationId,
+      pagarmeCustomerId,
+    });
+
     const pagarmeSubId = `sub_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    const cardId = `card_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    const newPagarmeSubId = `sub_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
 
     // Set up subscription with Pagarme ID and pending change
     const scheduledAt = new Date();
@@ -182,21 +192,65 @@ describe("PlanChangeService.executeScheduledChange", () => {
       })
       .where(eq(schema.orgSubscriptions.id, subscriptionId));
 
-    // Mock Pagarme cancel
+    // Mock Pagarme operations
     const { PagarmeClient } = await import("@/modules/payments/pagarme/client");
+    const { PagarmePlanService } = await import(
+      "@/modules/payments/pagarme/pagarme-plan.service"
+    );
+
+    const getSpy = spyOn(PagarmeClient, "getSubscription").mockResolvedValue({
+      id: pagarmeSubId,
+      card: {
+        id: cardId,
+        last_four_digits: "1234",
+        brand: "visa",
+        exp_month: 12,
+        exp_year: 2030,
+      },
+    } as never);
+
     const cancelSpy = spyOn(
       PagarmeClient,
       "cancelSubscription"
     ).mockResolvedValue({} as never);
 
+    const ensurePlanSpy = spyOn(
+      PagarmePlanService,
+      "ensurePlan"
+    ).mockResolvedValue("pagarme_plan_123");
+
+    const createSubSpy = spyOn(
+      PagarmeClient,
+      "createSubscription"
+    ).mockResolvedValue({ id: newPagarmeSubId } as never);
+
     // Execute the scheduled change
     await PlanChangeService.executeScheduledChange(subscriptionId);
 
-    // Verify Pagarme cancel was called
+    // Verify old subscription was fetched for card info
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy.mock.calls[0][0]).toBe(pagarmeSubId);
+
+    // Verify old subscription was canceled
     expect(cancelSpy).toHaveBeenCalledTimes(1);
     expect(cancelSpy.mock.calls[0][0]).toBe(pagarmeSubId);
 
-    // Verify subscription was updated and pagarmeSubscriptionId cleared
+    // Verify Pagarme plan was ensured for new tier
+    expect(ensurePlanSpy).toHaveBeenCalledTimes(1);
+    expect(ensurePlanSpy.mock.calls[0][0]).toBe(newTiers[0].id);
+    expect(ensurePlanSpy.mock.calls[0][1]).toBe("monthly");
+
+    // Verify new subscription was created with correct parameters
+    expect(createSubSpy).toHaveBeenCalledTimes(1);
+    const createArgs = createSubSpy.mock.calls[0][0];
+    expect(createArgs.customer_id).toBe(pagarmeCustomerId);
+    expect(createArgs.plan_id).toBe("pagarme_plan_123");
+    expect(createArgs.payment_method).toBe("credit_card");
+    expect(createArgs.card_id).toBe(cardId);
+    expect(createArgs.metadata?.organization_id).toBe(organizationId);
+    expect(createArgs.metadata?.is_downgrade).toBe("true");
+
+    // Verify subscription was updated with new Pagarme subscription ID
     const [subscription] = await db
       .select()
       .from(schema.orgSubscriptions)
@@ -204,9 +258,164 @@ describe("PlanChangeService.executeScheduledChange", () => {
       .limit(1);
 
     expect(subscription.planId).toBe(newPlan.id);
-    expect(subscription.pagarmeSubscriptionId).toBeNull();
+    expect(subscription.pagarmeSubscriptionId).toBe(newPagarmeSubId);
 
+    getSpy.mockRestore();
     cancelSpy.mockRestore();
+    ensurePlanSpy.mockRestore();
+    createSubSpy.mockRestore();
+  });
+
+  test("should proceed with null pagarmeSubscriptionId when card fetch fails", async () => {
+    const { organizationId } = await UserFactory.createWithOrganization({
+      emailVerified: true,
+    });
+
+    const { plan: currentPlan, tiers: currentTiers } =
+      await PlanFactory.createPaid("diamond");
+    const { plan: newPlan, tiers: newTiers } =
+      await PlanFactory.createPaid("gold");
+
+    const subscriptionId = await SubscriptionFactory.createActive(
+      organizationId,
+      currentPlan.id
+    );
+
+    const pagarmeSubId = `sub_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+
+    const scheduledAt = new Date();
+    scheduledAt.setDate(scheduledAt.getDate() - 1);
+
+    await db
+      .update(schema.orgSubscriptions)
+      .set({
+        pagarmeSubscriptionId: pagarmeSubId,
+        pendingPlanId: newPlan.id,
+        pendingBillingCycle: "monthly",
+        pendingPricingTierId: newTiers[0].id,
+        pricingTierId: currentTiers[0].id,
+        planChangeAt: scheduledAt,
+      })
+      .where(eq(schema.orgSubscriptions.id, subscriptionId));
+
+    const { PagarmeClient } = await import("@/modules/payments/pagarme/client");
+
+    // getSubscription fails - can't get card
+    const getSpy = spyOn(PagarmeClient, "getSubscription").mockRejectedValue(
+      new Error("Pagarme API error")
+    );
+    const cancelSpy = spyOn(
+      PagarmeClient,
+      "cancelSubscription"
+    ).mockResolvedValue({} as never);
+
+    await PlanChangeService.executeScheduledChange(subscriptionId);
+
+    // Change should still complete, but without new Pagarme subscription
+    const [subscription] = await db
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.id, subscriptionId))
+      .limit(1);
+
+    expect(subscription.planId).toBe(newPlan.id);
+    expect(subscription.pricingTierId).toBe(newTiers[0].id);
+    expect(subscription.pagarmeSubscriptionId).toBeNull();
+    expect(subscription.pendingPlanId).toBeNull();
+
+    getSpy.mockRestore();
+    cancelSpy.mockRestore();
+  });
+
+  test("should proceed with null pagarmeSubscriptionId when createSubscription fails", async () => {
+    const { organizationId } = await UserFactory.createWithOrganization({
+      emailVerified: true,
+    });
+
+    const { plan: currentPlan, tiers: currentTiers } =
+      await PlanFactory.createPaid("diamond");
+    const { plan: newPlan, tiers: newTiers } =
+      await PlanFactory.createPaid("gold");
+
+    const subscriptionId = await SubscriptionFactory.createActive(
+      organizationId,
+      currentPlan.id
+    );
+
+    const pagarmeCustomerId = `cus_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    await BillingProfileFactory.create({
+      organizationId,
+      pagarmeCustomerId,
+    });
+
+    const pagarmeSubId = `sub_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    const cardId = `card_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+
+    const scheduledAt = new Date();
+    scheduledAt.setDate(scheduledAt.getDate() - 1);
+
+    await db
+      .update(schema.orgSubscriptions)
+      .set({
+        pagarmeSubscriptionId: pagarmeSubId,
+        pendingPlanId: newPlan.id,
+        pendingBillingCycle: "monthly",
+        pendingPricingTierId: newTiers[0].id,
+        pricingTierId: currentTiers[0].id,
+        planChangeAt: scheduledAt,
+      })
+      .where(eq(schema.orgSubscriptions.id, subscriptionId));
+
+    const { PagarmeClient } = await import("@/modules/payments/pagarme/client");
+    const { PagarmePlanService } = await import(
+      "@/modules/payments/pagarme/pagarme-plan.service"
+    );
+
+    const getSpy = spyOn(PagarmeClient, "getSubscription").mockResolvedValue({
+      id: pagarmeSubId,
+      card: {
+        id: cardId,
+        last_four_digits: "1234",
+        brand: "visa",
+        exp_month: 12,
+        exp_year: 2030,
+      },
+    } as never);
+
+    const cancelSpy = spyOn(
+      PagarmeClient,
+      "cancelSubscription"
+    ).mockResolvedValue({} as never);
+
+    const ensurePlanSpy = spyOn(
+      PagarmePlanService,
+      "ensurePlan"
+    ).mockResolvedValue("pagarme_plan_123");
+
+    // createSubscription fails
+    const createSubSpy = spyOn(
+      PagarmeClient,
+      "createSubscription"
+    ).mockRejectedValue(new Error("Pagarme API error"));
+
+    await PlanChangeService.executeScheduledChange(subscriptionId);
+
+    // Change should still complete, but without new Pagarme subscription
+    const [subscription] = await db
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.id, subscriptionId))
+      .limit(1);
+
+    expect(subscription.planId).toBe(newPlan.id);
+    expect(subscription.pricingTierId).toBe(newTiers[0].id);
+    expect(subscription.pagarmeSubscriptionId).toBeNull();
+    expect(subscription.pendingPlanId).toBeNull();
+
+    getSpy.mockRestore();
+    cancelSpy.mockRestore();
+    ensurePlanSpy.mockRestore();
+    createSubSpy.mockRestore();
   });
 
   test("should handle concurrent cancellation gracefully", async () => {

--- a/src/modules/payments/plan-change/plan-change.service.ts
+++ b/src/modules/payments/plan-change/plan-change.service.ts
@@ -244,6 +244,7 @@ export abstract class PlanChangeService {
   /**
    * Executes a scheduled plan change. Called by the daily job.
    * Uses transaction to prevent race conditions with user cancellation.
+   * Creates a new Pagar.me subscription for the downgraded plan.
    */
   static async executeScheduledChange(subscriptionId: string): Promise<void> {
     // 1. First read to check if we need to cancel Pagarme subscription
@@ -265,7 +266,15 @@ export abstract class PlanChangeService {
       return;
     }
 
-    // 2. Cancel current Pagarme subscription OUTSIDE transaction (can fail)
+    // 2. Fetch card info from old subscription before canceling
+    let oldSubscriptionCardId: string | null = null;
+    if (initialSubscription.pagarmeSubscriptionId) {
+      oldSubscriptionCardId = await PlanChangeService.fetchCardFromSubscription(
+        initialSubscription.pagarmeSubscriptionId
+      );
+    }
+
+    // 3. Cancel current Pagarme subscription OUTSIDE transaction (can fail)
     if (initialSubscription.pagarmeSubscriptionId) {
       const pagarmeSubId = initialSubscription.pagarmeSubscriptionId;
       try {
@@ -283,18 +292,26 @@ export abstract class PlanChangeService {
       }
     }
 
-    // 3. Execute plan change inside transaction
+    // 4. Create new Pagarme subscription for the downgraded plan
+    const newPagarmeSubscriptionId =
+      await PlanChangeService.createDowngradeSubscription({
+        subscription: initialSubscription,
+        cardId: oldSubscriptionCardId,
+      });
+
+    // 5. Execute plan change inside transaction
     const result = await db.transaction(async (tx) => {
       const transactionResult =
         await PlanChangeService.executeScheduledChangeTransaction(
           tx,
           subscriptionId,
-          currentPlan.displayName
+          currentPlan.displayName,
+          newPagarmeSubscriptionId
         );
       return transactionResult;
     });
 
-    // 4. Emit event and send email OUTSIDE transaction
+    // 6. Emit event and send email OUTSIDE transaction
     if (result?.subscription) {
       PaymentHooks.emit("planChange.executed", {
         subscription: result.subscription,
@@ -821,7 +838,8 @@ export abstract class PlanChangeService {
   private static async executeScheduledChangeTransaction(
     tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
     subscriptionId: string,
-    currentPlanDisplayName: string
+    currentPlanDisplayName: string,
+    newPagarmeSubscriptionId: string | null
   ): Promise<{
     subscription: typeof schema.orgSubscriptions.$inferSelect;
     previousPlanId: string;
@@ -910,7 +928,7 @@ export abstract class PlanChangeService {
         pendingBillingCycle: null,
         pendingPricingTierId: null,
         planChangeAt: null,
-        pagarmeSubscriptionId: null,
+        pagarmeSubscriptionId: newPagarmeSubscriptionId,
         currentPeriodStart: new Date(),
         currentPeriodEnd: ProrationService.calculatePeriodEnd(
           new Date(),
@@ -928,6 +946,114 @@ export abstract class PlanChangeService {
       newPlanName: newPlan.displayName,
       organizationId: subscription.organizationId,
     };
+  }
+
+  /**
+   * Fetches the card ID from an existing Pagar.me subscription.
+   * Returns null if the subscription cannot be fetched or has no card.
+   */
+  private static async fetchCardFromSubscription(
+    pagarmeSubscriptionId: string
+  ): Promise<string | null> {
+    try {
+      const pagarmeSubscription = await Retry.withRetry(
+        () => PagarmeClient.getSubscription(pagarmeSubscriptionId),
+        PAGARME_RETRY_CONFIG.READ
+      );
+      return pagarmeSubscription.card?.id ?? null;
+    } catch {
+      const { logger } = await import("@/lib/logger");
+      logger.warn({
+        type: "plan-change:execute:fetch-card-failed",
+        pagarmeSubscriptionId,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Creates a new Pagar.me subscription for a downgrade using the customer's stored card.
+   * Returns the new subscription ID, or null if creation fails.
+   */
+  private static async createDowngradeSubscription(params: {
+    subscription: typeof schema.orgSubscriptions.$inferSelect;
+    cardId: string | null;
+  }): Promise<string | null> {
+    const { subscription, cardId } = params;
+
+    if (!cardId) {
+      const { logger } = await import("@/lib/logger");
+      logger.warn({
+        type: "plan-change:execute:no-card-for-downgrade",
+        subscriptionId: subscription.id,
+        organizationId: subscription.organizationId,
+      });
+      return null;
+    }
+
+    const newPricingTierId =
+      subscription.pendingPricingTierId ?? subscription.pricingTierId;
+    const newBillingCycle = (subscription.pendingBillingCycle ??
+      subscription.billingCycle ??
+      "monthly") as "monthly" | "yearly";
+    const newPlanId = subscription.pendingPlanId ?? subscription.planId;
+
+    if (!newPricingTierId) {
+      return null;
+    }
+
+    try {
+      const pagarmePlanId = await PagarmePlanService.ensurePlan(
+        newPricingTierId,
+        newBillingCycle
+      );
+
+      const pagarmeCustomerId = await CustomerService.getCustomerId(
+        subscription.organizationId
+      );
+
+      if (!pagarmeCustomerId) {
+        const { logger } = await import("@/lib/logger");
+        logger.warn({
+          type: "plan-change:execute:no-customer-for-downgrade",
+          subscriptionId: subscription.id,
+          organizationId: subscription.organizationId,
+        });
+        return null;
+      }
+
+      const newSubscription = await Retry.withRetry(
+        () =>
+          PagarmeClient.createSubscription(
+            {
+              customer_id: pagarmeCustomerId,
+              plan_id: pagarmePlanId,
+              payment_method: "credit_card",
+              card_id: cardId,
+              metadata: {
+                organization_id: subscription.organizationId,
+                plan_id: newPlanId,
+                billing_cycle: newBillingCycle,
+                pricing_tier_id: newPricingTierId,
+                is_downgrade: "true",
+              },
+            },
+            `create-downgrade-sub-${subscription.id}-${Date.now()}`
+          ),
+        PAGARME_RETRY_CONFIG.WRITE
+      );
+
+      return newSubscription.id;
+    } catch (error) {
+      const { logger } = await import("@/lib/logger");
+      logger.error({
+        type: "plan-change:execute:create-subscription-failed",
+        subscriptionId: subscription.id,
+        organizationId: subscription.organizationId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- When a scheduled downgrade executes, the old Pagar.me subscription was canceled but no new one was created, leaving `pagarmeSubscriptionId: null` and the customer with no recurring billing
- Now `executeScheduledChange` fetches the card from the old Pagar.me subscription, cancels it, then creates a new subscription for the downgraded plan using the stored card via `PagarmeClient.createSubscription()`
- Handles API failures gracefully: if card fetch or subscription creation fails, the local plan change still completes (with `pagarmeSubscriptionId: null` and structured logging for manual follow-up)

## Changes

- **`pagarme.types.ts`** — Added `card` field to `PagarmeSubscription` type to support extracting card ID from existing subscriptions
- **`plan-change.service.ts`** — Added `fetchCardFromSubscription()` and `createDowngradeSubscription()` private methods; modified `executeScheduledChange()` to create new Pagar.me subscription after canceling old one; updated `executeScheduledChangeTransaction()` to accept `newPagarmeSubscriptionId` parameter
- **`execute-scheduled-change.test.ts`** — Updated existing test to verify full cancel+create flow; added tests for card fetch failure and subscription creation failure scenarios

## Acceptance Criteria (from #22)

- [x] Given a scheduled downgrade, when the job executes it, then a new Pagar.me subscription is created for the new plan/tier/price
- [x] Given the downgrade completes, when querying `org_subscriptions`, then `pagarmeSubscriptionId` is NOT null
- [x] Given the new Pagar.me subscription, when the next billing cycle arrives, then the customer is charged the new (lower) price
- [x] Given the old Pagar.me subscription, when it's canceled, then no further charges are made on the old plan
- [x] Given a downgrade execution fails midway (e.g., Pagar.me API error), when the job runs, then the subscription state remains consistent (logs error, proceeds with local change)

## Design Decision

Chose **Option A** from issue: create subscription directly via `PagarmeClient.createSubscription()` using stored card, rather than generating checkout link (Option B) or updating subscription plan (Option C). This provides a seamless experience — the customer doesn't need to take any action.

## Test plan

- [x] Verify new Pagar.me subscription is created with correct customer_id, plan_id, card_id, and metadata
- [x] Verify old subscription is canceled and new `pagarmeSubscriptionId` is stored
- [x] Verify graceful degradation when card fetch fails (API error)
- [x] Verify graceful degradation when `createSubscription` fails
- [x] Verify existing tests still pass (concurrent cancellation, missing tier, no pending change)
- [x] Verify downgrade use-case integration test passes (29/29)
- [x] Lint passes (`npx ultracite check`: 0 issues)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)