### PR TITLE
feat: add organization data to provision trial (#116)

### DIFF
--- a/src/modules/payments/admin-provision/__tests__/create-provision-trial.test.ts
+++ b/src/modules/payments/admin-provision/__tests__/create-provision-trial.test.ts
@@ -6,6 +6,7 @@ import { env } from "@/env";
 import { PlanFactory } from "@/test/factories/payments/plan.factory";
 import { UserFactory } from "@/test/factories/user.factory";
 import { createTestApp, type TestApp } from "@/test/support/app";
+import { generateCnpj } from "@/test/support/faker";
 
 const BASE_URL = env.API_URL;
 const ENDPOINT = `${BASE_URL}/v1/payments/admin/provisions/trial`;
@@ -15,7 +16,12 @@ function buildPayload(overrides: Record<string, unknown> = {}) {
   return {
     ownerName: `Owner ${id}`,
     ownerEmail: `owner-${id}@example.com`,
-    organizationName: `Org ${id}`,
+    organization: {
+      tradeName: `Org ${id}`,
+      taxId: generateCnpj(),
+      email: `org-${id}@example.com`,
+      phone: "11999990000",
+    },
     organizationSlug: `org-${id}`,
     ...overrides,
   };
@@ -174,7 +180,7 @@ describe("POST /v1/payments/admin/provisions/trial", () => {
     expect(data.status).toBe("pending_activation");
     expect(data.ownerName).toBe(payload.ownerName);
     expect(data.ownerEmail).toBe(payload.ownerEmail);
-    expect(data.organizationName).toBe(payload.organizationName);
+    expect(data.organizationName).toBe(payload.organization.tradeName);
     expect(data.notes).toBe("Test provision");
     expect(data.createdBy).toBe(adminUser.id);
     expect(data.activationUrl).toBeString();
@@ -198,7 +204,7 @@ describe("POST /v1/payments/admin/provisions/trial", () => {
       .limit(1);
 
     expect(createdOrg).toBeDefined();
-    expect(createdOrg.name).toBe(payload.organizationName);
+    expect(createdOrg.name).toBe(payload.organization.tradeName);
     expect(createdOrg.slug).toBe(payload.organizationSlug);
 
     // Verify member with role=owner
@@ -251,8 +257,63 @@ describe("POST /v1/payments/admin/provisions/trial", () => {
       .limit(1);
 
     expect(orgProfile).toBeDefined();
-    expect(orgProfile.tradeName).toBe(payload.organizationName);
-    expect(orgProfile.legalName).toBeNull();
-    expect(orgProfile.taxId).toBeNull();
+    // Verify organization profile enriched with provided data
+    expect(orgProfile.tradeName).toBe(payload.organization.tradeName);
+    expect(orgProfile.taxId).toBe(payload.organization.taxId);
+    expect(orgProfile.email).toBe(payload.organization.email);
+    expect(orgProfile.phone).toBe(payload.organization.phone);
+    // Optional fields not provided → null
+    expect(orgProfile.street).toBeNull();
+    expect(orgProfile.city).toBeNull();
+  });
+
+  test("should enrich org profile with optional address fields", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const payload = buildPayload({
+      organization: {
+        tradeName: "Org With Address",
+        taxId: generateCnpj(),
+        email: "address-test@example.com",
+        phone: "11999990000",
+        legalName: "Razao Social Ltda",
+        street: "Rua Teste",
+        number: "123",
+        complement: "Sala 1",
+        neighborhood: "Centro",
+        city: "Sao Paulo",
+        state: "SP",
+        zipCode: "01001000",
+      },
+    });
+
+    const response = await app.handle(
+      new Request(ENDPOINT, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const data = body.data;
+
+    const [orgProfile] = await db
+      .select()
+      .from(schema.organizationProfiles)
+      .where(
+        eq(schema.organizationProfiles.organizationId, data.organizationId)
+      )
+      .limit(1);
+
+    expect(orgProfile.legalName).toBe("Razao Social Ltda");
+    expect(orgProfile.street).toBe("Rua Teste");
+    expect(orgProfile.number).toBe("123");
+    expect(orgProfile.complement).toBe("Sala 1");
+    expect(orgProfile.neighborhood).toBe("Centro");
+    expect(orgProfile.city).toBe("Sao Paulo");
+    expect(orgProfile.state).toBe("SP");
+    expect(orgProfile.zipCode).toBe("01001000");
+    expect(orgProfile.mobile).toBe("11999990000");
   });
 });

--- a/src/modules/payments/admin-provision/admin-provision.model.ts
+++ b/src/modules/payments/admin-provision/admin-provision.model.ts
@@ -60,7 +60,29 @@ export const provisionDataSchema = z.object({
 export const createProvisionTrialSchema = z.object({
   ownerName: z.string().min(2).max(100).describe("Name of the owner"),
   ownerEmail: z.email().describe("Email of the owner"),
-  organizationName: z.string().min(1).describe("Organization name"),
+  organization: z
+    .object({
+      tradeName: z.string().min(1).describe("Nome fantasia"),
+      taxId: z
+        .string()
+        .refine((value) => isValidCNPJ(value), { message: "CNPJ invalido" })
+        .describe("CNPJ (14 digitos)"),
+      email: z.email().describe("Email comercial da organizacao"),
+      phone: z
+        .string()
+        .min(10)
+        .max(15)
+        .describe("Telefone comercial (10-15 digitos)"),
+      legalName: z.string().optional().describe("Razao social"),
+      street: z.string().optional().describe("Logradouro"),
+      number: z.string().optional().describe("Numero"),
+      complement: z.string().optional().describe("Complemento"),
+      neighborhood: z.string().optional().describe("Bairro"),
+      city: z.string().optional().describe("Cidade"),
+      state: z.string().length(2).optional().describe("UF (2 chars)"),
+      zipCode: z.string().length(8).optional().describe("CEP (8 digitos)"),
+    })
+    .describe("Organization profile data"),
   organizationSlug: z
     .string()
     .regex(

--- a/src/modules/payments/admin-provision/admin-provision.service.ts
+++ b/src/modules/payments/admin-provision/admin-provision.service.ts
@@ -100,7 +100,7 @@ export abstract class AdminProvisionService {
     const {
       ownerName,
       ownerEmail,
-      organizationName,
+      organization,
       organizationSlug,
       notes,
       adminUserId,
@@ -127,18 +127,25 @@ export abstract class AdminProvisionService {
     try {
       // 4. Create organization directly (bypasses allowUserToCreateOrganization)
       const createdOrg = await createOrganizationForUser({
-        name: organizationName,
+        name: organization.tradeName,
         slug: organizationSlug,
         userId: createdUser.id,
       });
 
-      // 5. Set emailVerified=true (trial does not require payment)
+      // 5. Enrich org profile with provided data
+      const { OrganizationService } = await import(
+        "@/modules/organizations/profile/organization.service"
+      );
+      const { tradeName: _tradeName, ...profileData } = organization;
+      await OrganizationService.enrichProfile(createdOrg.id, profileData);
+
+      // 6. Set emailVerified=true (trial does not require payment)
       await db
         .update(schema.users)
         .set({ emailVerified: true })
         .where(eq(schema.users.id, createdUser.id));
 
-      // 6. Insert provision record
+      // 7. Insert provision record
       const provisionId = `provision-${crypto.randomUUID()}`;
       await db.insert(schema.adminOrgProvisions).values({
         id: provisionId,
@@ -150,13 +157,13 @@ export abstract class AdminProvisionService {
         createdBy: adminUserId,
       });
 
-      // 7. Trigger activation email via requestPasswordReset
+      // 8. Trigger activation email via requestPasswordReset
       await auth.api.requestPasswordReset({
         body: { email: ownerEmail },
         headers,
       });
 
-      // 8. Return provision data
+      // 9. Return provision data
       const [provision] = await db
         .select()
         .from(schema.adminOrgProvisions)
@@ -166,7 +173,7 @@ export abstract class AdminProvisionService {
       return toProvisionData(
         provision,
         { name: ownerName, email: ownerEmail },
-        { name: organizationName }
+        { name: organization.tradeName }
       );
     } catch (error) {
       // Cleanup: delete user if org creation or subsequent steps fail


### PR DESCRIPTION
## Summary

- Replace `organizationName` with structured `organization` object in `createProvisionTrialSchema` containing: `tradeName`, `taxId` (CNPJ validated), `email`, `phone` (required) + `legalName`, `street`, `number`, `complement`, `neighborhood`, `city`, `state`, `zipCode` (optional)
- Call `OrganizationService.enrichProfile()` after creating the minimal profile in `createWithTrial()`, so the org profile is enriched immediately with admin-provided data
- Update tests: payload uses `organization` object, assertions verify enriched profile fields, new test for optional address fields

## Implementation Notes

- Reuses existing `enrichProfile()` (null-only fill, idempotent) — no new enrichment logic needed
- `tradeName` is excluded from `enrichProfile()` call since `createMinimalProfile()` already sets it
- Uses `generateCnpj()` in tests to avoid unique constraint violations on `taxId` across runs
- `phone` is automatically synced to `mobile` by `enrichProfile()` (existing behavior)

Closes #116

## Test plan

- [x] Admin creates provision trial with org data → org profile enriched with required fields
- [x] Admin creates provision trial without optional fields → address fields remain null
- [x] Admin creates provision trial with all optional address fields → all fields stored
- [x] Existing auth/validation/conflict tests pass with updated payload
- [x] Lint passes (`npx ultracite check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)