### PR TITLE
fix(api-keys): return 404 instead of 500 for missing API keys

### DIFF
--- a/src/modules/api-keys/api-key.service.ts
+++ b/src/modules/api-keys/api-key.service.ts
@@ -1,4 +1,3 @@
-import { APIError } from "better-auth/api";
 import { auth } from "@/lib/auth";
 import { DEFAULT_API_KEY_PERMISSIONS } from "@/lib/permissions";
 import type {
@@ -129,7 +128,7 @@ export abstract class ApiKeyService {
         createdAt: result.createdAt.toISOString(),
       };
     } catch (error) {
-      if (error instanceof APIError && error.status === "NOT_FOUND") {
+      if (isBetterAuthNotFound(error)) {
         throw new ApiKeyNotFoundError(keyId);
       }
       throw error;
@@ -153,7 +152,7 @@ export abstract class ApiKeyService {
         revoked: true,
       };
     } catch (error) {
-      if (error instanceof APIError && error.status === "NOT_FOUND") {
+      if (isBetterAuthNotFound(error)) {
         throw new ApiKeyNotFoundError(keyId);
       }
       throw error;
@@ -174,10 +173,18 @@ export abstract class ApiKeyService {
         deleted: true,
       };
     } catch (error) {
-      if (error instanceof APIError && error.status === "NOT_FOUND") {
+      if (isBetterAuthNotFound(error)) {
         throw new ApiKeyNotFoundError(keyId);
       }
       throw error;
     }
   }
+}
+
+function isBetterAuthNotFound(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "APIError" &&
+    (error as unknown as { statusCode: number }).statusCode === 404
+  );
 }


### PR DESCRIPTION
## Summary

- Replaced `instanceof APIError` checks with duck-typing (`error.name === "APIError" && error.statusCode === 404`) in `ApiKeyService` to fix the ESM/CJS dual-package hazard
- The `APIError` class from `better-auth/api` is not the same reference as the one used internally by Better Auth (from `better-call`), causing `instanceof` to always return `false`
- Extracted a reusable `isBetterAuthNotFound()` helper function for all 3 catch blocks (`getById`, `revoke`, `delete`)

## Test plan

- [x] `GET /v1/admin/api-keys/:id` returns 404 for non-existent key (was 500)
- [x] `DELETE /v1/admin/api-keys/:id` returns 404 for non-existent key (was 500)
- [x] `GET /v1/admin/api-keys/:id` after delete returns 404 (was 500)
- [x] All 24 api-keys module tests pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)