### PR TITLE
feat: adicionar mensagens PT-BR nos schemas OpenAPI (média prioridade)

### DIFF
--- a/src/modules/occurrences/absences/__tests__/create-absence.test.ts
+++ b/src/modules/occurrences/absences/__tests__/create-absence.test.ts
@@ -54,6 +54,62 @@ describe("POST /v1/absences", () => {
     expect(body.error.code).toBe("NO_ACTIVE_ORGANIZATION");
   });
 
+  test("should return PT-BR messages for empty required fields", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/absences`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: "",
+          startDate: "",
+          endDate: "",
+          type: "justified",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("ID do funcionário é obrigatório");
+    expect(messages).toContain("Data de início é obrigatória");
+    expect(messages).toContain("Data de término é obrigatória");
+  });
+
+  test("should return PT-BR message for invalid absence type", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/absences`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: "employee-123",
+          startDate: "2024-01-01",
+          endDate: "2024-01-01",
+          type: "invalid-type",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Tipo de ausência inválido");
+  });
+
   test("should reject invalid employee", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,

--- a/src/modules/occurrences/absences/absence.model.ts
+++ b/src/modules/occurrences/absences/absence.model.ts
@@ -2,7 +2,9 @@ import { z } from "zod";
 import { successResponseSchema } from "@/lib/responses/response.types";
 import { entityReferenceSchema } from "@/lib/schemas/relationships";
 
-export const absenceTypeEnum = z.enum(["justified", "unjustified"]);
+export const absenceTypeEnum = z.enum(["justified", "unjustified"], {
+  error: "Tipo de ausência inválido",
+});
 
 export type AbsenceType = z.infer<typeof absenceTypeEnum>;
 

--- a/src/modules/occurrences/accidents/__tests__/create-accident.test.ts
+++ b/src/modules/occurrences/accidents/__tests__/create-accident.test.ts
@@ -73,6 +73,68 @@ describe("POST /v1/accidents", () => {
     expect(response.status).toBe(422);
   });
 
+  test("should return PT-BR messages for empty required fields", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/accidents`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          employeeId: "",
+          date: "not-a-date",
+          description: "",
+          nature: "",
+          measuresTaken: "",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("ID do funcionário é obrigatório");
+    expect(messages).toContain("Descrição é obrigatória");
+    expect(messages).toContain("Medidas tomadas são obrigatórias");
+  });
+
+  test("should return PT-BR message for invalid date", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/accidents`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...validAccidentData,
+          employeeId: "employee-123",
+          date: "not-a-date",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Data inválida");
+  });
+
   test("should reject future date", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({

--- a/src/modules/occurrences/labor-lawsuits/__tests__/create-labor-lawsuit.test.ts
+++ b/src/modules/occurrences/labor-lawsuits/__tests__/create-labor-lawsuit.test.ts
@@ -76,6 +76,43 @@ describe("POST /v1/labor-lawsuits", () => {
     expect(response.status).toBe(422);
   });
 
+  test("should return PT-BR messages for empty required fields", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/labor-lawsuits`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          employeeId: "employee-123",
+          processNumber: "",
+          court: "",
+          filingDate: "2024-01-15",
+          knowledgeDate: "2024-01-10",
+          plaintiff: "",
+          defendant: "Empresa XYZ",
+          description: "",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Número do processo é obrigatório");
+    expect(messages).toContain("Tribunal é obrigatório");
+    expect(messages).toContain("Reclamante é obrigatório");
+    expect(messages).toContain("Descrição é obrigatória");
+  });
+
   test("should reject invalid employee", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,

--- a/src/modules/occurrences/ppe-deliveries/__tests__/create-ppe-delivery.test.ts
+++ b/src/modules/occurrences/ppe-deliveries/__tests__/create-ppe-delivery.test.ts
@@ -58,6 +58,39 @@ describe("POST /v1/ppe-deliveries", () => {
     expect(body.error.code).toBe("NO_ACTIVE_ORGANIZATION");
   });
 
+  test("should return PT-BR messages for empty required fields", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/ppe-deliveries`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          employeeId: "",
+          deliveryDate: "",
+          reason: "",
+          deliveredBy: "",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("ID do funcionário é obrigatório");
+    expect(messages).toContain("Data de entrega é obrigatória");
+    expect(messages).toContain("Motivo é obrigatório");
+    expect(messages).toContain("Nome de quem entregou é obrigatório");
+  });
+
   test("should return 404 for non-existent employee", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,

--- a/src/modules/occurrences/promotions/__tests__/create-promotion.test.ts
+++ b/src/modules/occurrences/promotions/__tests__/create-promotion.test.ts
@@ -75,6 +75,37 @@ describe("POST /v1/promotions", () => {
     expect(response.status).toBe(422);
   });
 
+  test("should return PT-BR messages for empty required fields", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/promotions`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: "",
+          previousJobPositionId: "",
+          newJobPositionId: "",
+          promotionDate: "2024-01-15",
+          previousSalary: "3000.00",
+          newSalary: "3600.00",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("ID do funcionário é obrigatório");
+    expect(messages).toContain("ID do cargo anterior é obrigatório");
+    expect(messages).toContain("ID do novo cargo é obrigatório");
+  });
+
   test("should reject when employee does not exist", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({ emailVerified: true });

--- a/src/modules/organizations/cost-centers/__tests__/create-cost-center.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/create-cost-center.test.ts
@@ -69,7 +69,7 @@ describe("POST /v1/cost-centers", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject empty name", async () => {
+  test("should return PT-BR message for empty name", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -86,6 +86,37 @@ describe("POST /v1/cost-centers", () => {
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome é obrigatório");
+  });
+
+  test("should return PT-BR message for name exceeding max length", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/cost-centers`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "x".repeat(101) }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome deve ter no máximo 100 caracteres");
   });
 
   test("should create cost center successfully", async () => {

--- a/src/modules/organizations/job-classifications/__tests__/create-job-classification.test.ts
+++ b/src/modules/organizations/job-classifications/__tests__/create-job-classification.test.ts
@@ -69,7 +69,7 @@ describe("POST /v1/job-classifications", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject empty name", async () => {
+  test("should return PT-BR message for empty name", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -86,6 +86,37 @@ describe("POST /v1/job-classifications", () => {
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome é obrigatório");
+  });
+
+  test("should return PT-BR message for name exceeding max length", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/job-classifications`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "x".repeat(256) }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome deve ter no máximo 255 caracteres");
   });
 
   test("should create job classification successfully", async () => {

--- a/src/modules/organizations/job-positions/__tests__/create-job-position.test.ts
+++ b/src/modules/organizations/job-positions/__tests__/create-job-position.test.ts
@@ -70,7 +70,7 @@ describe("POST /v1/job-positions", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject empty name", async () => {
+  test("should return PT-BR message for empty name", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -87,6 +87,12 @@ describe("POST /v1/job-positions", () => {
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome é obrigatório");
   });
 
   test("should create job position successfully", async () => {

--- a/src/modules/organizations/ppe-items/__tests__/create-ppe-item.test.ts
+++ b/src/modules/organizations/ppe-items/__tests__/create-ppe-item.test.ts
@@ -71,7 +71,7 @@ describe("POST /v1/ppe-items", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject empty name", async () => {
+  test("should return PT-BR message for empty name", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -92,9 +92,15 @@ describe("POST /v1/ppe-items", () => {
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome é obrigatório");
   });
 
-  test("should reject missing description", async () => {
+  test("should return PT-BR message for empty description", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -108,15 +114,22 @@ describe("POST /v1/ppe-items", () => {
         },
         body: JSON.stringify({
           name: "Capacete",
+          description: "",
           equipment: "Equipamento",
         }),
       })
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Descrição é obrigatória");
   });
 
-  test("should reject missing equipment", async () => {
+  test("should return PT-BR message for empty equipment", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -131,11 +144,18 @@ describe("POST /v1/ppe-items", () => {
         body: JSON.stringify({
           name: "Capacete",
           description: "Descrição",
+          equipment: "",
         }),
       })
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Equipamento é obrigatório");
   });
 
   test("should create ppe item successfully", async () => {

--- a/src/modules/organizations/projects/__tests__/create-project.test.ts
+++ b/src/modules/organizations/projects/__tests__/create-project.test.ts
@@ -74,7 +74,39 @@ describe("POST /v1/projects", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject invalid CNO length", async () => {
+  test("should return PT-BR messages for empty required fields", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/projects`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "",
+          description: "",
+          startDate: "",
+          cno: "123456789012",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome é obrigatório");
+    expect(messages).toContain("Descrição é obrigatória");
+    expect(messages).toContain("Data de início é obrigatória");
+  });
+
+  test("should return PT-BR message for invalid CNO length", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -94,6 +126,12 @@ describe("POST /v1/projects", () => {
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("CNO deve ter exatamente 12 caracteres");
   });
 
   test("should create project successfully", async () => {

--- a/src/modules/organizations/sectors/__tests__/create-sector.test.ts
+++ b/src/modules/organizations/sectors/__tests__/create-sector.test.ts
@@ -69,7 +69,7 @@ describe("POST /v1/sectors", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject empty name", async () => {
+  test("should return PT-BR message for empty name", async () => {
     const { headers } = await createTestUserWithOrganization({
       emailVerified: true,
     });
@@ -86,6 +86,37 @@ describe("POST /v1/sectors", () => {
     );
 
     expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome é obrigatório");
+  });
+
+  test("should return PT-BR message for name exceeding max length", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/sectors`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ name: "x".repeat(101) }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+    const messages = body.error.details.map(
+      (d: { message: string }) => d.message
+    );
+    expect(messages).toContain("Nome deve ter no máximo 100 caracteres");
   });
 
   test("should create sector successfully", async () => {


### PR DESCRIPTION
## Summary

- Adicionadas asserções de mensagens de validação PT-BR nos testes de integração dos módulos de média prioridade
- Adicionada mensagem de erro customizada ao `absenceTypeEnum` ("Tipo de ausência inválido")
- Todos os schemas já possuíam mensagens PT-BR; esta PR formaliza a cobertura com testes

### Entidades organizacionais
- **sectors**: "Nome é obrigatório", "Nome deve ter no máximo 100 caracteres"
- **cost-centers**: "Nome é obrigatório", "Nome deve ter no máximo 100 caracteres"
- **job-classifications**: "Nome é obrigatório", "Nome deve ter no máximo 255 caracteres"
- **ppe-items**: "Nome é obrigatório", "Descrição é obrigatória", "Equipamento é obrigatório"
- **job-positions**: "Nome é obrigatório"
- **projects**: "Nome é obrigatório", "Descrição é obrigatória", "Data de início é obrigatória", "CNO deve ter exatamente 12 caracteres"

### Ocorrências
- **accidents**: "ID do funcionário é obrigatório", "Data inválida", "Descrição é obrigatória", "Medidas tomadas são obrigatórias"
- **labor-lawsuits**: "Número do processo é obrigatório", "Tribunal é obrigatório", "Reclamante é obrigatório", "Descrição é obrigatória"
- **ppe-deliveries**: "ID do funcionário é obrigatório", "Data de entrega é obrigatória", "Motivo é obrigatório", "Nome de quem entregou é obrigatório"
- **promotions**: "ID do funcionário é obrigatório", "ID do cargo anterior é obrigatório", "ID do novo cargo é obrigatório"
- **absences**: "ID do funcionário é obrigatório", "Data de início é obrigatória", "Data de término é obrigatória", "Tipo de ausência inválido"

## Alterações

| Arquivo | Tipo |
|---------|------|
| `absence.model.ts` | Schema — adicionado `{ error: "Tipo de ausência inválido" }` ao enum |
| 11 test files | Testes — asserções de mensagens PT-BR nas respostas 422 |

## Test plan

- [x] 112 testes dos módulos afetados passam
- [x] 1683 testes do projeto completo passam (0 falhas)
- [x] Lint passa (`npx ultracite check`)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)