### PR TITLE
feat: add PT-BR validations, date range checks, and CPF/CNPJ validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,35 @@ const isProduction = process.env.NODE_ENV === "production";
 
 const RATE_LIMIT_SKIP_PATHS = ["/health", "/health/live", "/api/auth"];
 
+// biome-ignore lint/suspicious/noExplicitAny: Zod v4 internal API for extracting check error messages
+function extractErrorMessages(zodDef: any): Record<string, string> | null {
+  const { checks } = zodDef;
+  if (!(checks && Array.isArray(checks))) {
+    return null;
+  }
+
+  const errorMessages: Record<string, string> = {};
+  for (const check of checks) {
+    const checkDef = check._zod?.def;
+    if (!checkDef?.error || typeof checkDef.error !== "function") {
+      continue;
+    }
+    try {
+      const msg = checkDef.error({ input: "" });
+      if (typeof msg === "string") {
+        const key = checkDef.format
+          ? `${checkDef.check}:${checkDef.format}`
+          : checkDef.check;
+        errorMessages[key] = msg;
+      }
+    } catch {
+      // Skip checks that can't produce a message
+    }
+  }
+
+  return Object.keys(errorMessages).length > 0 ? errorMessages : null;
+}
+
 const app = new Elysia({
   serve: {
     maxRequestBodySize: 1024 * 1024 * 10,
@@ -83,6 +112,11 @@ const app = new Elysia({
               if (ctx.zodSchema._zod.def.type === "date") {
                 ctx.jsonSchema.type = "string";
                 ctx.jsonSchema.format = "date-time";
+              }
+
+              const messages = extractErrorMessages(ctx.zodSchema._zod.def);
+              if (messages) {
+                ctx.jsonSchema["x-error-messages"] = messages;
               }
             },
           }),

--- a/src/lib/auth-plugin.ts
+++ b/src/lib/auth-plugin.ts
@@ -229,6 +229,67 @@ let _schema: ReturnType<typeof auth.api.generateOpenAPISchema>;
 // biome-ignore lint/suspicious/noAssignInExpressions: memoization pattern from better-auth docs
 const getSchema = async () => (_schema ??= auth.api.generateOpenAPISchema());
 
+/**
+ * Adds validation constraints to better-auth OpenAPI schemas.
+ * Better-auth generates schemas with bare `{ type: "string" }` properties.
+ * This overlay adds format, minLength, and maxLength constraints so
+ * Kubb can generate Zod schemas with proper validations on the frontend.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: OpenAPI schema typing from better-auth
+function addAuthSchemaValidations(components: any): void {
+  const schemas = components?.schemas;
+  if (!schemas) {
+    return;
+  }
+
+  for (const schemaName of Object.keys(schemas)) {
+    const schema = schemas[schemaName];
+    const properties = schema?.properties;
+    if (!properties) {
+      continue;
+    }
+
+    if (properties.email) {
+      properties.email.format = "email";
+      properties.email.minLength = 1;
+      properties.email["x-error-messages"] = {
+        "string_format:email": "Email inválido",
+        min_length: "Email é obrigatório",
+      };
+    }
+
+    if (properties.password) {
+      properties.password.minLength = 8;
+      properties.password["x-error-messages"] = {
+        min_length: "Senha deve ter no mínimo 8 caracteres",
+      };
+    }
+
+    if (properties.newPassword) {
+      properties.newPassword.minLength = 8;
+      properties.newPassword["x-error-messages"] = {
+        min_length: "Nova senha deve ter no mínimo 8 caracteres",
+      };
+    }
+
+    if (properties.currentPassword) {
+      properties.currentPassword.minLength = 8;
+      properties.currentPassword["x-error-messages"] = {
+        min_length: "Senha atual deve ter no mínimo 8 caracteres",
+      };
+    }
+
+    if (properties.name) {
+      properties.name.minLength = 2;
+      properties.name.maxLength = 100;
+      properties.name["x-error-messages"] = {
+        min_length: "Nome deve ter no mínimo 2 caracteres",
+        max_length: "Nome deve ter no máximo 100 caracteres",
+      };
+    }
+  }
+}
+
 export const OpenAPI = {
   getPaths: (prefix = "/api/auth") =>
     getSchema().then(({ paths }) => {
@@ -249,6 +310,9 @@ export const OpenAPI = {
       return reference;
       // biome-ignore lint/suspicious/noExplicitAny: OpenAPI schema typing from better-auth
     }) as Promise<any>,
-  // biome-ignore lint/suspicious/noExplicitAny: OpenAPI schema typing from better-auth
-  components: getSchema().then(({ components }) => components) as Promise<any>,
+  components: getSchema().then(({ components }) => {
+    addAuthSchemaValidations(components);
+    return components;
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI schema typing from better-auth
+  }) as Promise<any>,
 } as const;

--- a/src/modules/employees/__tests__/create-employee.test.ts
+++ b/src/modules/employees/__tests__/create-employee.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { generateCpf } from "@/test/helpers/faker";
 import { createTestJobClassification } from "@/test/helpers/job-classification";
 import { createTestJobPosition } from "@/test/helpers/job-position";
 import { createTestSector } from "@/test/helpers/sector";
@@ -21,7 +22,7 @@ const createValidEmployeeData = (overrides?: Record<string, unknown>) => ({
   birthplace: "São Paulo",
   nationality: "Brasileiro",
   motherName: "Maria da Silva",
-  cpf: "12345678901",
+  cpf: generateCpf(),
   identityCard: "123456789",
   pis: "12345678901",
   workPermitNumber: "1234567",
@@ -202,8 +203,9 @@ describe("POST /v1/employees", () => {
 
     const deps = await createTestDependencies(organizationId, user.id);
 
+    const sharedCpf = generateCpf();
     const employeeData = createValidEmployeeData({
-      cpf: "98765432101",
+      cpf: sharedCpf,
       ...deps,
     });
 
@@ -341,7 +343,7 @@ describe("POST /v1/employees", () => {
         },
         body: JSON.stringify(
           createValidEmployeeData({
-            cpf: "11122233344",
+            cpf: generateCpf(),
             ...deps,
           })
         ),

--- a/src/modules/employees/__tests__/update-employee.test.ts
+++ b/src/modules/employees/__tests__/update-employee.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestEmployee } from "@/test/helpers/employee";
+import { generateCpf } from "@/test/helpers/faker";
 import {
   createTestUser,
   createTestUserWithOrganization,
@@ -104,17 +105,20 @@ describe("PUT /v1/employees/:id", () => {
         emailVerified: true,
       });
 
+    const cpf1 = generateCpf();
+    const cpf2 = generateCpf();
+
     const { dependencies } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      cpf: "20202020202",
+      cpf: cpf1,
     });
 
     const { employee: employee2 } = await createTestEmployee({
       organizationId,
       userId: user.id,
       dependencies,
-      cpf: "30303030303",
+      cpf: cpf2,
     });
 
     const response = await app.handle(
@@ -124,7 +128,7 @@ describe("PUT /v1/employees/:id", () => {
           ...headers,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ cpf: "20202020202" }),
+        body: JSON.stringify({ cpf: cpf1 }),
       })
     );
 

--- a/src/modules/employees/employee.model.ts
+++ b/src/modules/employees/employee.model.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { successResponseSchema } from "@/lib/responses/response.types";
 import { entityReferenceSchema } from "@/lib/schemas/relationships";
+import { isValidCPF } from "@/lib/validation/documents";
 
 const isFutureDate = (dateStr: string) => {
   const date = new Date(dateStr);
@@ -105,6 +106,7 @@ export const createEmployeeSchema = z.object({
   cpf: z
     .string()
     .regex(/^\d{11}$/, "CPF deve ter 11 dígitos")
+    .refine((val) => isValidCPF(val), "CPF inválido")
     .describe("CPF (11 dígitos)"),
   identityCard: z
     .string()

--- a/src/modules/occurrences/absences/__tests__/create-absence.test.ts
+++ b/src/modules/occurrences/absences/__tests__/create-absence.test.ts
@@ -100,7 +100,7 @@ describe("POST /v1/absences", () => {
 
     expect(response.status).toBe(422);
     const body = await response.json();
-    expect(body.error.code).toBe("ABSENCE_INVALID_DATE_RANGE");
+    expect(body.error.code).toBe("VALIDATION_ERROR");
   });
 
   test("should create absence successfully", async () => {

--- a/src/modules/occurrences/absences/absence.model.ts
+++ b/src/modules/occurrences/absences/absence.model.ts
@@ -6,27 +6,47 @@ export const absenceTypeEnum = z.enum(["justified", "unjustified"]);
 
 export type AbsenceType = z.infer<typeof absenceTypeEnum>;
 
-export const createAbsenceSchema = z.object({
+const absenceFieldsSchema = z.object({
   employeeId: z
     .string()
     .min(1, "ID do funcionário é obrigatório")
     .describe("ID do funcionário"),
   startDate: z
     .string()
-    .min(1, "Data de início é obrigatória")
+    .date("Data de início deve ser uma data válida")
     .describe("Data de início (YYYY-MM-DD)"),
   endDate: z
     .string()
-    .min(1, "Data de término é obrigatória")
+    .date("Data de término deve ser uma data válida")
     .describe("Data de término (YYYY-MM-DD)"),
   type: absenceTypeEnum.describe("Tipo da ausência"),
   reason: z.string().optional().describe("Motivo da ausência"),
   notes: z.string().optional().describe("Observações adicionais"),
 });
 
-export const updateAbsenceSchema = createAbsenceSchema
+export const createAbsenceSchema = absenceFieldsSchema.refine(
+  (data) => data.startDate <= data.endDate,
+  {
+    message: "Data final deve ser igual ou posterior à data inicial",
+    path: ["endDate"],
+  }
+);
+
+export const updateAbsenceSchema = absenceFieldsSchema
   .partial()
-  .omit({ employeeId: true });
+  .omit({ employeeId: true })
+  .refine(
+    (data) => {
+      if (data.startDate && data.endDate) {
+        return data.startDate <= data.endDate;
+      }
+      return true;
+    },
+    {
+      message: "Data final deve ser igual ou posterior à data inicial",
+      path: ["endDate"],
+    }
+  );
 
 export const idParamSchema = z.object({
   id: z.string().min(1).describe("ID da ausência"),

--- a/src/modules/occurrences/terminations/__tests__/create-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/create-termination.test.ts
@@ -23,9 +23,9 @@ describe("POST /v1/terminations", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: "employee-123",
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "RESIGNATION",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );
@@ -42,9 +42,9 @@ describe("POST /v1/terminations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: "employee-123",
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "RESIGNATION",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );
@@ -77,9 +77,9 @@ describe("POST /v1/terminations", () => {
         },
         body: JSON.stringify({
           employeeId: "employee-123",
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "RESIGNATION",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );
@@ -100,9 +100,9 @@ describe("POST /v1/terminations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: "employee-nonexistent",
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "RESIGNATION",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );
@@ -131,9 +131,9 @@ describe("POST /v1/terminations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: otherEmployee.id,
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "RESIGNATION",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );
@@ -210,7 +210,7 @@ describe("POST /v1/terminations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-02-15",
           type: "RESIGNATION",
           reason: "Pedido de demissão para nova oportunidade",
           noticePeriodDays: 30,
@@ -229,7 +229,7 @@ describe("POST /v1/terminations", () => {
     expect(body.data.employee.id).toBe(employee.id);
     expect(body.data.employee.name).toBeString();
     expect(body.data.organizationId).toBe(organizationId);
-    expect(body.data.terminationDate).toBe("2024-01-15");
+    expect(body.data.terminationDate).toBe("2024-02-15");
     expect(body.data.type).toBe("RESIGNATION");
     expect(body.data.reason).toBe("Pedido de demissão para nova oportunidade");
     expect(body.data.noticePeriodDays).toBe(30);
@@ -266,9 +266,9 @@ describe("POST /v1/terminations", () => {
         },
         body: JSON.stringify({
           employeeId: employee.id,
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "DISMISSAL_WITHOUT_CAUSE",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );
@@ -296,9 +296,9 @@ describe("POST /v1/terminations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          terminationDate: "2024-01-15",
+          terminationDate: "2024-01-30",
           type: "MUTUAL_AGREEMENT",
-          lastWorkingDay: "2024-01-30",
+          lastWorkingDay: "2024-01-15",
         }),
       })
     );

--- a/src/modules/occurrences/terminations/termination.model.ts
+++ b/src/modules/occurrences/terminations/termination.model.ts
@@ -9,7 +9,7 @@ const isFutureDate = (dateStr: string) => {
   return date > today;
 };
 
-export const createTerminationSchema = z.object({
+const terminationFieldsSchema = z.object({
   employeeId: z
     .string()
     .min(1, "ID do funcionário é obrigatório")
@@ -61,9 +61,31 @@ export const createTerminationSchema = z.object({
     .describe("Observações adicionais (opcional)"),
 });
 
-export const updateTerminationSchema = createTerminationSchema
+export const createTerminationSchema = terminationFieldsSchema.refine(
+  (data) => data.lastWorkingDay <= data.terminationDate,
+  {
+    message:
+      "Último dia trabalhado deve ser anterior ou igual à data de demissão",
+    path: ["lastWorkingDay"],
+  }
+);
+
+export const updateTerminationSchema = terminationFieldsSchema
   .omit({ employeeId: true })
-  .partial();
+  .partial()
+  .refine(
+    (data) => {
+      if (data.lastWorkingDay && data.terminationDate) {
+        return data.lastWorkingDay <= data.terminationDate;
+      }
+      return true;
+    },
+    {
+      message:
+        "Último dia trabalhado deve ser anterior ou igual à data de demissão",
+      path: ["lastWorkingDay"],
+    }
+  );
 
 export const idParamSchema = z.object({
   id: z.string().min(1).describe("ID da demissão"),

--- a/src/modules/occurrences/vacations/vacation.model.ts
+++ b/src/modules/occurrences/vacations/vacation.model.ts
@@ -5,80 +5,133 @@ import { entityReferenceSchema } from "@/lib/schemas/relationships";
 
 const vacationStatuses = vacationStatusEnum.enumValues;
 
-export const createVacationSchema = z
-  .object({
-    employeeId: z
-      .string()
-      .min(1, "Employee ID is required")
-      .describe("Employee ID"),
-    startDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
-      .describe("Vacation start date (YYYY-MM-DD)"),
-    endDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
-      .describe("Vacation end date (YYYY-MM-DD)"),
-    daysTotal: z
-      .number()
-      .int()
-      .positive("Total days must be positive")
-      .describe("Total vacation days"),
-    daysUsed: z
-      .number()
-      .int()
-      .nonnegative("Days used cannot be negative")
-      .describe("Days used"),
-    acquisitionPeriodStart: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
-      .describe("Acquisition period start date (YYYY-MM-DD)"),
-    acquisitionPeriodEnd: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date format (YYYY-MM-DD)")
-      .describe("Acquisition period end date (YYYY-MM-DD)"),
-    status: z
-      .enum(vacationStatuses)
-      .default("scheduled")
-      .describe("Vacation status"),
-    notes: z.string().optional().describe("Optional notes"),
-  })
+const vacationFieldsSchema = z.object({
+  employeeId: z
+    .string()
+    .min(1, "ID do funcionário é obrigatório")
+    .describe("ID do funcionário"),
+  startDate: z
+    .string()
+    .regex(
+      /^\d{4}-\d{2}-\d{2}$/,
+      "Data de início deve estar no formato YYYY-MM-DD"
+    )
+    .describe("Data de início das férias (YYYY-MM-DD)"),
+  endDate: z
+    .string()
+    .regex(
+      /^\d{4}-\d{2}-\d{2}$/,
+      "Data de término deve estar no formato YYYY-MM-DD"
+    )
+    .describe("Data de término das férias (YYYY-MM-DD)"),
+  daysTotal: z
+    .number()
+    .int("Total de dias deve ser um número inteiro")
+    .positive("Total de dias deve ser positivo")
+    .describe("Total de dias de férias"),
+  daysUsed: z
+    .number()
+    .int("Dias utilizados deve ser um número inteiro")
+    .nonnegative("Dias utilizados não pode ser negativo")
+    .describe("Dias utilizados"),
+  acquisitionPeriodStart: z
+    .string()
+    .regex(
+      /^\d{4}-\d{2}-\d{2}$/,
+      "Início do período aquisitivo deve estar no formato YYYY-MM-DD"
+    )
+    .describe("Início do período aquisitivo (YYYY-MM-DD)"),
+  acquisitionPeriodEnd: z
+    .string()
+    .regex(
+      /^\d{4}-\d{2}-\d{2}$/,
+      "Fim do período aquisitivo deve estar no formato YYYY-MM-DD"
+    )
+    .describe("Fim do período aquisitivo (YYYY-MM-DD)"),
+  status: z
+    .enum(vacationStatuses)
+    .default("scheduled")
+    .describe("Status das férias"),
+  notes: z.string().optional().describe("Observações"),
+});
+
+export const createVacationSchema = vacationFieldsSchema
   .refine((data) => data.startDate <= data.endDate, {
-    message: "Start date must be before or equal to end date",
+    message: "Data de início deve ser anterior ou igual à data de término",
     path: ["endDate"],
   })
+  .refine((data) => data.acquisitionPeriodStart <= data.acquisitionPeriodEnd, {
+    message: "Início do período aquisitivo deve ser anterior ou igual ao fim",
+    path: ["acquisitionPeriodEnd"],
+  })
   .refine((data) => data.daysUsed <= data.daysTotal, {
-    message: "Days used cannot exceed total days",
+    message: "Dias utilizados não pode exceder o total de dias",
     path: ["daysUsed"],
   });
 
-export const updateVacationSchema = createVacationSchema
+export const updateVacationSchema = vacationFieldsSchema
   .omit({ employeeId: true })
-  .partial();
+  .partial()
+  .refine(
+    (data) => {
+      if (data.startDate && data.endDate) {
+        return data.startDate <= data.endDate;
+      }
+      return true;
+    },
+    {
+      message: "Data de início deve ser anterior ou igual à data de término",
+      path: ["endDate"],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.acquisitionPeriodStart && data.acquisitionPeriodEnd) {
+        return data.acquisitionPeriodStart <= data.acquisitionPeriodEnd;
+      }
+      return true;
+    },
+    {
+      message: "Início do período aquisitivo deve ser anterior ou igual ao fim",
+      path: ["acquisitionPeriodEnd"],
+    }
+  )
+  .refine(
+    (data) => {
+      if (data.daysUsed !== undefined && data.daysTotal !== undefined) {
+        return data.daysUsed <= data.daysTotal;
+      }
+      return true;
+    },
+    {
+      message: "Dias utilizados não pode exceder o total de dias",
+      path: ["daysUsed"],
+    }
+  );
 
 export const idParamSchema = z.object({
   id: z.string().min(1).describe("ID das férias"),
 });
 
 const vacationDataSchema = z.object({
-  id: z.string().describe("Vacation ID"),
-  organizationId: z.string().describe("Organization ID"),
-  employee: entityReferenceSchema.describe("Employee"),
-  startDate: z.string().describe("Vacation start date"),
-  endDate: z.string().describe("Vacation end date"),
-  daysTotal: z.number().describe("Total vacation days"),
-  daysUsed: z.number().describe("Days used"),
-  acquisitionPeriodStart: z.string().describe("Acquisition period start date"),
-  acquisitionPeriodEnd: z.string().describe("Acquisition period end date"),
-  status: z.enum(vacationStatuses).describe("Vacation status"),
-  notes: z.string().nullable().describe("Notes"),
-  createdAt: z.coerce.date().describe("Creation date"),
-  updatedAt: z.coerce.date().describe("Last update date"),
+  id: z.string().describe("ID das férias"),
+  organizationId: z.string().describe("ID da organização"),
+  employee: entityReferenceSchema.describe("Funcionário"),
+  startDate: z.string().describe("Data de início das férias"),
+  endDate: z.string().describe("Data de término das férias"),
+  daysTotal: z.number().describe("Total de dias de férias"),
+  daysUsed: z.number().describe("Dias utilizados"),
+  acquisitionPeriodStart: z.string().describe("Início do período aquisitivo"),
+  acquisitionPeriodEnd: z.string().describe("Fim do período aquisitivo"),
+  status: z.enum(vacationStatuses).describe("Status das férias"),
+  notes: z.string().nullable().describe("Observações"),
+  createdAt: z.coerce.date().describe("Data de criação"),
+  updatedAt: z.coerce.date().describe("Data de atualização"),
 });
 
 const deletedVacationDataSchema = vacationDataSchema.extend({
-  deletedAt: z.coerce.date().describe("Deletion date"),
-  deletedBy: z.string().nullable().describe("ID of user who deleted"),
+  deletedAt: z.coerce.date().describe("Data de exclusão"),
+  deletedBy: z.string().nullable().describe("ID do usuário que excluiu"),
 });
 
 const vacationListDataSchema = z.array(vacationDataSchema);

--- a/src/modules/occurrences/warnings/warning.model.ts
+++ b/src/modules/occurrences/warnings/warning.model.ts
@@ -4,12 +4,15 @@ import { entityReferenceSchema } from "@/lib/schemas/relationships";
 
 export const warningTypeEnum = z.enum(["verbal", "written", "suspension"]);
 
-export const createWarningSchema = z.object({
+const warningFieldsSchema = z.object({
   employeeId: z
     .string()
     .min(1, "ID do funcionário é obrigatório")
     .describe("ID do funcionário"),
-  date: z.string().date("Data inválida").describe("Data da advertência"),
+  date: z
+    .string()
+    .date("Data da advertência deve ser uma data válida")
+    .describe("Data da advertência"),
   type: warningTypeEnum.describe("Tipo da advertência"),
   reason: z
     .string()
@@ -18,11 +21,34 @@ export const createWarningSchema = z.object({
   description: z.string().optional().describe("Descrição detalhada"),
   witnessName: z.string().optional().describe("Nome da testemunha"),
   acknowledged: z.boolean().default(false).describe("Funcionário ciente"),
-  acknowledgedAt: z.string().datetime().optional().describe("Data do ciente"),
+  acknowledgedAt: z
+    .string()
+    .datetime("Data do ciente deve ser uma data/hora válida")
+    .optional()
+    .describe("Data do ciente"),
   notes: z.string().optional().describe("Observações"),
 });
 
-export const updateWarningSchema = createWarningSchema.partial();
+export const createWarningSchema = warningFieldsSchema.refine(
+  (data) => !data.acknowledged || data.acknowledgedAt,
+  {
+    message: "Data de ciência é obrigatória quando o funcionário deu ciência",
+    path: ["acknowledgedAt"],
+  }
+);
+
+export const updateWarningSchema = warningFieldsSchema.partial().refine(
+  (data) => {
+    if (data.acknowledged === true) {
+      return !!data.acknowledgedAt;
+    }
+    return true;
+  },
+  {
+    message: "Data de ciência é obrigatória quando o funcionário deu ciência",
+    path: ["acknowledgedAt"],
+  }
+);
 
 export const idParamSchema = z.object({
   id: z.string().min(1).describe("ID da advertência"),

--- a/src/modules/organizations/branches/__tests__/create-branch.test.ts
+++ b/src/modules/organizations/branches/__tests__/create-branch.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { generateCnpj } from "@/test/helpers/faker";
 import {
   createTestUser,
   createTestUserWithOrganization,
@@ -10,7 +11,7 @@ const BASE_URL = env.API_URL;
 
 const validBranchData = {
   name: "Filial Centro",
-  taxId: "12345678000195",
+  taxId: generateCnpj(),
   street: "Rua das Flores",
   number: "123",
   complement: "Sala 101",
@@ -66,8 +67,7 @@ describe("POST /v1/branches", () => {
       emailVerified: true,
     });
 
-    // Use unique taxId for this test
-    const uniqueTaxId = `${Date.now()}`.slice(-14).padStart(14, "0");
+    const uniqueTaxId = generateCnpj();
 
     // Create first branch
     const firstResponse = await app.handle(
@@ -115,7 +115,7 @@ describe("POST /v1/branches", () => {
     );
 
     // Create organization with a valid 14-digit taxId
-    const orgTaxId = `${Date.now()}`.slice(-14).padStart(14, "0");
+    const orgTaxId = generateCnpj();
     const organization = await createTestOrganization({ taxId: orgTaxId });
 
     const userResult = await createTestUser({ emailVerified: true });
@@ -201,7 +201,7 @@ describe("POST /v1/branches", () => {
         },
         body: JSON.stringify({
           ...validBranchData,
-          taxId: "98765432000199",
+          taxId: generateCnpj(),
           foundedAt: futureDate.toISOString().split("T")[0],
         }),
       })
@@ -215,7 +215,7 @@ describe("POST /v1/branches", () => {
       emailVerified: true,
     });
 
-    const uniqueTaxId = `${Date.now()}`.slice(-14).padStart(14, "0");
+    const uniqueTaxId = generateCnpj();
 
     const response = await app.handle(
       new Request(`${BASE_URL}/v1/branches`, {
@@ -250,7 +250,7 @@ describe("POST /v1/branches", () => {
       emailVerified: true,
     });
 
-    const uniqueTaxId = `${Date.now() + 1}`.slice(-14).padStart(14, "0");
+    const uniqueTaxId = generateCnpj();
     const {
       complement: _,
       phone: __,
@@ -308,7 +308,7 @@ describe("POST /v1/branches", () => {
         },
         body: JSON.stringify({
           ...validBranchData,
-          taxId: `${Date.now() + 2}`.slice(-14).padStart(14, "0"),
+          taxId: generateCnpj(),
         }),
       })
     );
@@ -333,7 +333,7 @@ describe("POST /v1/branches", () => {
       role: "manager",
     });
 
-    const uniqueTaxId = `${Date.now() + 3}`.slice(-14).padStart(14, "0");
+    const uniqueTaxId = generateCnpj();
 
     const response = await app.handle(
       new Request(`${BASE_URL}/v1/branches`, {

--- a/src/modules/organizations/branches/__tests__/delete-branch.test.ts
+++ b/src/modules/organizations/branches/__tests__/delete-branch.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestBranch } from "@/test/helpers/branch";
+import { generateCnpj } from "@/test/helpers/faker";
 import {
   createTestUser,
   createTestUserWithOrganization,
@@ -263,7 +264,7 @@ describe("DELETE /v1/branches/:id", () => {
         emailVerified: true,
       });
 
-    const taxId = `${Date.now()}`.slice(-14).padStart(14, "0");
+    const taxId = generateCnpj();
 
     const branch = await createTestBranch({
       organizationId,

--- a/src/modules/organizations/branches/__tests__/update-branch.test.ts
+++ b/src/modules/organizations/branches/__tests__/update-branch.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestBranch } from "@/test/helpers/branch";
+import { generateCnpj } from "@/test/helpers/faker";
 import {
   createTestUser,
   createTestUserWithOrganization,
@@ -105,8 +106,8 @@ describe("PUT /v1/branches/:id", () => {
         emailVerified: true,
       });
 
-    const taxId1 = `${Date.now()}`.slice(-14).padStart(14, "0");
-    const taxId2 = `${Date.now() + 1}`.slice(-14).padStart(14, "0");
+    const taxId1 = generateCnpj();
+    const taxId2 = generateCnpj();
 
     await createTestBranch({
       organizationId,
@@ -179,7 +180,7 @@ describe("PUT /v1/branches/:id", () => {
       userId: user.id,
     });
 
-    const newTaxId = `${Date.now() + 5}`.slice(-14).padStart(14, "0");
+    const newTaxId = generateCnpj();
 
     const response = await app.handle(
       new Request(`${BASE_URL}/v1/branches/${branch.id}`, {
@@ -223,7 +224,7 @@ describe("PUT /v1/branches/:id", () => {
         emailVerified: true,
       });
 
-    const taxId = `${Date.now() + 6}`.slice(-14).padStart(14, "0");
+    const taxId = generateCnpj();
 
     const branch = await createTestBranch({
       organizationId,

--- a/src/modules/organizations/branches/branch.model.ts
+++ b/src/modules/organizations/branches/branch.model.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { successResponseSchema } from "@/lib/responses/response.types";
+import { isValidCNPJ } from "@/lib/validation/documents";
 
 const isFutureDate = (dateStr: string) => {
   const date = new Date(dateStr);
@@ -17,6 +18,7 @@ export const createBranchSchema = z.object({
   taxId: z
     .string()
     .regex(/^\d{14}$/, "CNPJ deve ter 14 dígitos")
+    .refine((val) => isValidCNPJ(val), "CNPJ inválido")
     .describe("CNPJ da filial (14 dígitos)"),
   street: z
     .string()

--- a/src/modules/organizations/profile/organization.model.ts
+++ b/src/modules/organizations/profile/organization.model.ts
@@ -1,41 +1,109 @@
 import { z } from "zod";
 import { successResponseSchema } from "@/lib/responses/response.types";
+import { isValidTaxId } from "@/lib/validation/documents";
 
 export const updateProfileSchema = z.object({
-  tradeName: z.string().min(1).max(200).optional(),
-  legalName: z.string().min(1).max(200).optional(),
-  email: z.string().email().optional(),
+  tradeName: z
+    .string()
+    .min(1, "Nome fantasia é obrigatório")
+    .max(200, "Nome fantasia deve ter no máximo 200 caracteres")
+    .optional()
+    .describe("Nome fantasia"),
+  legalName: z
+    .string()
+    .min(1, "Razão social é obrigatória")
+    .max(200, "Razão social deve ter no máximo 200 caracteres")
+    .optional()
+    .describe("Razão social"),
+  email: z
+    .string()
+    .email("Email inválido")
+    .optional()
+    .describe("Email da organização"),
   phone: z
     .string()
     .regex(/^\d{10,11}$/, "Telefone deve ter 10 ou 11 dígitos")
-    .optional(),
+    .optional()
+    .describe("Telefone"),
   taxId: z
     .string()
     .regex(
       /^(\d{11}|\d{14})$/,
       "CPF deve ter 11 dígitos ou CNPJ deve ter 14 dígitos"
     )
-    .optional(),
-  taxRegime: z.string().max(100).optional(),
-  stateRegistration: z.string().max(50).optional(),
-  mainActivityCode: z.string().max(20).optional(),
-  street: z.string().max(200).optional(),
-  number: z.string().max(20).optional(),
-  complement: z.string().max(100).optional(),
-  neighborhood: z.string().max(100).optional(),
-  city: z.string().max(100).optional(),
-  state: z.string().length(2, "Estado deve ter 2 caracteres").optional(),
+    .refine((val) => isValidTaxId(val), "CPF ou CNPJ inválido")
+    .optional()
+    .describe("CPF ou CNPJ"),
+  taxRegime: z
+    .string()
+    .max(100, "Regime tributário deve ter no máximo 100 caracteres")
+    .optional()
+    .describe("Regime tributário"),
+  stateRegistration: z
+    .string()
+    .max(50, "Inscrição estadual deve ter no máximo 50 caracteres")
+    .optional()
+    .describe("Inscrição estadual"),
+  mainActivityCode: z
+    .string()
+    .max(20, "CNAE deve ter no máximo 20 caracteres")
+    .optional()
+    .describe("CNAE principal"),
+  street: z
+    .string()
+    .max(200, "Rua deve ter no máximo 200 caracteres")
+    .optional()
+    .describe("Rua"),
+  number: z
+    .string()
+    .max(20, "Número deve ter no máximo 20 caracteres")
+    .optional()
+    .describe("Número"),
+  complement: z
+    .string()
+    .max(100, "Complemento deve ter no máximo 100 caracteres")
+    .optional()
+    .describe("Complemento"),
+  neighborhood: z
+    .string()
+    .max(100, "Bairro deve ter no máximo 100 caracteres")
+    .optional()
+    .describe("Bairro"),
+  city: z
+    .string()
+    .max(100, "Cidade deve ter no máximo 100 caracteres")
+    .optional()
+    .describe("Cidade"),
+  state: z
+    .string()
+    .length(2, "Estado deve ter 2 caracteres")
+    .optional()
+    .describe("UF"),
   zipCode: z
     .string()
     .regex(/^\d{8}$/, "CEP deve ter 8 dígitos")
-    .optional(),
-  industry: z.string().max(100).optional(),
-  businessArea: z.string().max(100).optional(),
-  foundingDate: z.string().date().optional(),
+    .optional()
+    .describe("CEP (8 dígitos)"),
+  industry: z
+    .string()
+    .max(100, "Ramo de atividade deve ter no máximo 100 caracteres")
+    .optional()
+    .describe("Ramo de atividade"),
+  businessArea: z
+    .string()
+    .max(100, "Área de atuação deve ter no máximo 100 caracteres")
+    .optional()
+    .describe("Área de atuação"),
+  foundingDate: z
+    .string()
+    .date("Data de fundação deve ser uma data válida")
+    .optional()
+    .describe("Data de fundação"),
   revenue: z
     .string()
     .regex(/^\d+(\.\d{1,2})?$/, "Receita deve ser um valor numérico")
-    .optional(),
+    .optional()
+    .describe("Receita"),
 });
 
 const organizationProfileDataSchema = z.object({


### PR DESCRIPTION
## Summary

- **#53** — Add PT-BR error messages and `.describe()` to OpenAPI schemas for employees, organization profile, and branches. Extract `x-error-messages` from Zod v4 check definitions into OpenAPI JSON Schema output.
- **#55** — Add validation constraints to better-auth OpenAPI schemas (email `format: email`, password `minLength: 8`, name `minLength: 2` / `maxLength: 100`) with PT-BR `x-error-messages` via post-processing in `auth-plugin.ts`.
- **#56** — Add server-side date range validations: absences (`startDate ≤ endDate`), vacations (`acquisitionPeriodStart ≤ acquisitionPeriodEnd`, `daysUsed ≤ daysTotal`), terminations (`lastWorkingDay ≤ terminationDate`), warnings (`acknowledged` + `acknowledgedAt` cross-field validation).
- **#57** — Add algorithmic CPF/CNPJ check-digit validation to employee, branch, and organization profile schemas using existing `isValidCPF`/`isValidCNPJ`/`isValidTaxId` from `lib/validation/documents.ts`.

## Implementation Notes

- Schema restructuring: modules using cross-field `.refine()` (absences, vacations, terminations, warnings) now extract a base `fieldsSchema` and derive both create and update schemas from it, following the pattern already established in `medical-certificates.model.ts`.
- The `x-error-messages` extraction uses Zod v4 internal API (`check._zod.def.error`, `check._zod.def.check`) to read error message functions and map them to JSON Schema extension properties. This enables the frontend (via Kubb) to generate Zod schemas with localized error messages.
- Better-auth schemas are post-processed in `addAuthSchemaValidations()` since we can't modify better-auth's internal schema generation.
- Test data updated to use `generateCpf()`/`generateCnpj()` from faker helpers for algorithmically valid documents.
- Termination test data corrected to satisfy `lastWorkingDay ≤ terminationDate` business rule.

## Changed Files

| File | Change |
|------|--------|
| `src/index.ts` | Extract `extractErrorMessages()` helper, add `x-error-messages` to JSON Schema override |
| `src/lib/auth-plugin.ts` | Add `addAuthSchemaValidations()` for better-auth OpenAPI post-processing |
| `src/modules/employees/employee.model.ts` | Add `.refine(isValidCPF)` to cpf field |
| `src/modules/organizations/branches/branch.model.ts` | Add `.refine(isValidCNPJ)` to taxId field |
| `src/modules/organizations/profile/organization.model.ts` | Add PT-BR messages, `.describe()`, `.refine(isValidTaxId)` |
| `src/modules/occurrences/absences/absence.model.ts` | Restructure with base schema, add date range refine |
| `src/modules/occurrences/vacations/vacation.model.ts` | Restructure, add acquisition period + days refines, PT-BR messages |
| `src/modules/occurrences/terminations/termination.model.ts` | Restructure, add lastWorkingDay ≤ terminationDate refine |
| `src/modules/occurrences/warnings/warning.model.ts` | Restructure, add acknowledged/acknowledgedAt cross-field refine |
| 7 test files | Update test data for valid CPF/CNPJ and corrected date ranges |

## Test plan

- [x] All 231 affected module tests pass (0 failures)
- [x] Full test suite: 1670 pass, 2 fail (pre-existing Pagarme API flaky tests)
- [x] Lint passes (`npx ultracite check`)

Closes #53, closes #55, closes #56, closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)