### PR TITLE
fix(payments): use TierNotFoundError in getTierById()

### DIFF
--- a/src/modules/payments/errors.ts
+++ b/src/modules/payments/errors.ts
@@ -544,10 +544,13 @@ export class TierGapError extends PaymentError {
 export class TierNotFoundError extends PaymentError {
   status = 404;
 
-  constructor(tierId: string, planId: string) {
-    super(`Tier "${tierId}" not found in plan "${planId}".`, "TIER_NOT_FOUND", {
+  constructor(tierId: string, planId?: string) {
+    const message = planId
+      ? `Tier "${tierId}" not found in plan "${planId}".`
+      : `Tier "${tierId}" not found.`;
+    super(message, "TIER_NOT_FOUND", {
       tierId,
-      planId,
+      ...(planId && { planId }),
     });
   }
 }

--- a/src/modules/payments/pagarme/__tests__/pagarme-plan.service.test.ts
+++ b/src/modules/payments/pagarme/__tests__/pagarme-plan.service.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
-import { PricingTierNotFoundError } from "@/modules/payments/errors";
+import { TierNotFoundError } from "@/modules/payments/errors";
 import { PagarmePlanService } from "@/modules/payments/pagarme/pagarme-plan.service";
 import { PlanFactory } from "@/test/factories/payments/plan.factory";
 import { skipIntegration } from "@/test/support/skip-integration";
@@ -83,16 +83,16 @@ describe("PagarmePlanService", () => {
   });
 
   describe("ensurePlan - validation errors", () => {
-    test("should throw PricingTierNotFoundError for non-existent tier", async () => {
+    test("should throw TierNotFoundError for non-existent tier", async () => {
       await expect(
         PagarmePlanService.ensurePlan("tier-non-existent-id", "monthly")
-      ).rejects.toBeInstanceOf(PricingTierNotFoundError);
+      ).rejects.toBeInstanceOf(TierNotFoundError);
     });
 
-    test("should throw PricingTierNotFoundError for invalid tier id format", async () => {
+    test("should throw TierNotFoundError for invalid tier id format", async () => {
       await expect(
         PagarmePlanService.ensurePlan("invalid-id", "yearly")
-      ).rejects.toBeInstanceOf(PricingTierNotFoundError);
+      ).rejects.toBeInstanceOf(TierNotFoundError);
     });
 
     // Note: PlanNotFoundError test removed because FK constraint with cascade delete

--- a/src/modules/payments/pagarme/pagarme-plan.service.ts
+++ b/src/modules/payments/pagarme/pagarme-plan.service.ts
@@ -4,7 +4,7 @@ import { schema } from "@/db/schema";
 import { Retry } from "@/lib/utils/retry";
 import {
   PlanNotFoundError,
-  PricingTierNotFoundError,
+  TierNotFoundError,
 } from "@/modules/payments/errors";
 import { PAGARME_RETRY_CONFIG, PagarmeClient } from "./client";
 import { PagarmePlanHistoryService } from "./pagarme-plan-history.service";
@@ -28,7 +28,7 @@ export abstract class PagarmePlanService {
       .limit(1);
 
     if (!tier) {
-      throw new PricingTierNotFoundError("unknown", tierId);
+      throw new TierNotFoundError(tierId);
     }
 
     const existingPlanId =

--- a/src/modules/payments/plans/__tests__/plans.service.test.ts
+++ b/src/modules/payments/plans/__tests__/plans.service.test.ts
@@ -5,6 +5,7 @@ import { schema } from "@/db/schema";
 import {
   PlanNotAvailableError,
   PlanNotFoundError,
+  TierNotFoundError,
 } from "@/modules/payments/errors";
 import { PlansService } from "@/modules/payments/plans/plans.service";
 import { PlanFactory } from "@/test/factories/payments/plan.factory";
@@ -75,8 +76,10 @@ describe("PlansService", () => {
       expect(result.priceYearly).toBe(expectedTier.priceYearly);
     });
 
-    test("should throw PricingTierNotFoundError for non-existent tier", () => {
-      expect(() => PlansService.getTierById("tier-non-existent-id")).toThrow();
+    test("should throw TierNotFoundError for non-existent tier", async () => {
+      await expect(() =>
+        PlansService.getTierById("tier-non-existent-id")
+      ).toThrow(TierNotFoundError);
     });
 
     test("should throw for archived tier", async () => {

--- a/src/modules/payments/plans/plans.service.ts
+++ b/src/modules/payments/plans/plans.service.ts
@@ -8,10 +8,10 @@ import {
   PlanNameAlreadyExistsError,
   PlanNotAvailableError,
   PlanNotFoundError,
-  PricingTierNotFoundError,
   TierGapError,
   TierMinExceedsMaxError,
   TierNegativeMinError,
+  TierNotFoundError,
   TierOverlapError,
   TrialPlanNotFoundError,
 } from "@/modules/payments/errors";
@@ -652,7 +652,7 @@ export abstract class PlansService {
       .limit(1);
 
     if (!tier) {
-      throw new PricingTierNotFoundError("unknown", tierId);
+      throw new TierNotFoundError(tierId);
     }
 
     return {


### PR DESCRIPTION
## Summary

- Replace incorrect `PricingTierNotFoundError("unknown", tierId)` with `TierNotFoundError(tierId)` in `PlansService.getTierById()` and `PagarmePlanService.ensurePlan()`
- Make `planId` optional in `TierNotFoundError` constructor (these call sites don't have planId context)
- Update tests to assert `TierNotFoundError` instead of `PricingTierNotFoundError`

## Context

`PricingTierNotFoundError` expects `(planId, employeeRange)` — designed for lookups by employee range within a plan. Using it for tier ID lookups produced confusing messages like:

> No pricing tier found for range "tier-abc123" in plan unknown

Now produces:

> Tier "tier-abc123" not found.

`TierNotFoundError` already existed in `errors.ts` but was unused. Made `planId` optional since `getTierById()` and `ensurePlan()` don't have plan context when the tier doesn't exist.

## Files changed

| File | Change |
|------|--------|
| `errors.ts` | `TierNotFoundError`: make `planId` optional, adjust message |
| `plans.service.ts` | `getTierById()`: swap error class |
| `pagarme-plan.service.ts` | `ensurePlan()`: swap error class |
| `plans.service.test.ts` | Assert `TierNotFoundError` |
| `pagarme-plan.service.test.ts` | Assert `TierNotFoundError` |

## Test plan

- [x] `plans.service.test.ts` — 9/9 pass
- [x] `pagarme-plan.service.test.ts` — 8/8 pass
- [x] Lint clean (`npx ultracite check`)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)