### PR TITLE
fix: plano trial não vinculado automaticamente ao criar organização

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -440,10 +440,16 @@ export const auth = betterAuth({
           organization: Organization;
           member: { userId: string };
         }) => {
-          await Promise.all([
-            SubscriptionService.createTrial(org.id),
-            auditOrganizationCreate(org, member.userId),
-          ]);
+          await SubscriptionService.createTrial(org.id);
+
+          auditOrganizationCreate(org, member.userId).catch((error) => {
+            logger.error({
+              type: "audit:organization-create:failed",
+              organizationId: org.id,
+              userId: member.userId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          });
         },
         afterUpdateOrganization: async ({
           organization: org,

--- a/src/modules/payments/errors.ts
+++ b/src/modules/payments/errors.ts
@@ -405,6 +405,17 @@ export class TrialPlanNotFoundError extends PaymentError {
   }
 }
 
+export class TrialPlanMisconfiguredError extends PaymentError {
+  status = 500;
+
+  constructor() {
+    super(
+      "Trial plan has no pricing tiers. Please verify the database seed.",
+      "TRIAL_PLAN_MISCONFIGURED"
+    );
+  }
+}
+
 export class InvalidTierCountError extends PaymentError {
   status = 422;
 

--- a/src/modules/payments/subscription/__tests__/create-trial.test.ts
+++ b/src/modules/payments/subscription/__tests__/create-trial.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { TrialPlanMisconfiguredError } from "@/modules/payments/errors";
+import { SubscriptionMutationService } from "@/modules/payments/subscription/subscription-mutation.service";
+import { OrganizationFactory } from "@/test/factories/organization.factory";
+
+describe("SubscriptionMutationService.createTrial", () => {
+  test("should create trial subscription for new organization", async () => {
+    const org = await OrganizationFactory.create();
+
+    await SubscriptionMutationService.createTrial(org.id);
+
+    const [subscription] = await db
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id))
+      .limit(1);
+
+    expect(subscription).toBeDefined();
+    expect(subscription.status).toBe("active");
+    expect(subscription.trialStart).toBeInstanceOf(Date);
+    expect(subscription.trialEnd).toBeInstanceOf(Date);
+    expect(subscription.trialUsed).toBe(true);
+    expect(subscription.pricingTierId).toBeDefined();
+    expect(subscription.seats).toBe(1);
+
+    // Verify the plan used is a trial plan
+    const [plan] = await db
+      .select({ isTrial: schema.subscriptionPlans.isTrial })
+      .from(schema.subscriptionPlans)
+      .where(eq(schema.subscriptionPlans.id, subscription.planId))
+      .limit(1);
+
+    expect(plan.isTrial).toBe(true);
+  });
+
+  test("should be idempotent — calling twice creates only one subscription", async () => {
+    const org = await OrganizationFactory.create();
+
+    await SubscriptionMutationService.createTrial(org.id);
+    await SubscriptionMutationService.createTrial(org.id);
+
+    const subscriptions = await db
+      .select()
+      .from(schema.orgSubscriptions)
+      .where(eq(schema.orgSubscriptions.organizationId, org.id));
+
+    expect(subscriptions).toHaveLength(1);
+  });
+
+  test("should throw TrialPlanMisconfiguredError when trial plan has no tiers", async () => {
+    const org = await OrganizationFactory.create();
+
+    // Disable all existing trial plans
+    const existingTrialPlans = await db
+      .select({ id: schema.subscriptionPlans.id })
+      .from(schema.subscriptionPlans)
+      .where(eq(schema.subscriptionPlans.isTrial, true));
+
+    for (const plan of existingTrialPlans) {
+      await db
+        .update(schema.subscriptionPlans)
+        .set({ isTrial: false })
+        .where(eq(schema.subscriptionPlans.id, plan.id));
+    }
+
+    // Create a trial plan without tiers
+    const [misconfiguredPlan] = await db
+      .insert(schema.subscriptionPlans)
+      .values({
+        id: `plan-${crypto.randomUUID()}`,
+        name: `Misconfigured Trial ${crypto.randomUUID().slice(0, 8)}`,
+        displayName: "Misconfigured Trial",
+        isTrial: true,
+        trialDays: 14,
+        isActive: true,
+        isPublic: false,
+        sortOrder: 999,
+      })
+      .returning();
+
+    try {
+      await expect(
+        SubscriptionMutationService.createTrial(org.id)
+      ).rejects.toBeInstanceOf(TrialPlanMisconfiguredError);
+    } finally {
+      // Restore all original trial plans
+      for (const plan of existingTrialPlans) {
+        await db
+          .update(schema.subscriptionPlans)
+          .set({ isTrial: true })
+          .where(eq(schema.subscriptionPlans.id, plan.id));
+      }
+
+      // Clean up the misconfigured plan
+      await db
+        .delete(schema.subscriptionPlans)
+        .where(eq(schema.subscriptionPlans.id, misconfiguredPlan.id));
+    }
+  });
+});

--- a/src/modules/payments/subscription/subscription-mutation.service.ts
+++ b/src/modules/payments/subscription/subscription-mutation.service.ts
@@ -153,32 +153,56 @@ export abstract class SubscriptionMutationService {
    * Trial uses a dedicated trial plan with isTrial=true that gives access
    * to all features. Employee limit comes from the trial plan's tier.
    *
+   * Idempotent: if a subscription already exists for the organization,
+   * logs a warning and returns without error. Uses onConflictDoNothing
+   * as an extra defense against race conditions.
+   *
    * @param organizationId - The organization ID to create trial for
    */
   static async createTrial(organizationId: string): Promise<void> {
+    const existing = await findByOrganizationId(organizationId);
+    if (existing) {
+      const { logger } = await import("@/lib/logger");
+      logger.warn({
+        type: "create-trial:already-exists",
+        organizationId,
+        subscriptionId: existing.id,
+      });
+      return;
+    }
+
     // getTrialPlan throws TrialPlanNotFoundError if not configured
     const trialPlan = await PlansService.getTrialPlan();
+
+    if (trialPlan.pricingTiers.length === 0) {
+      const { TrialPlanMisconfiguredError } = await import(
+        "@/modules/payments/errors"
+      );
+      throw new TrialPlanMisconfiguredError();
+    }
 
     const trialStart = new Date();
     const trialEnd = new Date();
     trialEnd.setDate(trialEnd.getDate() + trialPlan.trialDays);
 
-    await db.insert(schema.orgSubscriptions).values({
-      id: `subscription-${crypto.randomUUID()}`,
-      organizationId,
-      planId: trialPlan.id,
-      pricingTierId: trialPlan.pricingTiers[0].id,
-      status: "active",
-      trialStart,
-      trialEnd,
-      trialUsed: true,
-      seats: 1,
-    });
+    const [inserted] = await db
+      .insert(schema.orgSubscriptions)
+      .values({
+        id: `subscription-${crypto.randomUUID()}`,
+        organizationId,
+        planId: trialPlan.id,
+        pricingTierId: trialPlan.pricingTiers[0].id,
+        status: "active",
+        trialStart,
+        trialEnd,
+        trialUsed: true,
+        seats: 1,
+      })
+      .onConflictDoNothing()
+      .returning();
 
-    const subscription = await findByOrganizationId(organizationId);
-
-    if (subscription) {
-      PaymentHooks.emit("trial.started", { subscription });
+    if (inserted) {
+      PaymentHooks.emit("trial.started", { subscription: inserted });
     }
   }
 


### PR DESCRIPTION
## Summary

- Tornou `createTrial()` **idempotente**: verifica se subscription já existe antes de inserir, com `onConflictDoNothing` como defesa extra contra race conditions
- Adicionou `TrialPlanMisconfiguredError` para planos trial sem pricing tiers configurados
- Eliminou re-query desnecessária usando `.returning()` no insert
- Tornou o hook `afterCreateOrganization` **sequencial**: `createTrial` executa primeiro (crítico), audit roda fire-and-forget com `.catch()` para log de erro

## Test plan

- [x] Happy path: createTrial para org nova cria subscription com campos corretos
- [x] Idempotência: chamar createTrial 2x para mesma org resulta em 1 subscription apenas
- [x] Validação de tier: plano trial sem tiers lança `TrialPlanMisconfiguredError`
- [x] Testes existentes passam sem alteração (signup-flow, trial-expired, subscription.service)
- [x] Lint passa (`npx ultracite check`)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)