### PR TITLE
feat(features): CRUD admin para gerenciamento de features

### DIFF
--- a/src/modules/payments/errors.ts
+++ b/src/modules/payments/errors.ts
@@ -571,6 +571,42 @@ export class TiersInUseError extends PaymentError {
   }
 }
 
+// Feature Errors
+
+export class FeatureNotFoundError extends PaymentError {
+  status = 404;
+
+  constructor(featureId: string) {
+    super(`Feature not found: ${featureId}`, "FEATURE_NOT_FOUND", {
+      featureId,
+    });
+  }
+}
+
+export class FeatureAlreadyExistsError extends PaymentError {
+  status = 409;
+
+  constructor(featureId: string) {
+    super(
+      `Feature with id "${featureId}" already exists`,
+      "FEATURE_ALREADY_EXISTS",
+      { featureId }
+    );
+  }
+}
+
+export class FeatureHasPlansError extends PaymentError {
+  status = 400;
+
+  constructor(featureId: string, planCount: number) {
+    super(
+      `Cannot delete feature "${featureId}": it is associated with ${planCount} plan(s)`,
+      "FEATURE_HAS_PLANS",
+      { featureId, planCount }
+    );
+  }
+}
+
 // Billing Profile Errors
 
 export class BillingProfileNotFoundError extends PaymentError {

--- a/src/modules/payments/features/__tests__/create-feature.test.ts
+++ b/src/modules/payments/features/__tests__/create-feature.test.ts
@@ -1,0 +1,196 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { env } from "@/env";
+import { UserFactory } from "@/test/factories/user.factory";
+import { createTestApp, type TestApp } from "@/test/support/app";
+
+const BASE_URL = env.API_URL;
+
+function generateUniqueId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+describe("POST /payments/features", () => {
+  let app: TestApp;
+  let authHeaders: Record<string, string>;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    const { headers } = await UserFactory.createAdmin({ emailVerified: true });
+    authHeaders = headers;
+  });
+
+  test("should reject unauthenticated requests", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "test_feature",
+          displayName: "Test Feature",
+        }),
+      })
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("should reject non-admin users", async () => {
+    const { headers: nonAdminHeaders } = await UserFactory.create({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...nonAdminHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "test_feature",
+          displayName: "Test Feature",
+        }),
+      })
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("should create feature with valid data", async () => {
+    const featureId = generateUniqueId("test_create");
+    const featureData = {
+      id: featureId,
+      displayName: "Test Create Feature",
+      description: "A test feature for creation",
+      category: "testing",
+      sortOrder: 50,
+      isDefault: true,
+      isPremium: true,
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(featureData),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe(featureId);
+    expect(body.data.displayName).toBe(featureData.displayName);
+    expect(body.data.description).toBe(featureData.description);
+    expect(body.data.category).toBe(featureData.category);
+    expect(body.data.sortOrder).toBe(featureData.sortOrder);
+    expect(body.data.isActive).toBe(true);
+    expect(body.data.isDefault).toBe(true);
+    expect(body.data.isPremium).toBe(true);
+    expect(body.data.planCount).toBe(0);
+    expect(body.data.createdAt).toBeString();
+    expect(body.data.updatedAt).toBeString();
+  });
+
+  test("should apply default values for optional fields", async () => {
+    const featureId = generateUniqueId("test_defaults");
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: featureId,
+          displayName: "Test Defaults Feature",
+        }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.sortOrder).toBe(0);
+    expect(body.data.isDefault).toBe(false);
+    expect(body.data.isPremium).toBe(false);
+    expect(body.data.isActive).toBe(true);
+    expect(body.data.description).toBeNull();
+    expect(body.data.category).toBeNull();
+  });
+
+  test("should reject duplicate feature id", async () => {
+    const featureId = generateUniqueId("test_dup");
+    const featureData = {
+      id: featureId,
+      displayName: "First Feature",
+    };
+
+    const firstResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(featureData),
+      })
+    );
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ ...featureData, displayName: "Second Feature" }),
+      })
+    );
+    expect(secondResponse.status).toBe(409);
+
+    const errorBody = await secondResponse.json();
+    expect(errorBody.error.code).toBe("FEATURE_ALREADY_EXISTS");
+  });
+
+  test("should reject non-snake_case id", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "Invalid-ID",
+          displayName: "Invalid Feature",
+        }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  test("should reject id starting with number", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "1_bad_id",
+          displayName: "Bad ID Feature",
+        }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  test("should reject missing required fields", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "missing_display_name",
+        }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  test("should reject id longer than 50 characters", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "a".repeat(51),
+          displayName: "Long ID Feature",
+        }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+});

--- a/src/modules/payments/features/__tests__/delete-feature.test.ts
+++ b/src/modules/payments/features/__tests__/delete-feature.test.ts
@@ -1,0 +1,141 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { env } from "@/env";
+import { PlanFactory } from "@/test/factories/payments/plan.factory";
+import { UserFactory } from "@/test/factories/user.factory";
+import { createTestApp, type TestApp } from "@/test/support/app";
+
+const BASE_URL = env.API_URL;
+
+function generateUniqueId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+async function createFeatureViaApi(
+  app: TestApp,
+  headers: Record<string, string>,
+  id?: string
+) {
+  const featureId = id ?? generateUniqueId("test_del");
+  const response = await app.handle(
+    new Request(`${BASE_URL}/v1/payments/features`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: featureId,
+        displayName: `Delete Test ${featureId}`,
+      }),
+    })
+  );
+  const body = await response.json();
+  return body.data;
+}
+
+describe("DELETE /payments/features/:id", () => {
+  let app: TestApp;
+  let authHeaders: Record<string, string>;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    const { headers } = await UserFactory.createAdmin({ emailVerified: true });
+    authHeaders = headers;
+  });
+
+  test("should reject unauthenticated requests", async () => {
+    const feature = await createFeatureViaApi(app, authHeaders);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "DELETE",
+      })
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("should reject non-admin users", async () => {
+    const feature = await createFeatureViaApi(app, authHeaders);
+    const { headers: nonAdminHeaders } = await UserFactory.create({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "DELETE",
+        headers: nonAdminHeaders,
+      })
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("should hard delete feature with no plan associations", async () => {
+    const feature = await createFeatureViaApi(app, authHeaders);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "DELETE",
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.deleted).toBe(true);
+
+    const [deletedFeature] = await db
+      .select()
+      .from(schema.features)
+      .where(eq(schema.features.id, feature.id))
+      .limit(1);
+    expect(deletedFeature).toBeUndefined();
+  });
+
+  test("should soft delete (deactivate) feature associated with plans", async () => {
+    const featureId = generateUniqueId("test_soft_del");
+
+    await db.insert(schema.features).values({
+      id: featureId,
+      displayName: "Soft Delete Feature",
+    });
+
+    await PlanFactory.createPaid("gold", {
+      features: [featureId],
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${featureId}`, {
+        method: "DELETE",
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.deactivated).toBe(true);
+    expect(body.data.planCount).toBeGreaterThan(0);
+
+    const [deactivatedFeature] = await db
+      .select()
+      .from(schema.features)
+      .where(eq(schema.features.id, featureId))
+      .limit(1);
+    expect(deactivatedFeature).toBeDefined();
+    expect(deactivatedFeature.isActive).toBe(false);
+  });
+
+  test("should return 404 for non-existent feature", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/non_existent_feature`, {
+        method: "DELETE",
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body.error.code).toBe("FEATURE_NOT_FOUND");
+  });
+});

--- a/src/modules/payments/features/__tests__/list-features.test.ts
+++ b/src/modules/payments/features/__tests__/list-features.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { env } from "@/env";
+import { UserFactory } from "@/test/factories/user.factory";
+import { createTestApp, type TestApp } from "@/test/support/app";
+
+const BASE_URL = env.API_URL;
+
+describe("GET /payments/features", () => {
+  let app: TestApp;
+  let authHeaders: Record<string, string>;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    const { headers } = await UserFactory.createAdmin({ emailVerified: true });
+    authHeaders = headers;
+  });
+
+  test("should reject unauthenticated requests", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`)
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("should reject non-admin users", async () => {
+    const { headers: nonAdminHeaders } = await UserFactory.create({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        headers: nonAdminHeaders,
+      })
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("should list all features with planCount", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.features).toBeArray();
+
+    for (const feature of body.data.features) {
+      expect(feature.id).toBeString();
+      expect(feature.displayName).toBeString();
+      expect(typeof feature.planCount).toBe("number");
+      expect(feature.planCount).toBeGreaterThanOrEqual(0);
+      expect(feature.createdAt).toBeString();
+      expect(feature.updatedAt).toBeString();
+    }
+  });
+
+  test("should return features ordered by sortOrder", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    const features = body.data.features;
+
+    for (let i = 1; i < features.length; i++) {
+      expect(features[i].sortOrder).toBeGreaterThanOrEqual(
+        features[i - 1].sortOrder
+      );
+    }
+  });
+
+  test("should include both active and inactive features", async () => {
+    const featureId = `test_inactive_list_${crypto.randomUUID().slice(0, 8)}`;
+
+    await db.insert(schema.features).values({
+      id: featureId,
+      displayName: "Test Inactive Feature",
+      isActive: false,
+      sortOrder: 999,
+    });
+
+    try {
+      const response = await app.handle(
+        new Request(`${BASE_URL}/v1/payments/features`, {
+          headers: authHeaders,
+        })
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      const inactiveFeature = body.data.features.find(
+        (f: { id: string }) => f.id === featureId
+      );
+      expect(inactiveFeature).toBeDefined();
+      expect(inactiveFeature.isActive).toBe(false);
+    } finally {
+      await db.delete(schema.features).where(eq(schema.features.id, featureId));
+    }
+  });
+});

--- a/src/modules/payments/features/__tests__/update-feature.test.ts
+++ b/src/modules/payments/features/__tests__/update-feature.test.ts
@@ -1,0 +1,191 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { env } from "@/env";
+import { UserFactory } from "@/test/factories/user.factory";
+import { createTestApp, type TestApp } from "@/test/support/app";
+
+const BASE_URL = env.API_URL;
+
+function generateUniqueId(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+async function createFeature(
+  app: TestApp,
+  headers: Record<string, string>,
+  overrides: { id?: string; displayName?: string } = {}
+) {
+  const id = overrides.id ?? generateUniqueId("test_upd");
+  const response = await app.handle(
+    new Request(`${BASE_URL}/v1/payments/features`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id,
+        displayName: overrides.displayName ?? "Update Test Feature",
+      }),
+    })
+  );
+  const body = await response.json();
+  return body.data;
+}
+
+describe("PUT /payments/features/:id", () => {
+  let app: TestApp;
+  let authHeaders: Record<string, string>;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    const { headers } = await UserFactory.createAdmin({ emailVerified: true });
+    authHeaders = headers;
+  });
+
+  test("should reject unauthenticated requests", async () => {
+    const feature = await createFeature(app, authHeaders);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Updated" }),
+      })
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("should reject non-admin users", async () => {
+    const feature = await createFeature(app, authHeaders);
+    const { headers: nonAdminHeaders } = await UserFactory.create({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "PUT",
+        headers: { ...nonAdminHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Updated" }),
+      })
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test("should update feature metadata", async () => {
+    const feature = await createFeature(app, authHeaders);
+
+    const updateData = {
+      displayName: "Updated Display Name",
+      description: "Updated description",
+      category: "updated_category",
+      sortOrder: 99,
+      isDefault: true,
+      isPremium: true,
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(updateData),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe(feature.id);
+    expect(body.data.displayName).toBe(updateData.displayName);
+    expect(body.data.description).toBe(updateData.description);
+    expect(body.data.category).toBe(updateData.category);
+    expect(body.data.sortOrder).toBe(updateData.sortOrder);
+    expect(body.data.isDefault).toBe(true);
+    expect(body.data.isPremium).toBe(true);
+  });
+
+  test("should deactivate feature via update", async () => {
+    const feature = await createFeature(app, authHeaders);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${feature.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ isActive: false }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.isActive).toBe(false);
+  });
+
+  test("should allow setting description to null", async () => {
+    const featureId = generateUniqueId("test_null_desc");
+    await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: featureId,
+          displayName: "Null Desc Feature",
+          description: "Has a description",
+        }),
+      })
+    );
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${featureId}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ description: null }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.description).toBeNull();
+  });
+
+  test("should return 404 for non-existent feature", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/non_existent_feature_id`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "Updated" }),
+      })
+    );
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body.error.code).toBe("FEATURE_NOT_FOUND");
+  });
+
+  test("should only update provided fields", async () => {
+    const featureId = generateUniqueId("test_partial");
+    await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: featureId,
+          displayName: "Original Name",
+          description: "Original description",
+          category: "original",
+          sortOrder: 5,
+        }),
+      })
+    );
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features/${featureId}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: "New Name" }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.displayName).toBe("New Name");
+    expect(body.data.description).toBe("Original description");
+    expect(body.data.category).toBe("original");
+    expect(body.data.sortOrder).toBe(5);
+  });
+});

--- a/src/modules/payments/features/features.model.ts
+++ b/src/modules/payments/features/features.model.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import { successResponseSchema } from "@/lib/responses/response.types";
+
+const SNAKE_CASE_REGEX = /^[a-z][a-z0-9_]*$/;
+
+export const createFeatureSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(SNAKE_CASE_REGEX, "ID must be snake_case (e.g., 'my_feature')")
+    .describe("Unique feature identifier (snake_case)"),
+  displayName: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe("Display name for the feature"),
+  description: z.string().max(500).optional().describe("Feature description"),
+  category: z.string().max(50).optional().describe("Category for grouping"),
+  sortOrder: z.number().int().min(0).default(0).describe("Display sort order"),
+  isDefault: z
+    .boolean()
+    .default(false)
+    .describe("Included in new plans by default"),
+  isPremium: z
+    .boolean()
+    .default(false)
+    .describe("Premium highlight on pricing page"),
+});
+
+export const updateFeatureSchema = z.object({
+  displayName: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).optional().nullable(),
+  category: z.string().max(50).optional().nullable(),
+  sortOrder: z.number().int().min(0).optional(),
+  isActive: z.boolean().optional(),
+  isDefault: z.boolean().optional(),
+  isPremium: z.boolean().optional(),
+});
+
+export const featureIdParamsSchema = z.object({
+  id: z.string().min(1).describe("Feature ID"),
+});
+
+const featureDataSchema = z.object({
+  id: z.string().describe("Feature ID"),
+  displayName: z.string().describe("Display name"),
+  description: z.string().nullable().describe("Feature description"),
+  category: z.string().nullable().describe("Category"),
+  sortOrder: z.number().int().describe("Sort order"),
+  isActive: z.boolean().describe("Whether feature is active"),
+  isDefault: z.boolean().describe("Whether feature is default for new plans"),
+  isPremium: z.boolean().describe("Whether feature is premium"),
+  planCount: z.number().int().describe("Number of plans using this feature"),
+  createdAt: z.string().datetime().describe("Creation timestamp"),
+  updatedAt: z.string().datetime().describe("Last update timestamp"),
+});
+
+const deactivateFeatureDataSchema = z.object({
+  deactivated: z.literal(true).describe("Deactivation confirmation"),
+  planCount: z
+    .number()
+    .int()
+    .describe("Number of plans affected by deactivation"),
+});
+
+const deleteFeatureDataSchema = z.object({
+  deleted: z.literal(true).describe("Deletion confirmation"),
+});
+
+export const listFeaturesResponseSchema = successResponseSchema(
+  z.object({ features: z.array(featureDataSchema) })
+);
+export const createFeatureResponseSchema =
+  successResponseSchema(featureDataSchema);
+export const updateFeatureResponseSchema =
+  successResponseSchema(featureDataSchema);
+export const deleteFeatureResponseSchema = successResponseSchema(
+  z.union([deactivateFeatureDataSchema, deleteFeatureDataSchema])
+);
+
+export type CreateFeatureInput = z.infer<typeof createFeatureSchema>;
+export type UpdateFeatureInput = z.infer<typeof updateFeatureSchema>;
+export type FeatureIdParams = z.infer<typeof featureIdParamsSchema>;
+export type FeatureData = z.infer<typeof featureDataSchema>;
+export type ListFeaturesData = { features: FeatureData[] };

--- a/src/modules/payments/features/features.service.ts
+++ b/src/modules/payments/features/features.service.ts
@@ -1,0 +1,186 @@
+import { count, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import {
+  FeatureAlreadyExistsError,
+  FeatureNotFoundError,
+} from "@/modules/payments/errors";
+import type {
+  CreateFeatureInput,
+  FeatureData,
+  ListFeaturesData,
+  UpdateFeatureInput,
+} from "./features.model";
+
+export abstract class FeaturesService {
+  static async list(): Promise<ListFeaturesData> {
+    const rows = await db
+      .select({
+        id: schema.features.id,
+        displayName: schema.features.displayName,
+        description: schema.features.description,
+        category: schema.features.category,
+        sortOrder: schema.features.sortOrder,
+        isActive: schema.features.isActive,
+        isDefault: schema.features.isDefault,
+        isPremium: schema.features.isPremium,
+        createdAt: schema.features.createdAt,
+        updatedAt: schema.features.updatedAt,
+        planCount: count(schema.planFeatures.planId),
+      })
+      .from(schema.features)
+      .leftJoin(
+        schema.planFeatures,
+        eq(schema.features.id, schema.planFeatures.featureId)
+      )
+      .groupBy(schema.features.id)
+      .orderBy(schema.features.sortOrder);
+
+    return {
+      features: rows.map((row) => FeaturesService.mapFeature(row)),
+    };
+  }
+
+  static async create(data: CreateFeatureInput): Promise<FeatureData> {
+    const existing = await db
+      .select({ id: schema.features.id })
+      .from(schema.features)
+      .where(eq(schema.features.id, data.id))
+      .limit(1);
+
+    if (existing.length > 0) {
+      throw new FeatureAlreadyExistsError(data.id);
+    }
+
+    const [feature] = await db
+      .insert(schema.features)
+      .values({
+        id: data.id,
+        displayName: data.displayName,
+        description: data.description,
+        category: data.category,
+        sortOrder: data.sortOrder,
+        isDefault: data.isDefault,
+        isPremium: data.isPremium,
+      })
+      .returning();
+
+    return FeaturesService.mapFeature({ ...feature, planCount: 0 });
+  }
+
+  static async update(
+    featureId: string,
+    data: UpdateFeatureInput
+  ): Promise<FeatureData> {
+    const existing = await db
+      .select()
+      .from(schema.features)
+      .where(eq(schema.features.id, featureId))
+      .limit(1);
+
+    if (existing.length === 0) {
+      throw new FeatureNotFoundError(featureId);
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (data.displayName !== undefined) {
+      updateData.displayName = data.displayName;
+    }
+    if (data.description !== undefined) {
+      updateData.description = data.description;
+    }
+    if (data.category !== undefined) {
+      updateData.category = data.category;
+    }
+    if (data.sortOrder !== undefined) {
+      updateData.sortOrder = data.sortOrder;
+    }
+    if (data.isActive !== undefined) {
+      updateData.isActive = data.isActive;
+    }
+    if (data.isDefault !== undefined) {
+      updateData.isDefault = data.isDefault;
+    }
+    if (data.isPremium !== undefined) {
+      updateData.isPremium = data.isPremium;
+    }
+
+    const [updated] = await db
+      .update(schema.features)
+      .set(updateData)
+      .where(eq(schema.features.id, featureId))
+      .returning();
+
+    const [planCountResult] = await db
+      .select({ planCount: count() })
+      .from(schema.planFeatures)
+      .where(eq(schema.planFeatures.featureId, featureId));
+
+    return FeaturesService.mapFeature({
+      ...updated,
+      planCount: planCountResult.planCount,
+    });
+  }
+
+  static async delete(
+    featureId: string
+  ): Promise<{ deactivated: true; planCount: number } | { deleted: true }> {
+    const existing = await db
+      .select()
+      .from(schema.features)
+      .where(eq(schema.features.id, featureId))
+      .limit(1);
+
+    if (existing.length === 0) {
+      throw new FeatureNotFoundError(featureId);
+    }
+
+    const [planCountResult] = await db
+      .select({ planCount: count() })
+      .from(schema.planFeatures)
+      .where(eq(schema.planFeatures.featureId, featureId));
+
+    const planCount = planCountResult.planCount;
+
+    if (planCount > 0) {
+      await db
+        .update(schema.features)
+        .set({ isActive: false })
+        .where(eq(schema.features.id, featureId));
+
+      return { deactivated: true, planCount };
+    }
+
+    await db.delete(schema.features).where(eq(schema.features.id, featureId));
+
+    return { deleted: true };
+  }
+
+  private static mapFeature(row: {
+    id: string;
+    displayName: string;
+    description: string | null;
+    category: string | null;
+    sortOrder: number;
+    isActive: boolean;
+    isDefault: boolean;
+    isPremium: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+    planCount: number;
+  }): FeatureData {
+    return {
+      id: row.id,
+      displayName: row.displayName,
+      description: row.description,
+      category: row.category,
+      sortOrder: row.sortOrder,
+      isActive: row.isActive,
+      isDefault: row.isDefault,
+      isPremium: row.isPremium,
+      planCount: row.planCount,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+}

--- a/src/modules/payments/features/index.ts
+++ b/src/modules/payments/features/index.ts
@@ -1,0 +1,103 @@
+import { Elysia } from "elysia";
+import { betterAuthPlugin } from "@/lib/auth-plugin";
+import { wrapSuccess } from "@/lib/responses/envelope";
+import {
+  badRequestErrorSchema,
+  conflictErrorSchema,
+  forbiddenErrorSchema,
+  notFoundErrorSchema,
+  unauthorizedErrorSchema,
+  validationErrorSchema,
+} from "@/lib/responses/response.types";
+import {
+  createFeatureResponseSchema,
+  createFeatureSchema,
+  deleteFeatureResponseSchema,
+  featureIdParamsSchema,
+  listFeaturesResponseSchema,
+  updateFeatureResponseSchema,
+  updateFeatureSchema,
+} from "./features.model";
+import { FeaturesService } from "./features.service";
+
+export const featuresController = new Elysia({
+  name: "features",
+  prefix: "/features",
+  detail: { tags: ["Payments - Features (Admin)"] },
+})
+  .use(betterAuthPlugin)
+  .get("/", async () => wrapSuccess(await FeaturesService.list()), {
+    auth: { requireAdmin: true },
+    response: {
+      200: listFeaturesResponseSchema,
+      401: unauthorizedErrorSchema,
+      403: forbiddenErrorSchema,
+    },
+    detail: {
+      summary: "List all features (Admin)",
+      description:
+        "Returns all features (active and inactive) with the count of plans using each feature. Requires admin privileges.",
+    },
+  })
+  .post(
+    "/",
+    async ({ body }) => wrapSuccess(await FeaturesService.create(body)),
+    {
+      auth: { requireAdmin: true },
+      body: createFeatureSchema,
+      response: {
+        200: createFeatureResponseSchema,
+        409: conflictErrorSchema,
+        422: validationErrorSchema,
+        401: unauthorizedErrorSchema,
+        403: forbiddenErrorSchema,
+      },
+      detail: {
+        summary: "Create a feature",
+        description:
+          "Creates a new feature. The ID is a snake_case identifier used as a contract in code. Requires admin privileges.",
+      },
+    }
+  )
+  .put(
+    "/:id",
+    async ({ params, body }) =>
+      wrapSuccess(await FeaturesService.update(params.id, body)),
+    {
+      auth: { requireAdmin: true },
+      params: featureIdParamsSchema,
+      body: updateFeatureSchema,
+      response: {
+        200: updateFeatureResponseSchema,
+        422: validationErrorSchema,
+        401: unauthorizedErrorSchema,
+        403: forbiddenErrorSchema,
+        404: notFoundErrorSchema,
+      },
+      detail: {
+        summary: "Update a feature",
+        description:
+          "Updates metadata of an existing feature. Cannot change the ID. Requires admin privileges.",
+      },
+    }
+  )
+  .delete(
+    "/:id",
+    async ({ params }) => wrapSuccess(await FeaturesService.delete(params.id)),
+    {
+      auth: { requireAdmin: true },
+      params: featureIdParamsSchema,
+      response: {
+        200: deleteFeatureResponseSchema,
+        400: badRequestErrorSchema,
+        401: unauthorizedErrorSchema,
+        403: forbiddenErrorSchema,
+        404: notFoundErrorSchema,
+      },
+      detail: {
+        summary: "Delete/deactivate a feature",
+        description:
+          "If the feature is not associated with any plan, performs a hard delete. Otherwise, deactivates it (isActive = false). Requires admin privileges.",
+      },
+    }
+  );

--- a/src/modules/payments/index.ts
+++ b/src/modules/payments/index.ts
@@ -4,6 +4,7 @@ import { adminProvisionController } from "./admin-provision";
 import { billingController } from "./billing";
 import { checkoutController } from "./checkout";
 import { customerController } from "./customer";
+import { featuresController } from "./features";
 import { jobsController } from "./jobs";
 import { orphanedPlansController } from "./pagarme/pagarme-orphaned-plans.controller";
 import { planChangeController } from "./plan-change";
@@ -20,6 +21,7 @@ export const paymentsController = new Elysia({
   .use(plansPublicController)
   .use(webhookController)
   .use(plansProtectedController)
+  .use(featuresController)
   .use(checkoutController)
   .use(adminCheckoutController)
   .use(adminProvisionController)


### PR DESCRIPTION
## Summary

- Cria módulo `src/modules/payments/features/` com controller, service, model e error classes
- `GET /v1/payments/features` — lista todas as features (ativas e inativas) com `planCount` via LEFT JOIN em `plan_features`
- `POST /v1/payments/features` — cria feature com validação snake_case no ID, unicidade e defaults
- `PUT /v1/payments/features/:id` — atualiza metadata parcialmente (não permite alterar ID)
- `DELETE /v1/payments/features/:id` — hard delete se sem associações; soft delete (isActive=false) se associada a planos, retornando `planCount` afetado

## Decisões de implementação

- **FeaturesService** segue o padrão de abstract class com static methods do projeto
- **Erros**: `FeatureNotFoundError` (404), `FeatureAlreadyExistsError` (409), `FeatureHasPlansError` (400) em `errors.ts`
- **DELETE**: comportamento duplo (hard/soft) com discriminated union no response schema (`{ deleted: true }` | `{ deactivated: true, planCount }`)
- **planCount** no list: calculado via `LEFT JOIN plan_features` + `GROUP BY` + `count()`
- Controller registrado em `payments/index.ts` com tag `Payments - Features (Admin)` para Swagger

## Test plan

- [x] 26 testes de integração (4 arquivos) cobrindo todos os endpoints
- [x] Auth: rejeita requests não autenticados (401) e não-admin (403)
- [x] Create: dados válidos, defaults, ID duplicado, ID não-snake_case, campos obrigatórios, limite de tamanho
- [x] Update: update parcial, desativação, set null em description, 404 para feature inexistente
- [x] Delete: hard delete sem associações, soft delete com planos associados, 404 para inexistente
- [x] List: retorna features com planCount, ordenação por sortOrder, inclui ativas e inativas
- [x] Lint passa (`npx ultracite check`)

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)