### PR TITLE
feat(admin): endpoint para listar todas as organizações

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { errorPlugin } from "./lib/errors/error-plugin";
 import { healthPlugin } from "./lib/health";
 import { logger, loggerPlugin } from "./lib/logger";
 import { setupGracefulShutdown } from "./lib/shutdown/shutdown";
+import { adminOrganizationsController } from "./modules/admin-organizations";
 import { apiKeysController } from "./modules/api-keys";
 import { auditController } from "./modules/audit";
 import { employeeController } from "./modules/employees";
@@ -159,6 +160,7 @@ const app = new Elysia({
   .use(paymentsController)
   .use(auditController)
   .use(apiKeysController)
+  .use(adminOrganizationsController)
   .get("/", ({ redirect }) => redirect("/health"))
   .listen(env.PORT, ({ hostname, port }) => {
     // Application initialization

--- a/src/modules/admin-organizations/__tests__/list-organizations.test.ts
+++ b/src/modules/admin-organizations/__tests__/list-organizations.test.ts
@@ -1,0 +1,195 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { env } from "@/env";
+import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { createTestOrganization } from "@/test/helpers/organization";
+import {
+  createTestAdminUser,
+  createTestUser,
+  createTestUserWithOrganization,
+} from "@/test/helpers/user";
+
+const BASE_URL = env.API_URL;
+const ENDPOINT = `${BASE_URL}/v1/admin/organizations`;
+
+describe("GET /v1/admin/organizations", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("should return 401 without session", async () => {
+    const response = await app.handle(new Request(ENDPOINT, { method: "GET" }));
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("UNAUTHORIZED");
+  });
+
+  test("should return 403 for non-admin user", async () => {
+    const { headers } = await createTestUser();
+
+    const response = await app.handle(
+      new Request(ENDPOINT, { method: "GET", headers })
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  test("should list all organizations with correct data", async () => {
+    const { headers } = await createTestAdminUser();
+
+    const org = await createTestOrganization({
+      name: "List Test Org",
+      tradeName: "List Test Trade",
+      taxId: `list-${Date.now()}`.slice(0, 14),
+    });
+
+    const response = await app.handle(
+      new Request(ENDPOINT, { method: "GET", headers })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.items).toBeArray();
+    expect(body.data.total).toBeNumber();
+    expect(body.data.page).toBe(1);
+    expect(body.data.limit).toBe(20);
+
+    const found = body.data.items.find(
+      (item: { id: string }) => item.id === org.id
+    );
+    expect(found).toBeDefined();
+    expect(found.name).toBe("List Test Org");
+    expect(found.tradeName).toBe("List Test Trade");
+    expect(found.slug).toBeString();
+    expect(found.createdAt).toBeString();
+    expect(typeof found.hasPowerBiUrl).toBe("boolean");
+    expect(typeof found.memberCount).toBe("number");
+  });
+
+  test("should paginate results", async () => {
+    const { headers } = await createTestAdminUser();
+
+    // Create 3 orgs to ensure we have data for pagination
+    await Promise.all([
+      createTestOrganization({ name: "Paginate Org A" }),
+      createTestOrganization({ name: "Paginate Org B" }),
+      createTestOrganization({ name: "Paginate Org C" }),
+    ]);
+
+    const responsePage1 = await app.handle(
+      new Request(`${ENDPOINT}?page=1&limit=2`, { method: "GET", headers })
+    );
+
+    expect(responsePage1.status).toBe(200);
+    const page1 = await responsePage1.json();
+    expect(page1.data.items.length).toBeLessThanOrEqual(2);
+    expect(page1.data.page).toBe(1);
+    expect(page1.data.limit).toBe(2);
+    expect(page1.data.total).toBeGreaterThanOrEqual(3);
+
+    const responsePage2 = await app.handle(
+      new Request(`${ENDPOINT}?page=2&limit=2`, { method: "GET", headers })
+    );
+
+    expect(responsePage2.status).toBe(200);
+    const page2 = await responsePage2.json();
+    expect(page2.data.page).toBe(2);
+    expect(page2.data.limit).toBe(2);
+  });
+
+  test("should search by name and tradeName", async () => {
+    const { headers } = await createTestAdminUser();
+    const uniqueName = `SearchUnique${Date.now()}`;
+
+    await createTestOrganization({
+      name: uniqueName,
+      tradeName: "Some Trade Name",
+      taxId: `srch-${Date.now()}`.slice(0, 14),
+    });
+
+    // Search by name
+    const responseByName = await app.handle(
+      new Request(`${ENDPOINT}?search=${uniqueName}`, {
+        method: "GET",
+        headers,
+      })
+    );
+
+    expect(responseByName.status).toBe(200);
+    const byName = await responseByName.json();
+    expect(byName.data.items.length).toBeGreaterThanOrEqual(1);
+    expect(
+      byName.data.items.some(
+        (item: { name: string }) => item.name === uniqueName
+      )
+    ).toBe(true);
+
+    // Search by tradeName
+    const uniqueTrade = `TradeUnique${Date.now()}`;
+    await createTestOrganization({
+      name: "Some Org Name",
+      tradeName: uniqueTrade,
+      taxId: `trd-${Date.now()}`.slice(0, 14),
+    });
+
+    const responseByTrade = await app.handle(
+      new Request(`${ENDPOINT}?search=${uniqueTrade}`, {
+        method: "GET",
+        headers,
+      })
+    );
+
+    expect(responseByTrade.status).toBe(200);
+    const byTrade = await responseByTrade.json();
+    expect(byTrade.data.items.length).toBeGreaterThanOrEqual(1);
+    expect(
+      byTrade.data.items.some(
+        (item: { tradeName: string }) => item.tradeName === uniqueTrade
+      )
+    ).toBe(true);
+  });
+
+  test("should return empty items when search has no matches", async () => {
+    const { headers } = await createTestAdminUser();
+
+    const response = await app.handle(
+      new Request(
+        `${ENDPOINT}?search=nonexistent-org-name-that-will-never-match-${Date.now()}`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.items).toEqual([]);
+    expect(body.data.total).toBe(0);
+  });
+
+  test("should include memberCount for organizations with members", async () => {
+    const { headers } = await createTestAdminUser();
+
+    // createTestUserWithOrganization creates a user + org + member (owner role)
+    const { organizationId } = await createTestUserWithOrganization();
+
+    const response = await app.handle(
+      new Request(ENDPOINT, { method: "GET", headers })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    const orgWithMember = body.data.items.find(
+      (item: { id: string }) => item.id === organizationId
+    );
+    expect(orgWithMember).toBeDefined();
+    expect(orgWithMember.memberCount).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/modules/admin-organizations/admin-organization.model.ts
+++ b/src/modules/admin-organizations/admin-organization.model.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { successResponseSchema } from "@/lib/responses/response.types";
+
+export const listOrganizationsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  search: z.string().optional(),
+});
+
+export type ListOrganizationsQuery = z.infer<
+  typeof listOrganizationsQuerySchema
+>;
+
+export type ListOrganizationsInput = {
+  page: number;
+  limit: number;
+  search?: string;
+};
+
+export const organizationItemSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  createdAt: z.string(),
+  tradeName: z.string().nullable(),
+  taxId: z.string().nullable(),
+  hasPowerBiUrl: z.boolean(),
+  memberCount: z.number(),
+  status: z.string().nullable(),
+});
+
+export type OrganizationItem = z.infer<typeof organizationItemSchema>;
+
+export const listOrganizationsDataSchema = z.object({
+  items: z.array(organizationItemSchema),
+  total: z.number(),
+  page: z.number(),
+  limit: z.number(),
+});
+
+export type ListOrganizationsData = z.infer<typeof listOrganizationsDataSchema>;
+
+export const listOrganizationsResponseSchema = successResponseSchema(
+  listOrganizationsDataSchema
+);

--- a/src/modules/admin-organizations/admin-organization.service.ts
+++ b/src/modules/admin-organizations/admin-organization.service.ts
@@ -1,0 +1,98 @@
+import { count, eq, ilike, isNull, or, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import type {
+  ListOrganizationsData,
+  ListOrganizationsInput,
+} from "./admin-organization.model";
+
+export abstract class AdminOrganizationService {
+  static async list(
+    input: ListOrganizationsInput
+  ): Promise<ListOrganizationsData> {
+    const { page, limit, search } = input;
+    const offset = (page - 1) * limit;
+
+    const searchConditions = search
+      ? or(
+          ilike(schema.organizations.name, `%${search}%`),
+          ilike(schema.organizationProfiles.tradeName, `%${search}%`)
+        )
+      : undefined;
+
+    const memberCountSq = db
+      .select({
+        organizationId: schema.members.organizationId,
+        count: count().as("member_count"),
+      })
+      .from(schema.members)
+      .groupBy(schema.members.organizationId)
+      .as("member_counts");
+
+    const baseConditions = isNull(schema.organizationProfiles.deletedAt);
+    const whereCondition = searchConditions
+      ? sql`${baseConditions} AND ${searchConditions}`
+      : baseConditions;
+
+    const [totalResult, items] = await Promise.all([
+      db
+        .select({ count: count() })
+        .from(schema.organizations)
+        .leftJoin(
+          schema.organizationProfiles,
+          eq(
+            schema.organizations.id,
+            schema.organizationProfiles.organizationId
+          )
+        )
+        .where(whereCondition),
+      db
+        .select({
+          id: schema.organizations.id,
+          name: schema.organizations.name,
+          slug: schema.organizations.slug,
+          createdAt: schema.organizations.createdAt,
+          tradeName: schema.organizationProfiles.tradeName,
+          taxId: schema.organizationProfiles.taxId,
+          pbUrl: schema.organizationProfiles.pbUrl,
+          status: schema.organizationProfiles.status,
+          memberCount: memberCountSq.count,
+        })
+        .from(schema.organizations)
+        .leftJoin(
+          schema.organizationProfiles,
+          eq(
+            schema.organizations.id,
+            schema.organizationProfiles.organizationId
+          )
+        )
+        .leftJoin(
+          memberCountSq,
+          eq(schema.organizations.id, memberCountSq.organizationId)
+        )
+        .where(whereCondition)
+        .orderBy(sql`${schema.organizations.createdAt} DESC`)
+        .limit(limit)
+        .offset(offset),
+    ]);
+
+    const total = totalResult[0]?.count ?? 0;
+
+    return {
+      items: items.map((row) => ({
+        id: row.id,
+        name: row.name,
+        slug: row.slug,
+        createdAt: row.createdAt.toISOString(),
+        tradeName: row.tradeName ?? null,
+        taxId: row.taxId ?? null,
+        hasPowerBiUrl: row.pbUrl !== null && row.pbUrl !== undefined,
+        memberCount: row.memberCount ?? 0,
+        status: row.status ?? null,
+      })),
+      total,
+      page,
+      limit,
+    };
+  }
+}

--- a/src/modules/admin-organizations/index.ts
+++ b/src/modules/admin-organizations/index.ts
@@ -1,0 +1,44 @@
+import { Elysia } from "elysia";
+import { betterAuthPlugin } from "@/lib/auth-plugin";
+import { wrapSuccess } from "@/lib/responses/envelope";
+import {
+  forbiddenErrorSchema,
+  unauthorizedErrorSchema,
+} from "@/lib/responses/response.types";
+import {
+  listOrganizationsQuerySchema,
+  listOrganizationsResponseSchema,
+} from "./admin-organization.model";
+import { AdminOrganizationService } from "./admin-organization.service";
+
+export const adminOrganizationsController = new Elysia({
+  name: "admin-organizations",
+  prefix: "/v1/admin/organizations",
+  detail: { tags: ["Organizations (Admin)"] },
+})
+  .use(betterAuthPlugin)
+  .get(
+    "/",
+    async ({ query }) =>
+      wrapSuccess(
+        await AdminOrganizationService.list({
+          page: query.page,
+          limit: query.limit,
+          search: query.search,
+        })
+      ),
+    {
+      auth: { requireAdmin: true },
+      query: listOrganizationsQuerySchema,
+      response: {
+        200: listOrganizationsResponseSchema,
+        401: unauthorizedErrorSchema,
+        403: forbiddenErrorSchema,
+      },
+      detail: {
+        summary: "List all organizations",
+        description:
+          "List all organizations with pagination and search. Only admins can access this endpoint.",
+      },
+    }
+  );

--- a/src/test/helpers/app.ts
+++ b/src/test/helpers/app.ts
@@ -5,6 +5,7 @@ import { betterAuthPlugin } from "@/lib/auth-plugin";
 import { errorPlugin } from "@/lib/errors/error-plugin";
 import { healthPlugin } from "@/lib/health";
 import { loggerPlugin } from "@/lib/logger";
+import { adminOrganizationsController } from "@/modules/admin-organizations";
 import { apiKeysController } from "@/modules/api-keys";
 import { auditController } from "@/modules/audit";
 import { employeeController } from "@/modules/employees";
@@ -32,6 +33,7 @@ export function createTestApp() {
     .use(paymentsController)
     .use(auditController)
     .use(apiKeysController)
+    .use(adminOrganizationsController)
     .get("/", ({ redirect }) => redirect("/health"));
 }
 


### PR DESCRIPTION
## Summary

- Add `GET /v1/admin/organizations` admin endpoint to list all organizations
- Supports pagination (`page`, `limit`) and search by `name` or `tradeName`
- Returns organization data with profile info, member count, `hasPowerBiUrl`, and `status`
- Query joins `organizations` + `organizationProfiles` + member count subquery

## Implementation

- **Controller**: `src/modules/admin-organizations/index.ts` — Elysia route with `requireAdmin: true`
- **Service**: `src/modules/admin-organizations/admin-organization.service.ts` — Drizzle query with LEFT JOINs
- **Model**: `src/modules/admin-organizations/admin-organization.model.ts` — Zod schemas for input/output
- Registered in main app (`src/index.ts`) and test app (`src/test/helpers/app.ts`)

## Test plan

- [x] Rejects unauthenticated requests (401)
- [x] Rejects non-admin users (403)
- [x] Lists all organizations with correct data shape
- [x] Pagination works (page, limit)
- [x] Search by name and tradeName
- [x] Empty response when no matches
- [x] Includes memberCount for organizations with members

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)