### PR TITLE
feat(admin-checkout): refactor to private dedicated plan model

### DIFF
--- a/src/modules/payments/admin-checkout/CLAUDE.md
+++ b/src/modules/payments/admin-checkout/CLAUDE.md
@@ -1,37 +1,54 @@
 # Admin Checkout (Checkout com Preço Customizado)
 
 Geração de links de pagamento com preço diferenciado pelo admin do sistema.
+Cria um **plano privado dedicado** (`isPublic=false`) com faixa de funcionários livre e preço customizado.
 
 ## Business Rules
 
 - Admin autenticado (role = admin ou super_admin)
 - Organização NÃO pode ter subscription paga ativa
-- Plano deve estar ativo, tier deve pertencer ao plano
-- customPriceMonthly >= 100 centavos (R$ 1,00)
+- `basePlanId` deve referenciar plano ativo e não-trial (herda features/limits)
+- `minEmployees >= 0`, `maxEmployees > minEmployees` (faixa livre, não precisa existir no catálogo)
+- `customPriceMonthly >= 100` centavos (R$ 1,00)
 - Preço anual: `calculateYearlyPrice(customPriceMonthly)` — mesma regra de 20% desconto do catálogo
 - Billing profile obrigatório — admin pode enviar dados de billing no payload para criação automática
-- Um plano Pagar.me dedicado é criado para cada preço customizado (não cacheado no tier)
+- Um plano Pagar.me dedicado é criado para cada checkout (não cacheado no tier)
+
+## Invariantes do plano privado
+
+- Exatamente **1 tier** por plano privado
+- `isPublic=false` — não aparece no catálogo (`GET /plans`)
+- `isTrial=false`, `isActive=true`
+- Features herdadas do plano base (Gold/Diamond/Platinum)
+- Exclusivo por organização (uma org por plano privado)
 
 ## Flow
 
-1. Validar admin + organização + plano + tier
+1. Validar admin + organização + plano base (ativo, não-trial)
 2. Garantir billing profile (criar se billing data informado, erro se ausente)
 3. Get/create customer no Pagar.me (via CustomerService)
 4. Calcular preço anual customizado
-5. Criar plano customizado no Pagar.me (`PagarmePlanService.createCustomPlan`)
-6. Criar payment link com metadata `is_custom_price=true`
-7. Salvar pending checkout com campos customizados
-8. Retornar link + dados comparativos de preço
+5. Criar plano privado (`subscription_plans`) + 1 tier (`plan_pricing_tiers`) em transação
+6. Criar plano customizado no Pagar.me (`PagarmePlanService.createCustomPlan`)
+7. Criar payment link com metadata apontando para o plano privado
+8. Salvar pending checkout referenciando plano privado
+9. Retornar link + dados do plano privado
+
+## Input
+
+`basePlanId`, `minEmployees`, `maxEmployees`, `customPriceMonthly`, `organizationId`, `billingCycle`, `successUrl`, `notes?`, `billing?`
+
+## Output
+
+`checkoutUrl`, `paymentLinkId`, `privatePlanId`, `privateTierId`, `customPriceMonthly`, `customPriceYearly`, `basePlanDisplayName`, `minEmployees`, `maxEmployees`, `expiresAt`
 
 ## Payment Link Metadata
 
-Todos os campos do checkout normal + `is_custom_price`, `custom_price_monthly`, `custom_price_yearly`
+`organization_id`, `plan_id` (privado), `pricing_tier_id` (privado), `billing_cycle`, `is_custom_price`, `custom_price_monthly`, `custom_price_yearly`
 
 ## Webhook Resolution
 
-O webhook `subscription.created` resolve checkouts customizados da mesma forma que self-service:
-- Via metadata (primary) ou lookup em `pending_checkouts` (fallback)
-- Propaga `priceAtPurchase` e `isCustomPrice` para `org_subscriptions`
+O webhook `subscription.created` resolve via metadata (`plan_id`, `pricing_tier_id`) que apontam para registros reais no banco (plano privado + tier). A resolução funciona identicamente ao checkout normal.
 
 ## Endpoint
 

--- a/src/modules/payments/admin-checkout/__tests__/admin-checkout.test.ts
+++ b/src/modules/payments/admin-checkout/__tests__/admin-checkout.test.ts
@@ -21,8 +21,9 @@ const ENDPOINT = `${BASE_URL}/v1/payments/admin/checkout`;
 function buildPayload(overrides: Record<string, unknown> = {}) {
   return {
     organizationId: "org-placeholder",
-    planId: "plan-placeholder",
-    pricingTierId: "tier-placeholder",
+    basePlanId: "plan-placeholder",
+    minEmployees: 0,
+    maxEmployees: 25,
     billingCycle: "monthly",
     customPriceMonthly: 5000,
     successUrl: "https://app.example.com/success",
@@ -78,8 +79,6 @@ describe("POST /v1/payments/admin/checkout", () => {
 
   test("should return 403 for non-admin user", async () => {
     const { headers } = await UserFactory.create();
-
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
     const org = await OrganizationFactory.create();
 
     const response = await app.handle(
@@ -89,8 +88,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: goldPlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: goldPlanResult.plan.id,
           })
         ),
       })
@@ -120,7 +118,6 @@ describe("POST /v1/payments/admin/checkout", () => {
   test("should return 422 when customPriceMonthly is below 100 centavos", async () => {
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     const response = await app.handle(
       new Request(ENDPOINT, {
@@ -129,8 +126,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: goldPlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: goldPlanResult.plan.id,
             customPriceMonthly: 50,
           })
         ),
@@ -142,18 +138,40 @@ describe("POST /v1/payments/admin/checkout", () => {
 
   test("should return 422 for missing required fields (no organizationId)", async () => {
     const { headers } = await UserFactory.createAdmin();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     const response = await app.handle(
       new Request(ENDPOINT, {
         method: "POST",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
-          planId: goldPlanResult.plan.id,
-          pricingTierId: tier.id,
+          basePlanId: goldPlanResult.plan.id,
+          minEmployees: 0,
+          maxEmployees: 25,
           customPriceMonthly: 5000,
           successUrl: "https://app.example.com/success",
         }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  test("should return 422 when maxEmployees <= minEmployees", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const org = await OrganizationFactory.create();
+
+    const response = await app.handle(
+      new Request(ENDPOINT, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(
+          buildPayload({
+            organizationId: org.id,
+            basePlanId: goldPlanResult.plan.id,
+            minEmployees: 10,
+            maxEmployees: 10,
+          })
+        ),
       })
     );
 
@@ -164,7 +182,6 @@ describe("POST /v1/payments/admin/checkout", () => {
 
   test("should return 404 for non-existent organization", async () => {
     const { headers } = await UserFactory.createAdmin();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     const response = await app.handle(
       new Request(ENDPOINT, {
@@ -173,8 +190,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: "org-non-existent-id",
-            planId: goldPlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: goldPlanResult.plan.id,
           })
         ),
       })
@@ -188,7 +204,6 @@ describe("POST /v1/payments/admin/checkout", () => {
   test("should return 400 when organization has active paid subscription", async () => {
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     await SubscriptionFactory.createActive(org.id, goldPlanResult.plan.id);
 
@@ -199,8 +214,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: goldPlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: goldPlanResult.plan.id,
           })
         ),
       })
@@ -211,10 +225,9 @@ describe("POST /v1/payments/admin/checkout", () => {
     expect(body.error.code).toBe("SUBSCRIPTION_ALREADY_ACTIVE");
   });
 
-  test("should return 404 for non-existent plan", async () => {
+  test("should return 404 for non-existent plan (basePlanId)", async () => {
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     const response = await app.handle(
       new Request(ENDPOINT, {
@@ -223,8 +236,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: "plan-non-existent",
-            pricingTierId: tier.id,
+            basePlanId: "plan-non-existent",
           })
         ),
       })
@@ -238,7 +250,6 @@ describe("POST /v1/payments/admin/checkout", () => {
   test("should return 400 for inactive plan", async () => {
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
-    const tier = PlanFactory.getFirstTier(inactivePlanResult);
 
     const response = await app.handle(
       new Request(ENDPOINT, {
@@ -247,8 +258,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: inactivePlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: inactivePlanResult.plan.id,
           })
         ),
       })
@@ -259,9 +269,11 @@ describe("POST /v1/payments/admin/checkout", () => {
     expect(body.error.code).toBe("PLAN_NOT_AVAILABLE");
   });
 
-  test("should return 404 for non-existent pricing tier", async () => {
+  test("should return 400 when basePlanId is a trial plan (TRIAL_PLAN_AS_BASE)", async () => {
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
+
+    await BillingProfileFactory.create({ organizationId: org.id });
 
     const response = await app.handle(
       new Request(ENDPOINT, {
@@ -270,22 +282,20 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: goldPlanResult.plan.id,
-            pricingTierId: "tier-non-existent",
+            basePlanId: trialPlanResult.plan.id,
           })
         ),
       })
     );
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error.code).toBe("PRICING_TIER_NOT_FOUND");
+    expect(body.error.code).toBe("TRIAL_PLAN_AS_BASE");
   });
 
   test("should return 400 when billing profile is missing and no billing data provided", async () => {
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     const response = await app.handle(
       new Request(ENDPOINT, {
@@ -294,8 +304,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: goldPlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: goldPlanResult.plan.id,
           })
         ),
       })
@@ -313,7 +322,6 @@ describe("POST /v1/payments/admin/checkout", () => {
     async () => {
       const { headers } = await UserFactory.createAdmin();
       const org = await OrganizationFactory.create();
-      const tier = PlanFactory.getFirstTier(goldPlanResult);
 
       await BillingProfileFactory.create({ organizationId: org.id });
 
@@ -324,8 +332,9 @@ describe("POST /v1/payments/admin/checkout", () => {
           body: JSON.stringify(
             buildPayload({
               organizationId: org.id,
-              planId: goldPlanResult.plan.id,
-              pricingTierId: tier.id,
+              basePlanId: goldPlanResult.plan.id,
+              minEmployees: 0,
+              maxEmployees: 25,
               customPriceMonthly: 5000,
               notes: "Desconto negociado",
             })
@@ -336,15 +345,46 @@ describe("POST /v1/payments/admin/checkout", () => {
       expect(response.status).toBe(200);
 
       const body = await response.json();
+
       expect(body.success).toBe(true);
       expect(body.data.checkoutUrl).toBeString();
       expect(body.data.paymentLinkId).toBeString();
+      expect(body.data.privatePlanId).toStartWith("plan-");
+      expect(body.data.privateTierId).toStartWith("tier-");
       expect(body.data.customPriceMonthly).toBe(5000);
       expect(body.data.customPriceYearly).toBeNumber();
-      expect(body.data.catalogPriceMonthly).toBeNumber();
-      expect(body.data.catalogPriceYearly).toBeNumber();
-      expect(body.data.discountPercentage).toBeNumber();
+      expect(body.data.basePlanDisplayName).toBe(
+        goldPlanResult.plan.displayName
+      );
+      expect(body.data.minEmployees).toBe(0);
+      expect(body.data.maxEmployees).toBe(25);
       expect(body.data.expiresAt).toBeString();
+
+      // Verify private plan was created in DB
+      const [privatePlan] = await db
+        .select()
+        .from(schema.subscriptionPlans)
+        .where(eq(schema.subscriptionPlans.id, body.data.privatePlanId))
+        .limit(1);
+
+      expect(privatePlan).toBeDefined();
+      expect(privatePlan.isPublic).toBe(false);
+      expect(privatePlan.isTrial).toBe(false);
+      expect(privatePlan.isActive).toBe(true);
+
+      // Verify private tier was created in DB
+      const [privateTier] = await db
+        .select()
+        .from(schema.planPricingTiers)
+        .where(eq(schema.planPricingTiers.id, body.data.privateTierId))
+        .limit(1);
+
+      expect(privateTier).toBeDefined();
+      expect(privateTier.planId).toBe(body.data.privatePlanId);
+      expect(privateTier.minEmployees).toBe(0);
+      expect(privateTier.maxEmployees).toBe(25);
+      expect(privateTier.priceMonthly).toBe(5000);
+      expect(privateTier.priceYearly).toBeNumber();
 
       // Verify pending checkout was saved
       const [checkout] = await db
@@ -357,8 +397,8 @@ describe("POST /v1/payments/admin/checkout", () => {
 
       expect(checkout).toBeDefined();
       expect(checkout.organizationId).toBe(org.id);
-      expect(checkout.planId).toBe(goldPlanResult.plan.id);
-      expect(checkout.pricingTierId).toBe(tier.id);
+      expect(checkout.planId).toBe(body.data.privatePlanId);
+      expect(checkout.pricingTierId).toBe(body.data.privateTierId);
       expect(checkout.status).toBe("pending");
       expect(checkout.customPriceMonthly).toBe(5000);
       expect(checkout.customPriceYearly).toBeNumber();
@@ -373,7 +413,6 @@ describe("POST /v1/payments/admin/checkout", () => {
     async () => {
       const { headers } = await UserFactory.createAdmin();
       const org = await OrganizationFactory.create();
-      const tier = PlanFactory.getFirstTier(goldPlanResult);
 
       const response = await app.handle(
         new Request(ENDPOINT, {
@@ -382,8 +421,9 @@ describe("POST /v1/payments/admin/checkout", () => {
           body: JSON.stringify(
             buildPayload({
               organizationId: org.id,
-              planId: goldPlanResult.plan.id,
-              pricingTierId: tier.id,
+              basePlanId: goldPlanResult.plan.id,
+              minEmployees: 0,
+              maxEmployees: 25,
               customPriceMonthly: 3000,
               billing: buildBillingData(),
             })
@@ -396,7 +436,14 @@ describe("POST /v1/payments/admin/checkout", () => {
       const body = await response.json();
       expect(body.success).toBe(true);
       expect(body.data.checkoutUrl).toBeString();
+      expect(body.data.privatePlanId).toStartWith("plan-");
+      expect(body.data.privateTierId).toStartWith("tier-");
       expect(body.data.customPriceMonthly).toBe(3000);
+      expect(body.data.basePlanDisplayName).toBe(
+        goldPlanResult.plan.displayName
+      );
+      expect(body.data.minEmployees).toBe(0);
+      expect(body.data.maxEmployees).toBe(25);
 
       // Verify billing profile was created
       const [profile] = await db
@@ -416,7 +463,6 @@ describe("POST /v1/payments/admin/checkout", () => {
     async () => {
       const { headers } = await UserFactory.createAdmin();
       const org = await OrganizationFactory.create();
-      const tier = PlanFactory.getFirstTier(goldPlanResult);
 
       await BillingProfileFactory.create({ organizationId: org.id });
       await SubscriptionFactory.createTrial(org.id, trialPlanResult.plan.id);
@@ -428,8 +474,9 @@ describe("POST /v1/payments/admin/checkout", () => {
           body: JSON.stringify(
             buildPayload({
               organizationId: org.id,
-              planId: goldPlanResult.plan.id,
-              pricingTierId: tier.id,
+              basePlanId: goldPlanResult.plan.id,
+              minEmployees: 0,
+              maxEmployees: 25,
             })
           ),
         })
@@ -440,6 +487,104 @@ describe("POST /v1/payments/admin/checkout", () => {
       const body = await response.json();
       expect(body.success).toBe(true);
       expect(body.data.checkoutUrl).toBeString();
+      expect(body.data.privatePlanId).toStartWith("plan-");
+      expect(body.data.privateTierId).toStartWith("tier-");
+      expect(body.data.basePlanDisplayName).toBe(
+        goldPlanResult.plan.displayName
+      );
+    },
+    15_000
+  );
+
+  test.skipIf(skipIntegration)(
+    "should create checkout with custom range above catalog (min=0, max=500)",
+    async () => {
+      const { headers } = await UserFactory.createAdmin();
+      const org = await OrganizationFactory.create();
+
+      await BillingProfileFactory.create({ organizationId: org.id });
+
+      const response = await app.handle(
+        new Request(ENDPOINT, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify(
+            buildPayload({
+              organizationId: org.id,
+              basePlanId: goldPlanResult.plan.id,
+              minEmployees: 0,
+              maxEmployees: 500,
+              customPriceMonthly: 200_000,
+            })
+          ),
+        })
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.data.checkoutUrl).toBeString();
+      expect(body.data.privatePlanId).toStartWith("plan-");
+      expect(body.data.privateTierId).toStartWith("tier-");
+      expect(body.data.minEmployees).toBe(0);
+      expect(body.data.maxEmployees).toBe(500);
+      expect(body.data.customPriceMonthly).toBe(200_000);
+
+      // Verify private tier has the custom range
+      const [privateTier] = await db
+        .select()
+        .from(schema.planPricingTiers)
+        .where(eq(schema.planPricingTiers.id, body.data.privateTierId))
+        .limit(1);
+
+      expect(privateTier).toBeDefined();
+      expect(privateTier.minEmployees).toBe(0);
+      expect(privateTier.maxEmployees).toBe(500);
+    },
+    15_000
+  );
+
+  test.skipIf(skipIntegration)(
+    "should create private plan with base plan features (verify DB limits)",
+    async () => {
+      const { headers } = await UserFactory.createAdmin();
+      const org = await OrganizationFactory.create();
+
+      await BillingProfileFactory.create({ organizationId: org.id });
+
+      const response = await app.handle(
+        new Request(ENDPOINT, {
+          method: "POST",
+          headers: { ...headers, "Content-Type": "application/json" },
+          body: JSON.stringify(
+            buildPayload({
+              organizationId: org.id,
+              basePlanId: goldPlanResult.plan.id,
+              minEmployees: 0,
+              maxEmployees: 50,
+              customPriceMonthly: 10_000,
+            })
+          ),
+        })
+      );
+
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body.success).toBe(true);
+
+      // Verify private plan inherits base plan's limits/features
+      const [privatePlan] = await db
+        .select()
+        .from(schema.subscriptionPlans)
+        .where(eq(schema.subscriptionPlans.id, body.data.privatePlanId))
+        .limit(1);
+
+      expect(privatePlan).toBeDefined();
+      expect(privatePlan.isPublic).toBe(false);
+      expect(privatePlan.isTrial).toBe(false);
+      expect(privatePlan.limits).toEqual(goldPlanResult.plan.limits);
     },
     15_000
   );
@@ -451,7 +596,6 @@ describe("POST /v1/payments/admin/checkout", () => {
 
     const { headers } = await UserFactory.createAdmin();
     const org = await OrganizationFactory.create();
-    const tier = PlanFactory.getFirstTier(goldPlanResult);
 
     await BillingProfileFactory.create({ organizationId: org.id });
 
@@ -467,8 +611,7 @@ describe("POST /v1/payments/admin/checkout", () => {
         body: JSON.stringify(
           buildPayload({
             organizationId: org.id,
-            planId: goldPlanResult.plan.id,
-            pricingTierId: tier.id,
+            basePlanId: goldPlanResult.plan.id,
           })
         ),
       })

--- a/src/modules/payments/admin-checkout/admin-checkout.model.ts
+++ b/src/modules/payments/admin-checkout/admin-checkout.model.ts
@@ -21,35 +21,54 @@ const billingDataSchema = z.object({
   zipCode: z.string().length(8).describe("ZIP code (CEP)"),
 });
 
-export const createAdminCheckoutSchema = z.object({
-  organizationId: z.string().min(1).describe("Target organization ID"),
-  planId: z.string().min(1).describe("Plan ID"),
-  pricingTierId: z.string().min(1).describe("Pricing tier ID"),
-  billingCycle: z
-    .enum(["monthly", "yearly"])
-    .default("monthly")
-    .describe("Billing cycle"),
-  customPriceMonthly: z
-    .number()
-    .int()
-    .min(100, "Minimum price is 100 centavos (R$ 1.00)")
-    .describe("Custom monthly price in centavos"),
-  successUrl: (isProduction ? z.httpUrl() : z.url()).describe(
-    "URL to redirect after successful payment"
-  ),
-  notes: z
-    .string()
-    .max(500)
-    .optional()
-    .describe("Admin notes (discount reason, contract info)"),
-  billing: billingDataSchema
-    .optional()
-    .describe("Billing data -- required if org has no billing profile"),
-});
+export const createAdminCheckoutSchema = z
+  .object({
+    organizationId: z.string().min(1).describe("Target organization ID"),
+    basePlanId: z
+      .string()
+      .min(1)
+      .describe("Base plan ID (public, active, non-trial) to inherit features"),
+    minEmployees: z
+      .number()
+      .int()
+      .min(0)
+      .describe("Minimum employees in custom tier"),
+    maxEmployees: z
+      .number()
+      .int()
+      .min(1)
+      .describe("Maximum employees in custom tier"),
+    billingCycle: z
+      .enum(["monthly", "yearly"])
+      .default("monthly")
+      .describe("Billing cycle"),
+    customPriceMonthly: z
+      .number()
+      .int()
+      .min(100, "Minimum price is 100 centavos (R$ 1.00)")
+      .describe("Custom monthly price in centavos"),
+    successUrl: (isProduction ? z.httpUrl() : z.url()).describe(
+      "URL to redirect after successful payment"
+    ),
+    notes: z
+      .string()
+      .max(500)
+      .optional()
+      .describe("Admin notes (discount reason, contract info)"),
+    billing: billingDataSchema
+      .optional()
+      .describe("Billing data -- required if org has no billing profile"),
+  })
+  .refine((data) => data.maxEmployees > data.minEmployees, {
+    message: "maxEmployees must be greater than minEmployees",
+    path: ["maxEmployees"],
+  });
 
 const adminCheckoutDataSchema = z.object({
   checkoutUrl: z.url().describe("Payment link URL"),
   paymentLinkId: z.string().describe("Pagar.me payment link ID"),
+  privatePlanId: z.string().describe("Created private plan ID"),
+  privateTierId: z.string().describe("Created private tier ID"),
   customPriceMonthly: z
     .number()
     .int()
@@ -58,17 +77,9 @@ const adminCheckoutDataSchema = z.object({
     .number()
     .int()
     .describe("Custom yearly price (centavos)"),
-  catalogPriceMonthly: z
-    .number()
-    .int()
-    .describe("Catalog monthly price (centavos)"),
-  catalogPriceYearly: z
-    .number()
-    .int()
-    .describe("Catalog yearly price (centavos)"),
-  discountPercentage: z
-    .number()
-    .describe("Discount percentage compared to catalog"),
+  basePlanDisplayName: z.string().describe("Base plan display name"),
+  minEmployees: z.number().int().describe("Custom tier min employees"),
+  maxEmployees: z.number().int().describe("Custom tier max employees"),
   expiresAt: z.string().describe("Checkout link expiration (ISO 8601)"),
 });
 

--- a/src/modules/payments/admin-checkout/admin-checkout.service.ts
+++ b/src/modules/payments/admin-checkout/admin-checkout.service.ts
@@ -7,6 +7,7 @@ import { CustomerService } from "@/modules/payments/customer/customer.service";
 import {
   BillingProfileRequiredError,
   OrganizationNotFoundError,
+  TrialPlanAsBaseError,
 } from "@/modules/payments/errors";
 import {
   PAGARME_RETRY_CONFIG,
@@ -31,8 +32,9 @@ export abstract class AdminCheckoutService {
     const {
       organizationId,
       adminUserId,
-      planId,
-      pricingTierId,
+      basePlanId,
+      minEmployees,
+      maxEmployees,
       billingCycle = "monthly",
       customPriceMonthly,
       successUrl,
@@ -54,9 +56,12 @@ export abstract class AdminCheckoutService {
     // 2. Validate no active paid subscription
     await SubscriptionService.ensureNoPaidSubscription(organizationId);
 
-    // 3. Validate plan + tier
-    const plan = await PlansService.getAvailableById(planId);
-    const tier = await PlansService.getTierById(pricingTierId);
+    // 3. Validate base plan (must be active, non-trial)
+    const basePlan = await PlansService.getAvailableById(basePlanId);
+
+    if (basePlan.isTrial) {
+      throw new TrialPlanAsBaseError(basePlanId);
+    }
 
     // 4. Handle billing profile
     await AdminCheckoutService.ensureBillingProfile(organizationId, billing);
@@ -70,23 +75,53 @@ export abstract class AdminCheckoutService {
     const effectivePrice =
       billingCycle === "monthly" ? customPriceMonthly : customPriceYearly;
 
-    // 7. Create custom Pagarme plan
+    // 7. Create private plan + tier in transaction
+    const privatePlanId = `plan-${crypto.randomUUID()}`;
+    const privateTierId = `tier-${crypto.randomUUID()}`;
+    const timestamp = Date.now();
+    const privatePlanName = `custom-${basePlan.name}-${organizationId}-${timestamp}`;
+
+    await db.transaction(async (tx) => {
+      await tx.insert(schema.subscriptionPlans).values({
+        id: privatePlanId,
+        name: privatePlanName,
+        displayName: basePlan.displayName,
+        description: `Custom plan based on ${basePlan.displayName} for org ${organizationId}`,
+        trialDays: 0,
+        limits: basePlan.limits,
+        isActive: true,
+        isPublic: false,
+        isTrial: false,
+        sortOrder: basePlan.sortOrder,
+      });
+
+      await tx.insert(schema.planPricingTiers).values({
+        id: privateTierId,
+        planId: privatePlanId,
+        minEmployees,
+        maxEmployees,
+        priceMonthly: customPriceMonthly,
+        priceYearly: customPriceYearly,
+      });
+    });
+
+    // 8. Create custom Pagarme plan
     const pagarmePlanId = await PagarmePlanService.createCustomPlan({
-      plan: { id: plan.id, name: plan.name, displayName: plan.displayName },
-      tier: {
-        id: tier.id,
-        minEmployees: tier.minEmployees,
-        maxEmployees: tier.maxEmployees,
+      plan: {
+        id: privatePlanId,
+        name: basePlan.name,
+        displayName: basePlan.displayName,
       },
+      tier: { id: privateTierId, minEmployees, maxEmployees },
       billingCycle,
       price: effectivePrice,
     });
 
-    // 8. Create payment link
-    const tierLabel = `${tier.minEmployees}-${tier.maxEmployees} funcionarios`;
+    // 9. Create payment link
+    const tierLabel = `${minEmployees}-${maxEmployees} funcionarios`;
     const paymentLinkData: CreatePaymentLinkRequest = {
       type: "subscription",
-      name: `${plan.displayName} (${tierLabel})${billingCycle === "yearly" ? " - Anual" : ""} [Custom]`,
+      name: `${basePlan.displayName} (${tierLabel})${billingCycle === "yearly" ? " - Anual" : ""} [Custom]`,
       payment_settings: {
         accepted_payment_methods: ["credit_card"],
         credit_card_settings: {
@@ -105,8 +140,8 @@ export abstract class AdminCheckoutService {
       max_paid_sessions: 1,
       metadata: {
         organization_id: organizationId,
-        plan_id: planId,
-        pricing_tier_id: tier.id,
+        plan_id: privatePlanId,
+        pricing_tier_id: privateTierId,
         billing_cycle: billingCycle,
         is_custom_price: "true",
         custom_price_monthly: String(customPriceMonthly),
@@ -121,20 +156,20 @@ export abstract class AdminCheckoutService {
       () =>
         PagarmeClient.createPaymentLink(
           paymentLinkData,
-          `admin-checkout-${organizationId}-${planId}-${Date.now()}`
+          `admin-checkout-${organizationId}-${privatePlanId}-${Date.now()}`
         ),
       PAGARME_RETRY_CONFIG.WRITE
     );
 
-    // 9. Save pending checkout
+    // 10. Save pending checkout
     const expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours() + CHECKOUT_EXPIRATION_HOURS);
 
     await db.insert(schema.pendingCheckouts).values({
       id: `checkout-${crypto.randomUUID()}`,
       organizationId,
-      planId,
-      pricingTierId: tier.id,
+      planId: privatePlanId,
+      pricingTierId: privateTierId,
       billingCycle,
       paymentLinkId: paymentLink.id,
       status: "pending",
@@ -146,25 +181,17 @@ export abstract class AdminCheckoutService {
       pagarmePlanId,
     });
 
-    // 10. Calculate comparison data
-    const catalogPriceMonthly = tier.priceMonthly;
-    const catalogPriceYearly = tier.priceYearly;
-    const discountPercentage =
-      catalogPriceMonthly > 0
-        ? Math.round(
-            ((catalogPriceMonthly - customPriceMonthly) / catalogPriceMonthly) *
-              10_000
-          ) / 100
-        : 0;
-
+    // 11. Return checkout data
     return {
       checkoutUrl: paymentLink.url,
       paymentLinkId: paymentLink.id,
+      privatePlanId,
+      privateTierId,
       customPriceMonthly,
       customPriceYearly,
-      catalogPriceMonthly,
-      catalogPriceYearly,
-      discountPercentage,
+      basePlanDisplayName: basePlan.displayName,
+      minEmployees,
+      maxEmployees,
       expiresAt: expiresAt.toISOString(),
     };
   }

--- a/src/modules/payments/errors.ts
+++ b/src/modules/payments/errors.ts
@@ -120,6 +120,18 @@ export class PlanNotAvailableError extends PaymentError {
   }
 }
 
+export class TrialPlanAsBaseError extends PaymentError {
+  status = 400;
+
+  constructor(planId: string) {
+    super(
+      `Trial plans cannot be used as base for custom checkout: ${planId}`,
+      "TRIAL_PLAN_AS_BASE",
+      { planId }
+    );
+  }
+}
+
 export class YearlyBillingNotAvailableError extends PaymentError {
   status = 400;
 


### PR DESCRIPTION
## Summary

- Refatora `POST /admin/checkout` para criar **plano privado dedicado** em vez de referenciar plano+tier existente do catálogo
- Admin define `basePlanId`, `minEmployees`, `maxEmployees`, `customPriceMonthly` — faixa de funcionários livre
- Service cria `subscription_plans` (`isPublic=false`) + 1 `plan_pricing_tiers` em transação, herdando features do plano base
- Webhook, LimitsService e listagem pública de planos não requerem alterações

## Changes

- **`errors.ts`**: add `TrialPlanAsBaseError` (400, `TRIAL_PLAN_AS_BASE`)
- **`admin-checkout.model.ts`**: replace `planId`+`pricingTierId` with `basePlanId`+`minEmployees`+`maxEmployees`; add `.refine()` for `maxEmployees > minEmployees`; update output schema with `privatePlanId`, `privateTierId`, `basePlanDisplayName`
- **`admin-checkout.service.ts`**: create private plan+tier in DB transaction; pass base plan name to Pagarme; metadata points to private plan
- **`admin-checkout.test.ts`**: 18 tests (was 14) — added trial plan rejection, employee range validation, custom range above catalog, features inheritance verification
- **`CLAUDE.md`**: updated module docs to reflect new model

## Test plan

- [x] 18 testes passam (`bun test admin-checkout`)
- [x] Lint passa (`npx ultracite check`)
- [ ] Verificar que planos privados não aparecem em `GET /plans`
- [ ] Verificar que webhook resolve corretamente com metadata do plano privado

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)