### PR TITLE
fix(tests): prevent duplicate subscription constraint violation

### DIFF
--- a/src/modules/employees/__tests__/create-employee.test.ts
+++ b/src/modules/employees/__tests__/create-employee.test.ts
@@ -140,6 +140,7 @@ describe("POST /v1/employees", () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
+        skipTrialCreation: true,
       });
 
     const deps = await createTestDependencies(organizationId, user.id);
@@ -167,6 +168,7 @@ describe("POST /v1/employees", () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
+        skipTrialCreation: true,
       });
 
     const deps = await createTestDependencies(organizationId, user.id);
@@ -199,6 +201,7 @@ describe("POST /v1/employees", () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
+        skipTrialCreation: true,
       });
 
     const deps = await createTestDependencies(organizationId, user.id);
@@ -246,6 +249,7 @@ describe("POST /v1/employees", () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
+        skipTrialCreation: true,
       });
 
     await setupSubscription(organizationId);
@@ -291,6 +295,7 @@ describe("POST /v1/employees", () => {
 
     const { organizationId, user } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
 
     const deps = await createTestDependencies(organizationId, user.id);
@@ -324,6 +329,7 @@ describe("POST /v1/employees", () => {
 
     const { organizationId, user } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
 
     const deps = await createTestDependencies(organizationId, user.id);

--- a/src/modules/employees/__tests__/feature-gate.test.ts
+++ b/src/modules/employees/__tests__/feature-gate.test.ts
@@ -60,6 +60,7 @@ describe("Employees — feature gate", () => {
     test("should pass feature gate with Gold plan (employee_status is a Gold feature)", async () => {
       const { headers, organizationId } = await createTestUserWithOrganization({
         emailVerified: true,
+        skipTrialCreation: true,
       });
       await SubscriptionFactory.createActive(organizationId, goldPlan.plan.id);
       const fakeId = `emp-${crypto.randomUUID()}`;

--- a/src/modules/employees/import/__tests__/import-employees.test.ts
+++ b/src/modules/employees/import/__tests__/import-employees.test.ts
@@ -137,7 +137,10 @@ describe("GET /v1/employees/import/template", () => {
 
   test("should return xlsx template", async () => {
     const { headers, organizationId, user } =
-      await createTestUserWithOrganization({ emailVerified: true });
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
 
     await createTestDependencies(organizationId, user.id);
 
@@ -189,7 +192,10 @@ describe("POST /v1/employees/import", () => {
 
   test("should import valid employees", async () => {
     const { headers, organizationId, user } =
-      await createTestUserWithOrganization({ emailVerified: true });
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
 
     const deps = await createTestDependencies(organizationId, user.id);
 
@@ -235,7 +241,10 @@ describe("POST /v1/employees/import", () => {
 
   test("should report errors for invalid rows", async () => {
     const { headers, organizationId, user } =
-      await createTestUserWithOrganization({ emailVerified: true });
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
 
     const deps = await createTestDependencies(organizationId, user.id);
 

--- a/src/modules/occurrences/absences/__tests__/feature-gate.test.ts
+++ b/src/modules/occurrences/absences/__tests__/feature-gate.test.ts
@@ -54,6 +54,7 @@ describe("GET /v1/absences — feature gate", () => {
   test("should return 200 with Gold plan (absences is a Gold feature)", async () => {
     const { headers, organizationId } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
     await SubscriptionFactory.createActive(organizationId, goldPlan.plan.id);
 

--- a/src/modules/occurrences/accidents/__tests__/feature-gate.test.ts
+++ b/src/modules/occurrences/accidents/__tests__/feature-gate.test.ts
@@ -54,6 +54,7 @@ describe("GET /v1/accidents — feature gate", () => {
   test("should return 200 with Gold plan (accidents is a Gold feature)", async () => {
     const { headers, organizationId } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
     await SubscriptionFactory.createActive(organizationId, goldPlan.plan.id);
 

--- a/src/modules/occurrences/medical-certificates/__tests__/feature-gate.test.ts
+++ b/src/modules/occurrences/medical-certificates/__tests__/feature-gate.test.ts
@@ -54,6 +54,7 @@ describe("GET /v1/medical-certificates — feature gate", () => {
   test("should return 200 with Gold plan (medical_certificates is a Gold feature)", async () => {
     const { headers, organizationId } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
     await SubscriptionFactory.createActive(organizationId, goldPlan.plan.id);
 

--- a/src/modules/occurrences/terminations/__tests__/feature-gate.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/feature-gate.test.ts
@@ -54,6 +54,7 @@ describe("GET /v1/terminations — feature gate", () => {
   test("should return 200 with Gold plan (terminated_employees is a Gold feature)", async () => {
     const { headers, organizationId } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
     await SubscriptionFactory.createActive(organizationId, goldPlan.plan.id);
 

--- a/src/modules/occurrences/warnings/__tests__/feature-gate.test.ts
+++ b/src/modules/occurrences/warnings/__tests__/feature-gate.test.ts
@@ -54,6 +54,7 @@ describe("GET /v1/warnings — feature gate", () => {
   test("should return 200 with Gold plan (warnings is a Gold feature)", async () => {
     const { headers, organizationId } = await createTestUserWithOrganization({
       emailVerified: true,
+      skipTrialCreation: true,
     });
     await SubscriptionFactory.createActive(organizationId, goldPlan.plan.id);
 


### PR DESCRIPTION
## Summary

- Added `skipTrialCreation: true` to `createTestUserWithOrganization()` calls in tests that create their own subscription afterward, preventing `duplicate key value violates unique constraint "org_subscriptions_organization_id_active_unique_idx"`

## Files changed (8)

- `src/modules/employees/__tests__/create-employee.test.ts` — 6 tests fixed
- `src/modules/employees/__tests__/feature-gate.test.ts` — 1 test fixed
- `src/modules/employees/import/__tests__/import-employees.test.ts` — 3 tests fixed
- `src/modules/occurrences/absences/__tests__/feature-gate.test.ts` — 1 test fixed
- `src/modules/occurrences/medical-certificates/__tests__/feature-gate.test.ts` — 1 test fixed
- `src/modules/occurrences/terminations/__tests__/feature-gate.test.ts` — 1 test fixed
- `src/modules/occurrences/accidents/__tests__/feature-gate.test.ts` — 1 test fixed
- `src/modules/occurrences/warnings/__tests__/feature-gate.test.ts` — 1 test fixed

## Note

`src/modules/payments/checkout/__tests__/create-checkout.test.ts` listed in the issue was **not affected** — it uses `UserFactory.createWithOrganization()` which does not create a trial subscription.

## Test plan

- [x] All 28 affected tests pass (0 fail)
- [x] Lint passes (`npx ultracite check`)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)