### PR TITLE
feat(auth): add member validation hooks and role update audit log

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -439,20 +439,6 @@ export const auth = betterAuth({
           }
           return Promise.resolve();
         },
-        beforeUpdateMemberRole: ({
-          member,
-          user,
-        }: {
-          member: Member;
-          user: User;
-        }) => {
-          if (member.userId === user.id) {
-            throw new APIError("FORBIDDEN", {
-              message: "Você não pode alterar sua própria função.",
-            });
-          }
-          return Promise.resolve();
-        },
         afterUpdateMemberRole: async ({
           member,
           previousRole,

--- a/src/modules/organizations/__tests__/member-hooks.test.ts
+++ b/src/modules/organizations/__tests__/member-hooks.test.ts
@@ -1,0 +1,200 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { addMemberToOrganization } from "@/test/helpers/organization";
+import {
+  createTestUser,
+  createTestUserWithOrganization,
+} from "@/test/helpers/user";
+
+describe("Organization member hooks", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  describe("beforeRemoveMember", () => {
+    test("should prevent removing the owner", async () => {
+      const owner = await createTestUserWithOrganization();
+
+      const [ownerMember] = await db
+        .select()
+        .from(schema.members)
+        .where(
+          and(
+            eq(schema.members.userId, owner.userId),
+            eq(schema.members.organizationId, owner.organizationId)
+          )
+        )
+        .limit(1);
+
+      // Create a second owner to attempt the removal
+      const secondUser = await createTestUser();
+      await addMemberToOrganization(secondUser, {
+        organizationId: owner.organizationId,
+        role: "owner",
+      });
+
+      const response = await app.handle(
+        new Request("http://localhost/api/auth/organization/remove-member", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...secondUser.headers,
+          },
+          body: JSON.stringify({
+            memberIdOrEmail: ownerMember.id,
+          }),
+        })
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    test("should allow removing a non-owner member", async () => {
+      const owner = await createTestUserWithOrganization();
+
+      const viewer = await createTestUser();
+      await addMemberToOrganization(viewer, {
+        organizationId: owner.organizationId,
+        role: "viewer",
+      });
+
+      const [viewerMember] = await db
+        .select()
+        .from(schema.members)
+        .where(
+          and(
+            eq(schema.members.userId, viewer.user.id),
+            eq(schema.members.organizationId, owner.organizationId)
+          )
+        )
+        .limit(1);
+
+      const response = await app.handle(
+        new Request("http://localhost/api/auth/organization/remove-member", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...owner.headers,
+          },
+          body: JSON.stringify({
+            memberIdOrEmail: viewerMember.id,
+          }),
+        })
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("afterUpdateMemberRole", () => {
+    test("should allow owner to change another member's role", async () => {
+      const owner = await createTestUserWithOrganization();
+
+      const viewer = await createTestUser();
+      await addMemberToOrganization(viewer, {
+        organizationId: owner.organizationId,
+        role: "viewer",
+      });
+
+      const [viewerMember] = await db
+        .select()
+        .from(schema.members)
+        .where(
+          and(
+            eq(schema.members.userId, viewer.user.id),
+            eq(schema.members.organizationId, owner.organizationId)
+          )
+        )
+        .limit(1);
+
+      const response = await app.handle(
+        new Request(
+          "http://localhost/api/auth/organization/update-member-role",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...owner.headers,
+            },
+            body: JSON.stringify({
+              memberId: viewerMember.id,
+              role: "manager",
+              organizationId: owner.organizationId,
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    test("should create audit log entry on role change", async () => {
+      const owner = await createTestUserWithOrganization();
+
+      const viewer = await createTestUser();
+      await addMemberToOrganization(viewer, {
+        organizationId: owner.organizationId,
+        role: "viewer",
+      });
+
+      const [viewerMember] = await db
+        .select()
+        .from(schema.members)
+        .where(
+          and(
+            eq(schema.members.userId, viewer.user.id),
+            eq(schema.members.organizationId, owner.organizationId)
+          )
+        )
+        .limit(1);
+
+      const response = await app.handle(
+        new Request(
+          "http://localhost/api/auth/organization/update-member-role",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...owner.headers,
+            },
+            body: JSON.stringify({
+              memberId: viewerMember.id,
+              role: "supervisor",
+              organizationId: owner.organizationId,
+            }),
+          }
+        )
+      );
+
+      expect(response.status).toBe(200);
+
+      const [auditEntry] = await db
+        .select()
+        .from(schema.auditLogs)
+        .where(
+          and(
+            eq(schema.auditLogs.resource, "member"),
+            eq(schema.auditLogs.action, "update"),
+            eq(schema.auditLogs.resourceId, viewerMember.id)
+          )
+        )
+        .orderBy(desc(schema.auditLogs.createdAt))
+        .limit(1);
+
+      expect(auditEntry).toBeDefined();
+      expect(auditEntry.organizationId).toBe(owner.organizationId);
+
+      const changes = auditEntry.changes as {
+        before: { role: string };
+        after: { role: string };
+      };
+      expect(changes.before.role).toBe("viewer");
+      expect(changes.after.role).toBe("supervisor");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `beforeRemoveMember` hook to prevent owner removal from organization
- Add `afterUpdateMemberRole` hook with audit logging for role changes
- Add `auditMemberRoleUpdate` function following the existing audit pattern
- Add integration tests covering owner protection and audit log creation

**Note:** `beforeUpdateMemberRole` (self-demotion prevention) was removed — Better Auth passes the target member's user instead of the authenticated user in the hook parameters, making self-demotion detection unreliable. Better Auth already prevents the sole owner from changing their role natively.

Closes #39

## Related

- Frontend: tlthiago/synnerdata-web-n#21

## Test plan

- [x] Attempt to remove owner member — should receive FORBIDDEN error
- [x] Remove a non-owner member — should succeed
- [x] Change another member's role — should succeed
- [x] Verify audit log entry contains before/after role values

🤖 Generated with [Claude Code](https://claude.com/claude-code)