### PR TITLE
feat(plans): limits CRUD, yearlyDiscountPercent update, feature validation

### DIFF
--- a/src/modules/payments/errors.ts
+++ b/src/modules/payments/errors.ts
@@ -573,6 +573,18 @@ export class TiersInUseError extends PaymentError {
 
 // Feature Errors
 
+export class InvalidFeatureIdsError extends PaymentError {
+  status = 422;
+
+  constructor(invalidIds: string[]) {
+    super(
+      `Features not found or inactive: ${invalidIds.join(", ")}`,
+      "INVALID_FEATURE_IDS",
+      { invalidIds }
+    );
+  }
+}
+
 export class FeatureNotFoundError extends PaymentError {
   status = 404;
 

--- a/src/modules/payments/plans/CLAUDE.md
+++ b/src/modules/payments/plans/CLAUDE.md
@@ -9,6 +9,7 @@ Planos com pricing tiers por faixa de funcionários.
 - Trial plan: `isTrial=true`, `trialDays=14`, 1 tier (0-10), todas as features
 - Unique trial constraint: apenas 1 plano trial ativo (não arquivado) por vez — enforced via partial unique index `subscription_plans_single_active_trial`
 - Paid plans: `isTrial=false`, >= 1 tier contíguo (sem gaps/overlaps, first tier starts at 0)
+- Feature IDs são validados contra a tabela `features` no create e update — devem existir e estar ativos (`is_active=true`). Erro `INVALID_FEATURE_IDS` (422) com lista de IDs inválidos
 
 ## Employee Tiers
 
@@ -16,6 +17,7 @@ Planos com pricing tiers por faixa de funcionários.
 - Paid: qualquer conjunto de tiers contíguos (min >= 0, sem gaps, sem overlaps)
 - `EMPLOYEE_TIERS` mantido como template/default para seeds
 - Desconto anual: configurável por plano via `yearlyDiscountPercent` (default 20%). Fórmula: `calculateYearlyPrice(monthlyPrice, discountPercent)` = `monthlyPrice * 12 * (1 - discountPercent / 100)`
+- `yearlyDiscountPercent` editável via `PUT /plans/:id` — ao alterar, recalcula `price_yearly` de todos os tiers ativos do plano
 
 ## Plan Features (tabela `plan_features`)
 
@@ -28,6 +30,14 @@ Features são armazenadas na tabela `plan_features` (junction: planId + featureI
 ## Plan Limits (tabela `plan_limits`)
 
 Limites numéricos por plano são armazenados na tabela `plan_limits` (planId + limitKey + limitValue). Exemplo: trial plan tem `max_employees = 10`.
+
+- Gerenciável via API: campo `limits` (array de `{ key, value }`) no `POST /plans` e `PUT /plans/:id`
+- `key`: string snake_case (1-50 chars), `value`: integer (`-1` = ilimitado)
+- No create: insere limites na transação
+- No update: se `limits` fornecido, deleta existentes e insere novos (replace-all, mesmo padrão de features)
+- `limits: []` remove todos os limites do plano
+- Chaves duplicadas no mesmo request são rejeitadas (validação Zod)
+- Retornado em todas as responses de plano (`GET /plans`, `GET /plans/all`, `GET /plans/:id`, `POST /plans`, `PUT /plans/:id`)
 
 ## Tier Versioning
 

--- a/src/modules/payments/plans/__tests__/create-plan.test.ts
+++ b/src/modules/payments/plans/__tests__/create-plan.test.ts
@@ -461,6 +461,223 @@ describe("POST /payments/plans", () => {
     expect(response.status).toBe(422);
   });
 
+  // --- plan_limits tests ---
+
+  test("should create plan with limits", async () => {
+    const planData = {
+      name: generateUniqueName("with-limits"),
+      displayName: "Plan With Limits",
+      features: GOLD_FEATURES,
+      pricingTiers: generateTierPrices(5000),
+      limits: [
+        { key: "max_employees", value: 10 },
+        { key: "max_members", value: 4 },
+        { key: "max_branches", value: -1 },
+      ],
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.limits).toBeArray();
+    expect(body.data.limits.length).toBe(3);
+
+    const maxEmployees = body.data.limits.find(
+      (l: { key: string }) => l.key === "max_employees"
+    );
+    expect(maxEmployees.value).toBe(10);
+
+    const maxBranches = body.data.limits.find(
+      (l: { key: string }) => l.key === "max_branches"
+    );
+    expect(maxBranches.value).toBe(-1);
+  });
+
+  test("should create plan without limits (empty array in response)", async () => {
+    const planData = {
+      name: generateUniqueName("no-limits"),
+      displayName: "Plan Without Limits",
+      features: GOLD_FEATURES,
+      pricingTiers: generateTierPrices(5000),
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.limits).toEqual([]);
+  });
+
+  test("should accept limit with value 0 (disabled)", async () => {
+    const planData = {
+      name: generateUniqueName("zero-limit"),
+      displayName: "Plan With Zero Limit",
+      features: GOLD_FEATURES,
+      pricingTiers: generateTierPrices(5000),
+      limits: [{ key: "max_employees", value: 0 }],
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.limits[0].value).toBe(0);
+  });
+
+  test("should reject duplicate limit keys in same request", async () => {
+    const planData = {
+      name: generateUniqueName("dup-limits"),
+      displayName: "Plan With Duplicate Limits",
+      features: GOLD_FEATURES,
+      pricingTiers: generateTierPrices(5000),
+      limits: [
+        { key: "max_employees", value: 10 },
+        { key: "max_employees", value: 20 },
+      ],
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  // --- yearlyDiscountPercent on create ---
+
+  test("should create plan with custom yearlyDiscountPercent via tiers calculation", async () => {
+    // yearlyDiscountPercent is a plan-level column with default 20.
+    // When creating a plan, tiers are calculated using the plan's default discount.
+    // To verify the formula, we check the yearly price.
+    const tierPrices = generateTierPrices(10_000);
+    const planData = {
+      name: generateUniqueName("discount-create"),
+      displayName: "Discount Create Plan",
+      features: GOLD_FEATURES,
+      pricingTiers: tierPrices,
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    // Default discount is 20%, so yearly = monthly * 12 * 0.8
+    const expectedYearly = Math.round(tierPrices[0].priceMonthly * 12 * 0.8);
+    expect(body.data.pricingTiers[0].priceYearly).toBe(expectedYearly);
+    expect(body.data.yearlyDiscountPercent).toBe(20);
+  });
+
+  // --- Feature ID validation tests ---
+
+  test("should reject plan with non-existent feature ID", async () => {
+    const planData = {
+      name: generateUniqueName("bad-feature"),
+      displayName: "Plan With Bad Feature",
+      features: ["terminated_employees", "nonexistent_feature"],
+      pricingTiers: generateTierPrices(5000),
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(422);
+
+    const errorBody = await response.json();
+    expect(errorBody.error.code).toBe("INVALID_FEATURE_IDS");
+    expect(errorBody.error.details.invalidIds).toContain("nonexistent_feature");
+  });
+
+  test("should reject plan with inactive feature", async () => {
+    // Deactivate a feature temporarily for this test
+    const { db: dbImport } = await import("@/db");
+    const { schema: schemaImport } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+
+    await dbImport
+      .update(schemaImport.features)
+      .set({ isActive: false })
+      .where(eq(schemaImport.features.id, "payroll"));
+
+    try {
+      const planData = {
+        name: generateUniqueName("inactive-feature"),
+        displayName: "Plan With Inactive Feature",
+        features: ["terminated_employees", "payroll"],
+        pricingTiers: generateTierPrices(5000),
+      };
+
+      const response = await app.handle(
+        new Request(`${BASE_URL}/v1/payments/plans`, {
+          method: "POST",
+          headers: { ...authHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify(planData),
+        })
+      );
+      expect(response.status).toBe(422);
+
+      const errorBody = await response.json();
+      expect(errorBody.error.code).toBe("INVALID_FEATURE_IDS");
+      expect(errorBody.error.details.invalidIds).toContain("payroll");
+    } finally {
+      // Restore the feature
+      await dbImport
+        .update(schemaImport.features)
+        .set({ isActive: true })
+        .where(eq(schemaImport.features.id, "payroll"));
+    }
+  });
+
+  test("should create plan with valid features (positive control)", async () => {
+    const planData = {
+      name: generateUniqueName("valid-features"),
+      displayName: "Plan With Valid Features",
+      features: GOLD_FEATURES,
+      pricingTiers: generateTierPrices(5000),
+    };
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans`, {
+        method: "POST",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify(planData),
+      })
+    );
+    expect(response.status).toBe(200);
+  });
+
   test("should still accept standard 10 EMPLOYEE_TIERS", async () => {
     const tierPrices = generateTierPrices(4900);
 

--- a/src/modules/payments/plans/__tests__/get-plan.test.ts
+++ b/src/modules/payments/plans/__tests__/get-plan.test.ts
@@ -106,10 +106,42 @@ describe("GET /payments/plans/:id", () => {
     expect(body.data.startingPriceYearly).toBe(tier.priceYearly);
     expect(body.data.trialDays).toBe(plan.trialDays);
     expect(body.data.features).toBeArray();
+    expect(body.data.limits).toBeArray();
     expect(body.data.isActive).toBe(plan.isActive);
     expect(body.data.isPublic).toBe(plan.isPublic);
     expect(body.data.sortOrder).toBe(plan.sortOrder);
     expect(body.data.pricingTiers).toBeArray();
     expect(body.data.pricingTiers.length).toBe(10);
+  });
+
+  test("should return limits for trial plan", async () => {
+    const { plan } = await PlanFactory.createTrial();
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.limits).toBeArray();
+    expect(body.data.limits.length).toBe(1);
+    expect(body.data.limits[0].key).toBe("max_employees");
+    expect(body.data.limits[0].value).toBe(10);
+  });
+
+  test("should return empty limits for paid plan without limits", async () => {
+    const { plan } = await PlanFactory.createPaid("diamond");
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        headers: authHeaders,
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.limits).toEqual([]);
   });
 });

--- a/src/modules/payments/plans/__tests__/list-all-plans.test.ts
+++ b/src/modules/payments/plans/__tests__/list-all-plans.test.ts
@@ -135,7 +135,9 @@ describe("GET /payments/plans/all", () => {
     expect(plan).toHaveProperty("isPublic");
     expect(plan).toHaveProperty("isTrial");
     expect(plan).toHaveProperty("sortOrder");
+    expect(plan).toHaveProperty("limits");
     expect(plan).toHaveProperty("pricingTiers");
     expect(plan.pricingTiers).toBeArray();
+    expect(plan.limits).toBeArray();
   });
 });

--- a/src/modules/payments/plans/__tests__/list-plans.test.ts
+++ b/src/modules/payments/plans/__tests__/list-plans.test.ts
@@ -109,11 +109,13 @@ describe("GET /payments/plans", () => {
     expect(plan).toHaveProperty("startingPriceYearly");
     expect(plan).toHaveProperty("trialDays");
     expect(plan).toHaveProperty("features");
+    expect(plan).toHaveProperty("limits");
     expect(plan).toHaveProperty("isActive");
     expect(plan).toHaveProperty("isPublic");
     expect(plan).toHaveProperty("sortOrder");
     expect(plan).toHaveProperty("pricingTiers");
     expect(plan.pricingTiers).toBeArray();
+    expect(plan.limits).toBeArray();
   });
 
   test("should return plan features as array", async () => {

--- a/src/modules/payments/plans/__tests__/update-plan.test.ts
+++ b/src/modules/payments/plans/__tests__/update-plan.test.ts
@@ -384,6 +384,239 @@ describe("PUT /payments/plans/:id", () => {
     expect(tier1History.isActive).toBe(false);
   });
 
+  // --- plan_limits tests ---
+
+  test("should update plan with limits", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          limits: [
+            { key: "max_employees", value: 50 },
+            { key: "max_members", value: 10 },
+          ],
+        }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.limits).toBeArray();
+    expect(body.data.limits.length).toBe(2);
+
+    const maxEmployees = body.data.limits.find(
+      (l: { key: string }) => l.key === "max_employees"
+    );
+    expect(maxEmployees.value).toBe(50);
+  });
+
+  test("should replace existing limits on update", async () => {
+    const { plan } = await PlanFactory.createTrial();
+    createdPlanIds.push(plan.id);
+
+    // Trial plan already has max_employees=10 from factory
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          limits: [{ key: "max_employees", value: 20 }],
+        }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.limits.length).toBe(1);
+    expect(body.data.limits[0].key).toBe("max_employees");
+    expect(body.data.limits[0].value).toBe(20);
+  });
+
+  test("should remove all limits with empty array", async () => {
+    const { plan } = await PlanFactory.createTrial();
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ limits: [] }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.limits).toEqual([]);
+  });
+
+  // --- yearlyDiscountPercent tests ---
+
+  test("should update yearlyDiscountPercent and recalculate tier prices", async () => {
+    const { plan, tiers } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ yearlyDiscountPercent: 10 }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.yearlyDiscountPercent).toBe(10);
+
+    // Verify recalculation: yearly = monthly * 12 * 0.9
+    const firstTier = body.data.pricingTiers[0];
+    const expectedYearly = Math.round(tiers[0].priceMonthly * 12 * 0.9);
+    expect(firstTier.priceYearly).toBe(expectedYearly);
+  });
+
+  test("should set yearlyDiscountPercent to 0 (no discount)", async () => {
+    const { plan, tiers } = await PlanFactory.createPaid("diamond");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ yearlyDiscountPercent: 0 }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.yearlyDiscountPercent).toBe(0);
+
+    // yearly = monthly * 12 (no discount)
+    const firstTier = body.data.pricingTiers[0];
+    expect(firstTier.priceYearly).toBe(tiers[0].priceMonthly * 12);
+  });
+
+  test("should set yearlyDiscountPercent to 100 (free yearly)", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ yearlyDiscountPercent: 100 }),
+      })
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.data.yearlyDiscountPercent).toBe(100);
+
+    for (const tier of body.data.pricingTiers) {
+      expect(tier.priceYearly).toBe(0);
+    }
+  });
+
+  test("should reject negative yearlyDiscountPercent", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ yearlyDiscountPercent: -5 }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  test("should reject yearlyDiscountPercent > 100", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ yearlyDiscountPercent: 101 }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  test("should reject non-integer yearlyDiscountPercent", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({ yearlyDiscountPercent: 20.5 }),
+      })
+    );
+    expect(response.status).toBe(422);
+  });
+
+  // --- Feature ID validation tests ---
+
+  test("should reject update with non-existent feature ID", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+        method: "PUT",
+        headers: { ...authHeaders, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          features: ["terminated_employees", "unknown_feature"],
+        }),
+      })
+    );
+    expect(response.status).toBe(422);
+
+    const errorBody = await response.json();
+    expect(errorBody.error.code).toBe("INVALID_FEATURE_IDS");
+    expect(errorBody.error.details.invalidIds).toContain("unknown_feature");
+  });
+
+  test("should reject update with inactive feature", async () => {
+    const { plan } = await PlanFactory.createPaid("gold");
+    createdPlanIds.push(plan.id);
+
+    // Deactivate a feature temporarily
+    await db
+      .update(schema.features)
+      .set({ isActive: false })
+      .where(eq(schema.features.id, "payroll"));
+
+    try {
+      const response = await app.handle(
+        new Request(`${BASE_URL}/v1/payments/plans/${plan.id}`, {
+          method: "PUT",
+          headers: { ...authHeaders, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            features: ["terminated_employees", "payroll"],
+          }),
+        })
+      );
+      expect(response.status).toBe(422);
+
+      const errorBody = await response.json();
+      expect(errorBody.error.code).toBe("INVALID_FEATURE_IDS");
+      expect(errorBody.error.details.invalidIds).toContain("payroll");
+    } finally {
+      await db
+        .update(schema.features)
+        .set({ isActive: true })
+        .where(eq(schema.features.id, "payroll"));
+    }
+  });
+
   test("should allow replaceTiers when only canceled subscriptions reference tier", async () => {
     const { plan, tiers } = await PlanFactory.createPaid("gold");
     createdPlanIds.push(plan.id);

--- a/src/modules/payments/plans/plans.model.ts
+++ b/src/modules/payments/plans/plans.model.ts
@@ -15,6 +15,16 @@ export const tierPriceInputSchema = z.object({
   priceMonthly: z.number().int().min(0).describe("Monthly price in cents"),
 });
 
+export const limitInputSchema = z.object({
+  key: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^[a-z][a-z0-9_]*$/, "Key must be snake_case")
+    .describe("Limit key (e.g., max_employees)"),
+  value: z.number().int().describe("Limit value (-1 for unlimited)"),
+});
+
 export const pricingTierSchema = z.object({
   id: z.string().describe("Pricing tier ID"),
   minEmployees: z.number().int().describe("Minimum employees in this tier"),
@@ -22,6 +32,28 @@ export const pricingTierSchema = z.object({
   priceMonthly: z.number().int().describe("Monthly price in cents"),
   priceYearly: z.number().int().describe("Yearly price in cents"),
 });
+
+export const planLimitSchema = z.object({
+  key: z.string().describe("Limit key"),
+  value: z.number().int().describe("Limit value"),
+});
+
+const limitsArraySchema = z
+  .array(limitInputSchema)
+  .optional()
+  .superRefine((limits, ctx) => {
+    if (!limits) {
+      return;
+    }
+    const keys = limits.map((l) => l.key);
+    const duplicates = keys.filter((key, index) => keys.indexOf(key) !== index);
+    if (duplicates.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate limit keys: ${[...new Set(duplicates)].join(", ")}`,
+      });
+    }
+  });
 
 export const createPlanSchema = z.object({
   name: z.string().min(1).max(50).describe("Plan internal name (unique)"),
@@ -54,6 +86,7 @@ export const createPlanSchema = z.object({
     .describe(
       "Pricing tiers: 1 tier (0-10) for trial, at least 1 contiguous tier for paid plans"
     ),
+  limits: limitsArraySchema.describe("Plan limits (e.g., max_employees)"),
 });
 
 export const updatePlanSchema = z.object({
@@ -73,6 +106,16 @@ export const updatePlanSchema = z.object({
     .min(1)
     .optional()
     .describe("Optional: update prices for all tiers"),
+  yearlyDiscountPercent: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe("Yearly discount percentage (0-100)"),
+  limits: limitsArraySchema.describe(
+    "Replace plan limits. Empty array removes all limits."
+  ),
 });
 
 export const planIdParamsSchema = z.object({
@@ -88,6 +131,9 @@ const planDataSchema = z.object({
   features: z
     .array(z.string())
     .describe("List of feature IDs assigned to this plan"),
+  limits: z
+    .array(planLimitSchema)
+    .describe("Plan limits (e.g., max_employees)"),
   yearlyDiscountPercent: z
     .number()
     .int()
@@ -129,6 +175,8 @@ export const updatePlanResponseSchema =
 export const deletePlanResponseSchema =
   successResponseSchema(deletePlanDataSchema);
 
+export type LimitInput = z.infer<typeof limitInputSchema>;
+export type PlanLimitData = z.infer<typeof planLimitSchema>;
 export type TierPriceInput = z.infer<typeof tierPriceInputSchema>;
 export type PricingTierData = z.infer<typeof pricingTierSchema>;
 export type CreatePlanInput = z.infer<typeof createPlanSchema>;

--- a/src/modules/payments/plans/plans.service.ts
+++ b/src/modules/payments/plans/plans.service.ts
@@ -11,6 +11,7 @@ import {
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import {
+  InvalidFeatureIdsError,
   InvalidTierCountError,
   InvalidTierRangeError,
   PlanHasActiveSubscriptionsError,
@@ -34,6 +35,7 @@ import type {
   DeletePlanData,
   GetPlanData,
   ListPlansData,
+  PlanLimitData,
   PlanWithTiersData,
   PricingTierData,
   TierPriceInput,
@@ -60,17 +62,18 @@ export abstract class PlansService {
       .where(isNull(schema.planPricingTiers.archivedAt))
       .orderBy(schema.planPricingTiers.minEmployees);
 
+    const planIds = plans.map((p) => p.id);
     const tiersByPlan = PlansService.groupTiersByPlan(tiers);
-    const featuresByPlan = await PlansService.getBulkPlanFeatures(
-      plans.map((p) => p.id)
-    );
+    const featuresByPlan = await PlansService.getBulkPlanFeatures(planIds);
+    const limitsByPlan = await PlansService.getBulkPlanLimits(planIds);
 
     return {
       plans: plans.map((plan) =>
         PlansService.mapPlanWithTiers(
           plan,
           tiersByPlan.get(plan.id) ?? [],
-          featuresByPlan.get(plan.id) ?? []
+          featuresByPlan.get(plan.id) ?? [],
+          limitsByPlan.get(plan.id) ?? []
         )
       ),
     };
@@ -88,17 +91,18 @@ export abstract class PlansService {
       .where(isNull(schema.planPricingTiers.archivedAt))
       .orderBy(schema.planPricingTiers.minEmployees);
 
+    const planIds = plans.map((p) => p.id);
     const tiersByPlan = PlansService.groupTiersByPlan(tiers);
-    const featuresByPlan = await PlansService.getBulkPlanFeatures(
-      plans.map((p) => p.id)
-    );
+    const featuresByPlan = await PlansService.getBulkPlanFeatures(planIds);
+    const limitsByPlan = await PlansService.getBulkPlanLimits(planIds);
 
     return {
       plans: plans.map((plan) =>
         PlansService.mapPlanWithTiers(
           plan,
           tiersByPlan.get(plan.id) ?? [],
-          featuresByPlan.get(plan.id) ?? []
+          featuresByPlan.get(plan.id) ?? [],
+          limitsByPlan.get(plan.id) ?? []
         )
       ),
     };
@@ -127,7 +131,8 @@ export abstract class PlansService {
       .orderBy(schema.planPricingTiers.minEmployees);
 
     const features = await PlansService.getPlanFeatureIds(plan.id);
-    return PlansService.mapPlanWithTiers(plan, tiers, features);
+    const limits = await PlansService.getPlanLimits(plan.id);
+    return PlansService.mapPlanWithTiers(plan, tiers, features, limits);
   }
 
   static async getAvailableById(planId: string): Promise<PlanWithTiersData> {
@@ -164,7 +169,8 @@ export abstract class PlansService {
       .orderBy(schema.planPricingTiers.minEmployees);
 
     const features = await PlansService.getPlanFeatureIds(plan.id);
-    return PlansService.mapPlanWithTiers(plan, tiers, features);
+    const limits = await PlansService.getPlanLimits(plan.id);
+    return PlansService.mapPlanWithTiers(plan, tiers, features, limits);
   }
 
   static async create(data: CreatePlanInput): Promise<CreatePlanData> {
@@ -181,6 +187,8 @@ export abstract class PlansService {
     if (data.pricingTiers) {
       PlansService.validateTierRanges(data.pricingTiers, data.isTrial ?? false);
     }
+
+    await PlansService.validateFeatureIds(data.features);
 
     const planId = `plan-${crypto.randomUUID()}`;
 
@@ -200,11 +208,21 @@ export abstract class PlansService {
         })
         .returning();
 
-      if (data.features && data.features.length > 0) {
+      if (data.features.length > 0) {
         await tx.insert(schema.planFeatures).values(
           data.features.map((featureId) => ({
             planId: plan.id,
             featureId,
+          }))
+        );
+      }
+
+      if (data.limits && data.limits.length > 0) {
+        await tx.insert(schema.planLimits).values(
+          data.limits.map((limit) => ({
+            planId: plan.id,
+            limitKey: limit.key,
+            limitValue: limit.value,
           }))
         );
       }
@@ -238,7 +256,12 @@ export abstract class PlansService {
         }));
       }
 
-      return PlansService.mapPlanWithTiers(plan, tiers, data.features ?? []);
+      const limits: PlanLimitData[] = (data.limits ?? []).map((l) => ({
+        key: l.key,
+        value: l.value,
+      }));
+
+      return PlansService.mapPlanWithTiers(plan, tiers, data.features, limits);
     });
   }
 
@@ -260,6 +283,10 @@ export abstract class PlansService {
       PlansService.validateTierRanges(data.pricingTiers, existingPlan.isTrial);
     }
 
+    if (data.features) {
+      await PlansService.validateFeatureIds(data.features);
+    }
+
     const updateFields = PlansService.buildUpdateFields(data);
     const tierInput = data.pricingTiers;
 
@@ -270,19 +297,9 @@ export abstract class PlansService {
         .where(eq(schema.subscriptionPlans.id, planId))
         .returning();
 
-      if (data.features) {
-        await tx
-          .delete(schema.planFeatures)
-          .where(eq(schema.planFeatures.planId, plan.id));
-        if (data.features.length > 0) {
-          await tx.insert(schema.planFeatures).values(
-            data.features.map((featureId) => ({
-              planId: plan.id,
-              featureId,
-            }))
-          );
-        }
-      }
+      await PlansService.replaceFeatures(tx, plan.id, data.features);
+      await PlansService.replaceLimits(tx, plan.id, data.limits);
+      await PlansService.recalculateYearlyPrices(tx, plan, data);
 
       const features =
         data.features ?? (await PlansService.getPlanFeatureIds(plan.id, tx));
@@ -296,7 +313,9 @@ export abstract class PlansService {
           )
         : await PlansService.getExistingTiers(tx, planId);
 
-      return PlansService.mapPlanWithTiers(plan, tiers, features);
+      const limits = await PlansService.getPlanLimits(plan.id, tx);
+
+      return PlansService.mapPlanWithTiers(plan, tiers, features, limits);
     });
   }
 
@@ -397,6 +416,33 @@ export abstract class PlansService {
     return tiersWithCounts;
   }
 
+  private static async validateFeatureIds(featureIds: string[]): Promise<void> {
+    if (featureIds.length === 0) {
+      return;
+    }
+
+    const existingFeatures = await db
+      .select({
+        id: schema.features.id,
+        isActive: schema.features.isActive,
+      })
+      .from(schema.features)
+      .where(inArray(schema.features.id, featureIds));
+
+    const existingMap = new Map(
+      existingFeatures.map((f) => [f.id, f.isActive])
+    );
+
+    const invalidIds = featureIds.filter((id) => {
+      const isActive = existingMap.get(id);
+      return isActive === undefined || !isActive;
+    });
+
+    if (invalidIds.length > 0) {
+      throw new InvalidFeatureIdsError(invalidIds);
+    }
+  }
+
   private static validateTierRanges(
     tiers: TierPriceInput[],
     isTrial: boolean
@@ -469,6 +515,79 @@ export abstract class PlansService {
     }
   }
 
+  private static async replaceFeatures(
+    tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+    planId: string,
+    features: string[] | undefined
+  ): Promise<void> {
+    if (!features) {
+      return;
+    }
+    await tx
+      .delete(schema.planFeatures)
+      .where(eq(schema.planFeatures.planId, planId));
+    if (features.length > 0) {
+      await tx.insert(schema.planFeatures).values(
+        features.map((featureId) => ({
+          planId,
+          featureId,
+        }))
+      );
+    }
+  }
+
+  private static async replaceLimits(
+    tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+    planId: string,
+    limits: UpdatePlanInput["limits"]
+  ): Promise<void> {
+    if (limits === undefined) {
+      return;
+    }
+    await tx
+      .delete(schema.planLimits)
+      .where(eq(schema.planLimits.planId, planId));
+    if (limits.length > 0) {
+      await tx.insert(schema.planLimits).values(
+        limits.map((limit) => ({
+          planId,
+          limitKey: limit.key,
+          limitValue: limit.value,
+        }))
+      );
+    }
+  }
+
+  private static async recalculateYearlyPrices(
+    tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+    plan: { id: string; yearlyDiscountPercent: number },
+    data: UpdatePlanInput
+  ): Promise<void> {
+    if (data.yearlyDiscountPercent === undefined) {
+      return;
+    }
+    const activeTiers = await tx
+      .select()
+      .from(schema.planPricingTiers)
+      .where(
+        and(
+          eq(schema.planPricingTiers.planId, plan.id),
+          isNull(schema.planPricingTiers.archivedAt)
+        )
+      );
+
+    for (const tier of activeTiers) {
+      const newYearlyPrice = calculateYearlyPrice(
+        tier.priceMonthly,
+        plan.yearlyDiscountPercent
+      );
+      await tx
+        .update(schema.planPricingTiers)
+        .set({ priceYearly: newYearlyPrice })
+        .where(eq(schema.planPricingTiers.id, tier.id));
+    }
+  }
+
   private static buildUpdateFields(
     data: UpdatePlanInput
   ): Record<string, unknown> {
@@ -491,6 +610,9 @@ export abstract class PlansService {
     }
     if (data.sortOrder !== undefined) {
       fields.sortOrder = data.sortOrder;
+    }
+    if (data.yearlyDiscountPercent !== undefined) {
+      fields.yearlyDiscountPercent = data.yearlyDiscountPercent;
     }
 
     return fields;
@@ -698,6 +820,47 @@ export abstract class PlansService {
     return map;
   }
 
+  private static async getPlanLimits(
+    planId: string,
+    tx?: Parameters<Parameters<typeof db.transaction>[0]>[0]
+  ): Promise<PlanLimitData[]> {
+    const client = tx ?? db;
+    const rows = await client
+      .select({
+        limitKey: schema.planLimits.limitKey,
+        limitValue: schema.planLimits.limitValue,
+      })
+      .from(schema.planLimits)
+      .where(eq(schema.planLimits.planId, planId));
+    return rows.map((r) => ({ key: r.limitKey, value: r.limitValue }));
+  }
+
+  private static async getBulkPlanLimits(
+    planIds: string[]
+  ): Promise<Map<string, PlanLimitData[]>> {
+    if (planIds.length === 0) {
+      return new Map();
+    }
+
+    const rows = await db
+      .select({
+        planId: schema.planLimits.planId,
+        limitKey: schema.planLimits.limitKey,
+        limitValue: schema.planLimits.limitValue,
+      })
+      .from(schema.planLimits)
+      .where(inArray(schema.planLimits.planId, planIds));
+
+    const map = new Map<string, PlanLimitData[]>();
+    for (const row of rows) {
+      if (!map.has(row.planId)) {
+        map.set(row.planId, []);
+      }
+      map.get(row.planId)?.push({ key: row.limitKey, value: row.limitValue });
+    }
+    return map;
+  }
+
   private static mapPlanWithTiers(
     plan: {
       id: string;
@@ -712,7 +875,8 @@ export abstract class PlansService {
       yearlyDiscountPercent: number;
     },
     tiers: PricingTierData[],
-    features: string[]
+    features: string[],
+    limits: PlanLimitData[] = []
   ): PlanWithTiersData {
     const startingPriceMonthly =
       tiers.length > 0 ? Math.min(...tiers.map((t) => t.priceMonthly)) : 0;
@@ -726,6 +890,7 @@ export abstract class PlansService {
       description: plan.description,
       trialDays: plan.trialDays,
       features,
+      limits,
       yearlyDiscountPercent: plan.yearlyDiscountPercent,
       isActive: plan.isActive,
       isPublic: plan.isPublic,


### PR DESCRIPTION
## Summary

- Add `limits` (array of `{ key, value }`) to `POST /plans` and `PUT /plans/:id` — insert/replace `plan_limits` in transactions
- Add `yearlyDiscountPercent` to `PUT /plans/:id` — recalculates `price_yearly` for all active tiers when changed
- Include `limits` in all plan response schemas (`GET /plans`, `GET /plans/all`, `GET /plans/:id`, `POST /plans`, `PUT /plans/:id`)
- Validate feature IDs against `features` table (exist + `is_active=true`) on create/update — returns 422 `INVALID_FEATURE_IDS` with invalid ID list
- Reject duplicate limit keys in same request via Zod `superRefine`
- Add `InvalidFeatureIdsError` error class (422)
- Update `plans/CLAUDE.md` with new business rules

Closes #143

## Test plan

- [x] `POST /plans` with `limits` — verifies `plan_limits` populated
- [x] `POST /plans` without `limits` — empty array in response
- [x] `PUT /plans/:id` with `limits` — replaces previous limits
- [x] `PUT /plans/:id` with `limits: []` — removes all limits
- [x] Limit with value `-1` (unlimited) accepted
- [x] Limit with value `0` (disabled) accepted
- [x] Duplicate limit keys rejected
- [x] `PUT /plans/:id` with `yearlyDiscountPercent: 10` — recalculates yearly prices
- [x] `PUT /plans/:id` with `yearlyDiscountPercent: 0` — no discount
- [x] `PUT /plans/:id` with `yearlyDiscountPercent: 100` — yearly = 0
- [x] Reject negative, > 100, and non-integer discount values
- [x] `GET /plans`, `GET /plans/all`, `GET /plans/:id` return `limits` array
- [x] Trial plan returns `limits: [{ key: "max_employees", value: 10 }]`
- [x] Paid plan without limits returns `limits: []`
- [x] `POST /plans` with non-existent feature ID → 422 `INVALID_FEATURE_IDS`
- [x] `POST /plans` with inactive feature → 422 `INVALID_FEATURE_IDS`
- [x] `PUT /plans/:id` with non-existent/inactive feature → 422
- [x] Error returns list of invalid IDs in `details.invalidIds`
- [x] No regressions on existing plan tests (create, update, list, get, delete, archived-tiers, trial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)