### PR TITLE
fix: store priceAtPurchase on upgrade plan changes

### DIFF
--- a/src/modules/payments/__tests__/price-at-purchase.test.ts
+++ b/src/modules/payments/__tests__/price-at-purchase.test.ts
@@ -148,6 +148,93 @@ describe("priceAtPurchase tracking", () => {
   });
 
   // ============================================================
+  // AC4: Plan change (upgrade) updates priceAtPurchase
+  // ============================================================
+
+  describe("upgrade activation updates priceAtPurchase", () => {
+    test("should set priceAtPurchase to new tier price after upgrade via metadata", async () => {
+      const org = await OrganizationFactory.create();
+      const goldTier = PlanFactory.getFirstTier(goldResult);
+      const diamondTier = PlanFactory.getFirstTier(diamondResult);
+
+      // Start with Gold subscription
+      await SubscriptionFactory.createActive(org.id, goldResult.plan.id, {
+        billingCycle: "monthly",
+        pricingTierId: goldTier.id,
+      });
+
+      // Set initial priceAtPurchase (Gold tier price)
+      await db
+        .update(schema.orgSubscriptions)
+        .set({
+          priceAtPurchase: goldTier.priceMonthly,
+          isCustomPrice: false,
+        })
+        .where(eq(schema.orgSubscriptions.organizationId, org.id));
+
+      // Simulate upgrade: subscription.created with Diamond metadata
+      const payload = new WebhookPayloadBuilder()
+        .subscriptionCreated()
+        .withOrganizationId(org.id)
+        .withPlanId(diamondResult.plan.id)
+        .withPricingTierId(diamondTier.id)
+        .withBillingCycle("monthly")
+        .build();
+
+      await WebhookService.process(
+        payload,
+        createValidAuthHeader(),
+        JSON.stringify(payload)
+      );
+
+      const [subscription] = await db
+        .select()
+        .from(schema.orgSubscriptions)
+        .where(eq(schema.orgSubscriptions.organizationId, org.id))
+        .limit(1);
+
+      expect(subscription.priceAtPurchase).toBe(diamondTier.priceMonthly);
+      expect(subscription.isCustomPrice).toBe(false);
+      expect(subscription.planId).toBe(diamondResult.plan.id);
+    });
+
+    test("should set yearly priceAtPurchase when upgrade changes to yearly billing", async () => {
+      const org = await OrganizationFactory.create();
+      const goldTier = PlanFactory.getFirstTier(goldResult);
+      const diamondTier = PlanFactory.getFirstTier(diamondResult);
+
+      await SubscriptionFactory.createActive(org.id, goldResult.plan.id, {
+        billingCycle: "monthly",
+        pricingTierId: goldTier.id,
+      });
+
+      // Simulate upgrade: subscription.created with Diamond yearly
+      const payload = new WebhookPayloadBuilder()
+        .subscriptionCreated()
+        .withOrganizationId(org.id)
+        .withPlanId(diamondResult.plan.id)
+        .withPricingTierId(diamondTier.id)
+        .withBillingCycle("yearly")
+        .build();
+
+      await WebhookService.process(
+        payload,
+        createValidAuthHeader(),
+        JSON.stringify(payload)
+      );
+
+      const [subscription] = await db
+        .select()
+        .from(schema.orgSubscriptions)
+        .where(eq(schema.orgSubscriptions.organizationId, org.id))
+        .limit(1);
+
+      expect(subscription.priceAtPurchase).toBe(diamondTier.priceYearly);
+      expect(subscription.isCustomPrice).toBe(false);
+    });
+  });
+
+  // ============================================================
   // AC4: Plan change (downgrade) updates priceAtPurchase
   // ============================================================
 

--- a/src/modules/payments/plan-change/plan-change.service.ts
+++ b/src/modules/payments/plan-change/plan-change.service.ts
@@ -1266,6 +1266,7 @@ export abstract class PlanChangeService {
       metadata: {
         organization_id: organizationId,
         plan_id: newPlan.id,
+        pricing_tier_id: newTier.id,
         billing_cycle: finalBillingCycle,
         is_upgrade: "true",
         previous_subscription_id: subscription.id,


### PR DESCRIPTION
## Summary

Closes #24

- Adds `pricing_tier_id` to the upgrade checkout payment link metadata so the `subscription.created` webhook can resolve the tier's catalog price
- Adds integration tests for upgrade flow priceAtPurchase tracking (monthly and yearly)

## Context

The `priceAtPurchase` field was already populated for:
- Self-service checkout (via pending_checkout and metadata paths)
- Admin checkout (custom price)
- Downgrade execution (`executeScheduledChange`)
- Trial (null by default)

The **only gap** was the upgrade flow: `createUnifiedUpgradeCheckout` omitted `pricing_tier_id` from the Pagarme payment link metadata. When `subscription.created` fired, the webhook resolved `organizationId` from metadata (taking the metadata path), but `pricingTierId` was undefined — causing the tier price resolution at `resolveCheckoutInfo` to skip entirely.

## Changes

| File | Change |
|------|--------|
| `plan-change.service.ts` | Add `pricing_tier_id: newTier.id` to upgrade checkout metadata |
| `price-at-purchase.test.ts` | Add 2 tests: upgrade monthly + upgrade yearly priceAtPurchase |

## Test plan

- [x] All 1672 tests pass (`bun run test`)
- [x] Lint passes (`npx ultracite check`)
- [x] New tests verify upgrade sets priceAtPurchase from tier catalog (monthly and yearly)
- [x] Existing tests verify self-service, downgrade, trial, immutability, and response schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)