### PR TITLE
feat(features): add public listing endpoint for pricing page

### DIFF
--- a/src/modules/payments/features/__tests__/list-features.test.ts
+++ b/src/modules/payments/features/__tests__/list-features.test.ts
@@ -8,7 +8,7 @@ import { createTestApp, type TestApp } from "@/test/support/app";
 
 const BASE_URL = env.API_URL;
 
-describe("GET /payments/features", () => {
+describe("GET /payments/features/all", () => {
   let app: TestApp;
   let authHeaders: Record<string, string>;
 
@@ -20,7 +20,7 @@ describe("GET /payments/features", () => {
 
   test("should reject unauthenticated requests", async () => {
     const response = await app.handle(
-      new Request(`${BASE_URL}/v1/payments/features`)
+      new Request(`${BASE_URL}/v1/payments/features/all`)
     );
     expect(response.status).toBe(401);
   });
@@ -31,7 +31,7 @@ describe("GET /payments/features", () => {
     });
 
     const response = await app.handle(
-      new Request(`${BASE_URL}/v1/payments/features`, {
+      new Request(`${BASE_URL}/v1/payments/features/all`, {
         headers: nonAdminHeaders,
       })
     );
@@ -40,7 +40,7 @@ describe("GET /payments/features", () => {
 
   test("should list all features with planCount", async () => {
     const response = await app.handle(
-      new Request(`${BASE_URL}/v1/payments/features`, {
+      new Request(`${BASE_URL}/v1/payments/features/all`, {
         headers: authHeaders,
       })
     );
@@ -62,7 +62,7 @@ describe("GET /payments/features", () => {
 
   test("should return features ordered by sortOrder", async () => {
     const response = await app.handle(
-      new Request(`${BASE_URL}/v1/payments/features`, {
+      new Request(`${BASE_URL}/v1/payments/features/all`, {
         headers: authHeaders,
       })
     );
@@ -90,7 +90,7 @@ describe("GET /payments/features", () => {
 
     try {
       const response = await app.handle(
-        new Request(`${BASE_URL}/v1/payments/features`, {
+        new Request(`${BASE_URL}/v1/payments/features/all`, {
           headers: authHeaders,
         })
       );

--- a/src/modules/payments/features/__tests__/list-public-features.test.ts
+++ b/src/modules/payments/features/__tests__/list-public-features.test.ts
@@ -1,0 +1,107 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { env } from "@/env";
+import { createTestApp, type TestApp } from "@/test/support/app";
+
+const BASE_URL = env.API_URL;
+
+describe("GET /payments/features (public)", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("should list features without authentication", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`)
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.features).toBeArray();
+  });
+
+  test("should return only active features", async () => {
+    const featureId = `test_inactive_pub_${crypto.randomUUID().slice(0, 8)}`;
+
+    await db.insert(schema.features).values({
+      id: featureId,
+      displayName: "Test Inactive Public",
+      isActive: false,
+      sortOrder: 999,
+    });
+
+    try {
+      const response = await app.handle(
+        new Request(`${BASE_URL}/v1/payments/features`)
+      );
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      const inactiveFeature = body.data.features.find(
+        (f: { id: string }) => f.id === featureId
+      );
+      expect(inactiveFeature).toBeUndefined();
+    } finally {
+      await db.delete(schema.features).where(eq(schema.features.id, featureId));
+    }
+  });
+
+  test("should return features ordered by sortOrder", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`)
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    const features = body.data.features;
+
+    for (let i = 1; i < features.length; i++) {
+      expect(features[i].sortOrder).toBeGreaterThanOrEqual(
+        features[i - 1].sortOrder
+      );
+    }
+  });
+
+  test("should return correct public feature properties", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`)
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    const features = body.data.features;
+
+    if (features.length > 0) {
+      const feature = features[0];
+      expect(feature).toHaveProperty("id");
+      expect(feature).toHaveProperty("displayName");
+      expect(feature).toHaveProperty("description");
+      expect(feature).toHaveProperty("category");
+      expect(feature).toHaveProperty("sortOrder");
+      expect(feature).toHaveProperty("isDefault");
+      expect(feature).toHaveProperty("isPremium");
+    }
+  });
+
+  test("should not expose internal fields", async () => {
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/features`)
+    );
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    const features = body.data.features;
+
+    for (const feature of features) {
+      expect(feature).not.toHaveProperty("isActive");
+      expect(feature).not.toHaveProperty("createdAt");
+      expect(feature).not.toHaveProperty("updatedAt");
+      expect(feature).not.toHaveProperty("planCount");
+    }
+  });
+});

--- a/src/modules/payments/features/features.model.ts
+++ b/src/modules/payments/features/features.model.ts
@@ -79,8 +79,24 @@ export const deleteFeatureResponseSchema = successResponseSchema(
   z.union([deactivateFeatureDataSchema, deleteFeatureDataSchema])
 );
 
+const publicFeatureDataSchema = z.object({
+  id: z.string().describe("Feature ID"),
+  displayName: z.string().describe("Display name"),
+  description: z.string().nullable().describe("Feature description"),
+  category: z.string().nullable().describe("Category"),
+  sortOrder: z.number().int().describe("Sort order"),
+  isDefault: z.boolean().describe("Whether feature is default for new plans"),
+  isPremium: z.boolean().describe("Whether feature is premium"),
+});
+
+export const listPublicFeaturesResponseSchema = successResponseSchema(
+  z.object({ features: z.array(publicFeatureDataSchema) })
+);
+
 export type CreateFeatureInput = z.infer<typeof createFeatureSchema>;
 export type UpdateFeatureInput = z.infer<typeof updateFeatureSchema>;
 export type FeatureIdParams = z.infer<typeof featureIdParamsSchema>;
 export type FeatureData = z.infer<typeof featureDataSchema>;
+export type PublicFeatureData = z.infer<typeof publicFeatureDataSchema>;
 export type ListFeaturesData = { features: FeatureData[] };
+export type ListPublicFeaturesData = { features: PublicFeatureData[] };

--- a/src/modules/payments/features/features.service.ts
+++ b/src/modules/payments/features/features.service.ts
@@ -9,10 +9,29 @@ import type {
   CreateFeatureInput,
   FeatureData,
   ListFeaturesData,
+  ListPublicFeaturesData,
   UpdateFeatureInput,
 } from "./features.model";
 
 export abstract class FeaturesService {
+  static async listPublic(): Promise<ListPublicFeaturesData> {
+    const rows = await db
+      .select({
+        id: schema.features.id,
+        displayName: schema.features.displayName,
+        description: schema.features.description,
+        category: schema.features.category,
+        sortOrder: schema.features.sortOrder,
+        isDefault: schema.features.isDefault,
+        isPremium: schema.features.isPremium,
+      })
+      .from(schema.features)
+      .where(eq(schema.features.isActive, true))
+      .orderBy(schema.features.sortOrder);
+
+    return { features: rows };
+  }
+
   static async list(): Promise<ListFeaturesData> {
     const rows = await db
       .select({

--- a/src/modules/payments/features/index.ts
+++ b/src/modules/payments/features/index.ts
@@ -15,18 +15,35 @@ import {
   deleteFeatureResponseSchema,
   featureIdParamsSchema,
   listFeaturesResponseSchema,
+  listPublicFeaturesResponseSchema,
   updateFeatureResponseSchema,
   updateFeatureSchema,
 } from "./features.model";
 import { FeaturesService } from "./features.service";
 
-export const featuresController = new Elysia({
-  name: "features",
+export const featuresPublicController = new Elysia({
+  name: "features-public",
+  prefix: "/features",
+  detail: { tags: ["Payments - Features"] },
+}).get("/", async () => wrapSuccess(await FeaturesService.listPublic()), {
+  response: {
+    200: listPublicFeaturesResponseSchema,
+    422: validationErrorSchema,
+  },
+  detail: {
+    summary: "List active features",
+    description:
+      "Returns all active features with metadata for the pricing page. No authentication required.",
+  },
+});
+
+export const featuresProtectedController = new Elysia({
+  name: "features-protected",
   prefix: "/features",
   detail: { tags: ["Payments - Features (Admin)"] },
 })
   .use(betterAuthPlugin)
-  .get("/", async () => wrapSuccess(await FeaturesService.list()), {
+  .get("/all", async () => wrapSuccess(await FeaturesService.list()), {
     auth: { requireAdmin: true },
     response: {
       200: listFeaturesResponseSchema,

--- a/src/modules/payments/index.ts
+++ b/src/modules/payments/index.ts
@@ -4,7 +4,10 @@ import { adminProvisionController } from "./admin-provision";
 import { billingController } from "./billing";
 import { checkoutController } from "./checkout";
 import { customerController } from "./customer";
-import { featuresController } from "./features";
+import {
+  featuresProtectedController,
+  featuresPublicController,
+} from "./features";
 import { jobsController } from "./jobs";
 import { orphanedPlansController } from "./pagarme/pagarme-orphaned-plans.controller";
 import { planChangeController } from "./plan-change";
@@ -19,9 +22,10 @@ export const paymentsController = new Elysia({
   detail: { tags: ["Payments"] },
 })
   .use(plansPublicController)
+  .use(featuresPublicController)
   .use(webhookController)
   .use(plansProtectedController)
-  .use(featuresController)
+  .use(featuresProtectedController)
   .use(checkoutController)
   .use(adminCheckoutController)
   .use(adminProvisionController)


### PR DESCRIPTION
## Summary

- Add `GET /v1/payments/features` as a **public (unauthenticated)** endpoint returning active features with metadata for the frontend pricing comparison table
- Split `featuresController` into `featuresPublicController` (no auth) and `featuresProtectedController` (admin), following the same pattern as `plansPublicController` / `plansProtectedController`
- Admin list endpoint moved from `GET /features` to `GET /features/all`

### Response shape

```json
{
  "success": true,
  "data": {
    "features": [
      {
        "id": "absences",
        "displayName": "Faltas",
        "description": "Controle de faltas justificadas e injustificadas",
        "category": null,
        "sortOrder": 1,
        "isDefault": true,
        "isPremium": false
      }
    ]
  }
}
```

Internal fields (`isActive`, `createdAt`, `updatedAt`, `planCount`) are omitted from the public response.

### Files changed

| File | Change |
|------|--------|
| `features/features.model.ts` | Add `publicFeatureDataSchema` and `listPublicFeaturesResponseSchema` |
| `features/features.service.ts` | Add `listPublic()` — queries active features only, no join |
| `features/index.ts` | Split into `featuresPublicController` + `featuresProtectedController` |
| `payments/index.ts` | Register both controllers (public before protected) |
| `features/__tests__/list-features.test.ts` | Update to use `/features/all` route |
| `features/__tests__/list-public-features.test.ts` | New test file for public endpoint |

Closes #144

## Test plan

- [x] Public endpoint returns 200 without authentication
- [x] Only active features are returned (inactive excluded)
- [x] Features ordered by sortOrder
- [x] Correct public properties (id, displayName, description, category, sortOrder, isDefault, isPremium)
- [x] Internal fields not exposed (isActive, createdAt, updatedAt, planCount)
- [x] Admin list at `/features/all` still requires auth (401/403)
- [x] Existing admin CRUD tests pass (create, update, delete)
- [x] Plans tests pass (no regression from controller registration change)
- [x] Lint passes (`npx ultracite check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)