### PR TITLE
fix: pass tx to PagarmePlanHistoryService for transactional safety

### DIFF
--- a/src/modules/payments/pagarme/__tests__/pagarme-plan-history.test.ts
+++ b/src/modules/payments/pagarme/__tests__/pagarme-plan-history.test.ts
@@ -136,6 +136,79 @@ describe("PagarmePlanHistoryService", () => {
     expect(recordB.isActive).toBe(true);
   });
 
+  test("deactivateByTierId() should rollback when transaction fails", async () => {
+    const tierId = `tier-${crypto.randomUUID()}`;
+    const pagarmePlanId = `plan_pagarme_${crypto.randomUUID().slice(0, 8)}`;
+
+    await PagarmePlanHistoryService.record({
+      localPlanId: testPlanId,
+      localTierId: tierId,
+      pagarmePlanId,
+      billingCycle: "monthly",
+      priceAtCreation: 4900,
+    });
+
+    // Run deactivateByTierId inside a transaction that rolls back
+    try {
+      await db.transaction(async (tx) => {
+        await PagarmePlanHistoryService.deactivateByTierId(tierId, tx);
+
+        // Verify deactivation is visible inside the transaction
+        const [insideTx] = await tx
+          .select()
+          .from(schema.pagarmePlanHistory)
+          .where(eq(schema.pagarmePlanHistory.pagarmePlanId, pagarmePlanId));
+        expect(insideTx.isActive).toBe(false);
+
+        // Force rollback
+        throw new Error("forced rollback");
+      });
+    } catch (err) {
+      if (!(err instanceof Error) || err.message !== "forced rollback") {
+        throw err;
+      }
+    }
+
+    // After rollback, the record should still be active
+    const [record] = await db
+      .select()
+      .from(schema.pagarmePlanHistory)
+      .where(eq(schema.pagarmePlanHistory.pagarmePlanId, pagarmePlanId));
+    expect(record.isActive).toBe(true);
+  });
+
+  test("record() should rollback when transaction fails", async () => {
+    const pagarmePlanId = `plan_pagarme_${crypto.randomUUID().slice(0, 8)}`;
+
+    try {
+      await db.transaction(async (tx) => {
+        await PagarmePlanHistoryService.record(
+          {
+            localPlanId: testPlanId,
+            localTierId: `tier-${crypto.randomUUID()}`,
+            pagarmePlanId,
+            billingCycle: "monthly",
+            priceAtCreation: 4900,
+          },
+          tx
+        );
+
+        throw new Error("forced rollback");
+      });
+    } catch (err) {
+      if (!(err instanceof Error) || err.message !== "forced rollback") {
+        throw err;
+      }
+    }
+
+    // After rollback, the record should not exist
+    const records = await db
+      .select()
+      .from(schema.pagarmePlanHistory)
+      .where(eq(schema.pagarmePlanHistory.pagarmePlanId, pagarmePlanId));
+    expect(records.length).toBe(0);
+  });
+
   test("listOrphaned() should return only inactive records", async () => {
     const activeTierId = `tier-${crypto.randomUUID()}`;
     const inactiveTierId = `tier-${crypto.randomUUID()}`;

--- a/src/modules/payments/pagarme/pagarme-plan-history.service.ts
+++ b/src/modules/payments/pagarme/pagarme-plan-history.service.ts
@@ -3,16 +3,21 @@ import { db } from "@/db";
 import { schema } from "@/db/schema";
 
 type BillingCycle = "monthly" | "yearly";
+type Transaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 export abstract class PagarmePlanHistoryService {
-  static async record(input: {
-    localPlanId: string;
-    localTierId: string;
-    pagarmePlanId: string;
-    billingCycle: BillingCycle;
-    priceAtCreation: number;
-  }): Promise<void> {
-    await db.insert(schema.pagarmePlanHistory).values({
+  static async record(
+    input: {
+      localPlanId: string;
+      localTierId: string;
+      pagarmePlanId: string;
+      billingCycle: BillingCycle;
+      priceAtCreation: number;
+    },
+    tx?: Transaction
+  ): Promise<void> {
+    const conn = tx ?? db;
+    await conn.insert(schema.pagarmePlanHistory).values({
       id: `pagarme-hist-${crypto.randomUUID()}`,
       localPlanId: input.localPlanId,
       localTierId: input.localTierId,
@@ -23,8 +28,12 @@ export abstract class PagarmePlanHistoryService {
     });
   }
 
-  static async deactivateByTierId(tierId: string): Promise<void> {
-    await db
+  static async deactivateByTierId(
+    tierId: string,
+    tx?: Transaction
+  ): Promise<void> {
+    const conn = tx ?? db;
+    await conn
       .update(schema.pagarmePlanHistory)
       .set({ isActive: false })
       .where(eq(schema.pagarmePlanHistory.localTierId, tierId));

--- a/src/modules/payments/plans/plans.service.ts
+++ b/src/modules/payments/plans/plans.service.ts
@@ -478,7 +478,7 @@ export abstract class PlansService {
         oldTier.id
       );
       if (!hasActiveReferences) {
-        await PagarmePlanHistoryService.deactivateByTierId(oldTier.id);
+        await PagarmePlanHistoryService.deactivateByTierId(oldTier.id, tx);
       }
     }
 


### PR DESCRIPTION
## Summary

- `PagarmePlanHistoryService.deactivateByTierId()` and `record()` now accept an optional `tx` parameter to operate within the caller's transaction scope
- Updated `PlansService.replaceTiers()` to pass `tx` when calling `deactivateByTierId()`, preventing `pagarme_plan_history` desync on rollback
- Added 2 integration tests verifying rollback behavior for both `deactivateByTierId()` and `record()`

Closes #77

## Test plan

- [x] Existing `PagarmePlanHistoryService` unit tests pass (5 tests)
- [x] New rollback tests pass — `deactivateByTierId(tx)` and `record(tx)` revert correctly on transaction failure
- [x] `update-plan.test.ts` passes (14 tests) — end-to-end `replaceTiers` flow works with `tx` propagation
- [x] Lint passes (`npx ultracite check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)