### PR TITLE
feat(payments): admin cancellation notice email

### DIFF
--- a/src/emails/templates/payments/admin-cancellation-notice.tsx
+++ b/src/emails/templates/payments/admin-cancellation-notice.tsx
@@ -1,0 +1,55 @@
+import { Heading, Hr, Text } from "@react-email/components";
+import { EmailInfoTable } from "../../components/email-info-table";
+import { EmailLayout } from "../../components/email-layout";
+import { formatDateLong } from "../../constants";
+
+type AdminCancellationNoticeEmailProps = {
+  organizationName: string;
+  planName: string;
+  ownerEmail: string;
+  canceledAt: Date;
+  reason?: string;
+  comment?: string;
+};
+
+export function AdminCancellationNoticeEmail({
+  organizationName,
+  planName,
+  ownerEmail,
+  canceledAt,
+  reason,
+  comment,
+}: AdminCancellationNoticeEmailProps) {
+  const rows = [
+    { label: "Organização", value: organizationName },
+    { label: "Plano", value: planName },
+    { label: "Email do responsável", value: ownerEmail },
+    { label: "Data do cancelamento", value: formatDateLong(canceledAt) },
+    ...(reason ? [{ label: "Motivo", value: reason }] : []),
+  ];
+
+  return (
+    <EmailLayout preview={`Cancelamento de assinatura — ${organizationName}`}>
+      <Heading as="h1" className="mb-4 text-2xl text-gray-800">
+        Cancelamento de Assinatura
+      </Heading>
+      <Text className="mb-2 text-base text-gray-600 leading-6">
+        Um usuário solicitou o cancelamento da assinatura. Confira os detalhes
+        abaixo:
+      </Text>
+      <Hr className="my-4 border-gray-200" />
+      <EmailInfoTable rows={rows} />
+      {comment ? (
+        <>
+          <Hr className="my-4 border-gray-200" />
+          <Heading as="h2" className="mb-2 text-gray-800 text-lg">
+            Observações do usuário
+          </Heading>
+          <Text className="whitespace-pre-wrap text-base text-gray-600 leading-6">
+            {comment}
+          </Text>
+        </>
+      ) : null}
+    </EmailLayout>
+  );
+}

--- a/src/lib/email.tsx
+++ b/src/lib/email.tsx
@@ -8,6 +8,7 @@ import { TwoFactorOtpEmail } from "@/emails/templates/auth/two-factor-otp";
 import { VerificationEmail } from "@/emails/templates/auth/verification";
 import { WelcomeEmail } from "@/emails/templates/auth/welcome";
 import { ContactMessageEmail } from "@/emails/templates/contact/contact-message";
+import { AdminCancellationNoticeEmail } from "@/emails/templates/payments/admin-cancellation-notice";
 import { CancellationScheduledEmail } from "@/emails/templates/payments/cancellation-scheduled";
 import { CheckoutLinkEmail } from "@/emails/templates/payments/checkout-link";
 import { PaymentFailedEmail } from "@/emails/templates/payments/payment-failed";
@@ -404,6 +405,40 @@ export async function sendProvisionCheckoutLinkEmail(params: {
   await sendEmail({
     to: params.to,
     subject: `Bem-vindo ao Synnerdata — finalize o pagamento do Plano ${params.planName}`,
+    html,
+    text,
+  });
+}
+
+// ============================================================
+// ADMIN NOTIFICATION EMAILS
+// ============================================================
+
+export async function sendAdminCancellationNoticeEmail(params: {
+  organizationName: string;
+  planName: string;
+  ownerEmail: string;
+  canceledAt: Date;
+  reason?: string;
+  comment?: string;
+}) {
+  if (!env.SMTP_USER) {
+    return;
+  }
+
+  const { html, text } = await renderEmail(
+    <AdminCancellationNoticeEmail
+      canceledAt={params.canceledAt}
+      comment={params.comment}
+      organizationName={params.organizationName}
+      ownerEmail={params.ownerEmail}
+      planName={params.planName}
+      reason={params.reason}
+    />
+  );
+  await sendEmail({
+    to: env.SMTP_USER,
+    subject: `[Cancelamento] ${params.organizationName} — Plano ${params.planName}`,
     html,
     text,
   });

--- a/src/modules/payments/hooks/__tests__/listeners.test.ts
+++ b/src/modules/payments/hooks/__tests__/listeners.test.ts
@@ -18,6 +18,7 @@ const mockSendUpgradeConfirmationEmail = mock(() => Promise.resolve());
 const mockSendCancellationScheduledEmail = mock(() => Promise.resolve());
 const mockSendSubscriptionCanceledEmail = mock(() => Promise.resolve());
 const mockSendPaymentFailedEmail = mock(() => Promise.resolve());
+const mockSendAdminCancellationNoticeEmail = mock(() => Promise.resolve());
 
 mock.module("@/lib/email", () => ({
   sendTrialExpiringEmail: mockSendTrialExpiringEmail,
@@ -26,6 +27,7 @@ mock.module("@/lib/email", () => ({
   sendCancellationScheduledEmail: mockSendCancellationScheduledEmail,
   sendSubscriptionCanceledEmail: mockSendSubscriptionCanceledEmail,
   sendPaymentFailedEmail: mockSendPaymentFailedEmail,
+  sendAdminCancellationNoticeEmail: mockSendAdminCancellationNoticeEmail,
 }));
 
 let diamondPlanResult: CreatePlanResult;
@@ -48,6 +50,7 @@ describe("Payment Listeners", () => {
     mockSendCancellationScheduledEmail.mockClear();
     mockSendSubscriptionCanceledEmail.mockClear();
     mockSendPaymentFailedEmail.mockClear();
+    mockSendAdminCancellationNoticeEmail.mockClear();
   });
 
   describe("trial.expiring listener", () => {
@@ -216,6 +219,112 @@ describe("Payment Listeners", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       expect(mockSendCancellationScheduledEmail).not.toHaveBeenCalled();
+    });
+
+    test("should call sendAdminCancellationNoticeEmail with translated reason", async () => {
+      const { organizationId } = await UserFactory.createWithOrganization({
+        emailVerified: true,
+      });
+      await SubscriptionFactory.createActive(
+        organizationId,
+        diamondPlanResult.plan.id
+      );
+
+      const canceledAt = new Date();
+      await db
+        .update(schema.orgSubscriptions)
+        .set({
+          cancelAtPeriodEnd: true,
+          canceledAt,
+          cancelReason: "too_expensive",
+          cancelComment: "O valor está acima do orçamento",
+        })
+        .where(eq(schema.orgSubscriptions.organizationId, organizationId));
+
+      const [subscription] = await db
+        .select()
+        .from(schema.orgSubscriptions)
+        .where(eq(schema.orgSubscriptions.organizationId, organizationId))
+        .limit(1);
+
+      await PaymentHooks.emit("subscription.cancelScheduled", { subscription });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mockSendAdminCancellationNoticeEmail).toHaveBeenCalledTimes(1);
+      expect(mockSendAdminCancellationNoticeEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "Muito caro",
+          comment: "O valor está acima do orçamento",
+        })
+      );
+    });
+
+    test("should call sendAdminCancellationNoticeEmail without reason when not provided", async () => {
+      const { organizationId } = await UserFactory.createWithOrganization({
+        emailVerified: true,
+      });
+      await SubscriptionFactory.createActive(
+        organizationId,
+        diamondPlanResult.plan.id
+      );
+
+      const [subscription] = await db
+        .select()
+        .from(schema.orgSubscriptions)
+        .where(eq(schema.orgSubscriptions.organizationId, organizationId))
+        .limit(1);
+
+      await PaymentHooks.emit("subscription.cancelScheduled", { subscription });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mockSendAdminCancellationNoticeEmail).toHaveBeenCalledTimes(1);
+      expect(mockSendAdminCancellationNoticeEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: undefined,
+          comment: undefined,
+        })
+      );
+    });
+
+    test("should not call sendAdminCancellationNoticeEmail if owner not found", async () => {
+      const subscription = {
+        id: "sub_test_admin",
+        organizationId: "non-existent-org",
+        planId: diamondPlanResult.plan.id,
+        status: "active" as const,
+        trialEnd: null,
+        trialStart: null,
+        trialUsed: false,
+        seats: 1,
+        pricingTierId: diamondPlanResult.tiers[0].id,
+        billingCycle: "monthly" as const,
+        currentPeriodStart: new Date(),
+        currentPeriodEnd: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        pagarmeSubscriptionId: null,
+        pagarmeUpdatedAt: null,
+        cancelAtPeriodEnd: true,
+        canceledAt: new Date(),
+        cancelReason: "too_expensive",
+        cancelComment: null,
+        pastDueSince: null,
+        gracePeriodEnds: null,
+        pendingPlanId: null,
+        pendingBillingCycle: null,
+        pendingPricingTierId: null,
+        planChangeAt: null,
+        priceAtPurchase: null,
+        isCustomPrice: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      await PaymentHooks.emit("subscription.cancelScheduled", { subscription });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(mockSendAdminCancellationNoticeEmail).not.toHaveBeenCalled();
     });
   });
 

--- a/src/modules/payments/hooks/listeners.ts
+++ b/src/modules/payments/hooks/listeners.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import {
+  sendAdminCancellationNoticeEmail,
   sendCancellationScheduledEmail,
   sendPaymentFailedEmail,
   sendPriceAdjustmentEmail,
@@ -276,6 +277,56 @@ export function registerPaymentListeners() {
       logger.error({
         type: "payment:listener:error",
         event: "subscription.cancelScheduled",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  // subscription.cancelScheduled → sendAdminCancellationNoticeEmail
+  PaymentHooks.on("subscription.cancelScheduled", async (payload) => {
+    try {
+      const { subscription } = payload;
+      const ownerEmail = await getOrganizationOwnerEmail(
+        subscription.organizationId
+      );
+      if (!ownerEmail) {
+        return;
+      }
+
+      const orgName = await getOrganizationName(subscription.organizationId);
+      const planName = await getPlanDisplayName(subscription.planId);
+      if (!planName) {
+        return;
+      }
+
+      const cancelReasonLabels: Record<string, string> = {
+        too_expensive: "Muito caro",
+        not_using_enough: "Não uso o suficiente",
+        missing_features: "Funcionalidades faltando",
+        switching_to_competitor: "Mudando para concorrente",
+        company_closing: "Empresa encerrando",
+        temporary_pause: "Pausa temporária",
+        bad_experience: "Experiência ruim",
+        other: "Outro",
+      };
+
+      const reasonLabel = subscription.cancelReason
+        ? (cancelReasonLabels[subscription.cancelReason] ??
+          subscription.cancelReason)
+        : undefined;
+
+      await sendAdminCancellationNoticeEmail({
+        organizationName: orgName ?? "Organização desconhecida",
+        planName,
+        ownerEmail,
+        canceledAt: subscription.canceledAt ?? new Date(),
+        reason: reasonLabel,
+        comment: subscription.cancelComment ?? undefined,
+      });
+    } catch (error) {
+      logger.error({
+        type: "payment:listener:error",
+        event: "subscription.cancelScheduled:admin-notice",
         error: error instanceof Error ? error.message : String(error),
       });
     }

--- a/src/test/support/mailhog.ts
+++ b/src/test/support/mailhog.ts
@@ -491,6 +491,100 @@ export async function waitForContactEmail(
 }
 
 // ============================================================
+// ADMIN CANCELLATION NOTICE EMAIL
+// ============================================================
+
+export type AdminCancellationNoticeEmailData = {
+  subject: string;
+  organizationName: string;
+  planName: string;
+  reason: string | null;
+  comment: string | null;
+  body: string;
+};
+
+const ADMIN_CANCELLATION_SUBJECT_PATTERN = "[Cancelamento]";
+
+function isAdminCancellationNoticeEmail(message: MailHogMessage): boolean {
+  const subject = message.Content.Headers.Subject?.[0] ?? "";
+  return subject.includes(ADMIN_CANCELLATION_SUBJECT_PATTERN);
+}
+
+function extractFieldFromEmailBody(
+  htmlBody: string,
+  label: string
+): string | null {
+  const decodedBody = htmlBody.replace(/=3D/g, "=").replace(/=\r?\n/g, "");
+  const regex = new RegExp(
+    `<strong>${label}<\\/strong>[\\s\\S]*?<\\/td>\\s*<td[^>]*>([^<]+)<\\/td>`,
+    "i"
+  );
+  const match = decodedBody.match(regex);
+  return match?.[1]?.trim() ?? null;
+}
+
+async function tryGetAdminCancellationNoticeEmail(
+  email: string
+): Promise<AdminCancellationNoticeEmailData | null> {
+  const messages = await searchEmailsByRecipient(email);
+  const noticeEmail = messages.find(isAdminCancellationNoticeEmail);
+
+  if (!noticeEmail) {
+    return null;
+  }
+
+  const subject = noticeEmail.Content.Headers.Subject?.[0] ?? "";
+  const body = noticeEmail.Content.Body;
+
+  return {
+    subject,
+    organizationName: extractFieldFromEmailBody(body, "Organização") ?? "",
+    planName: extractFieldFromEmailBody(body, "Plano") ?? "",
+    reason: extractFieldFromEmailBody(body, "Motivo"),
+    comment: extractFieldFromEmailBody(body, "Observações do usuário"),
+    body,
+  };
+}
+
+export async function waitForAdminCancellationNoticeEmail(
+  email: string,
+  maxRetries = DEFAULT_MAX_RETRIES,
+  delayMs = DEFAULT_RETRY_DELAY_MS
+): Promise<AdminCancellationNoticeEmailData> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const emailData = await tryGetAdminCancellationNoticeEmail(email);
+
+      if (emailData) {
+        return emailData;
+      }
+
+      if (attempt >= maxRetries) {
+        throw new Error(
+          `No admin cancellation notice email found for ${email} after ${maxRetries} attempts.`
+        );
+      }
+
+      await delay(delayMs);
+    } catch (error) {
+      if (error instanceof TypeError && error.message.includes("fetch")) {
+        throwMailHogUnavailableError();
+      }
+
+      if (attempt >= maxRetries) {
+        throw error;
+      }
+
+      await delay(delayMs);
+    }
+  }
+
+  throw new Error(
+    `Admin cancellation notice email not found for ${email} after ${maxRetries} retries`
+  );
+}
+
+// ============================================================
 // CLEAR MAILBOX
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Adiciona email de notificação ao admin quando um usuário agenda o cancelamento da assinatura
- O email é enviado para `env.SMTP_USER` com detalhes: organização, plano, email do responsável, data, motivo (traduzido para PT-BR) e observações opcionais
- Novo listener no evento `subscription.cancelScheduled` — o listener existente que envia email ao usuário permanece inalterado

## Arquivos alterados

- `src/emails/templates/payments/admin-cancellation-notice.tsx` — template React Email
- `src/lib/email.tsx` — função `sendAdminCancellationNoticeEmail()` (early return se `SMTP_USER` não definido)
- `src/modules/payments/hooks/listeners.ts` — segundo listener em `subscription.cancelScheduled`
- `src/modules/payments/hooks/__tests__/listeners.test.ts` — 3 testes: com motivo traduzido, sem motivo, owner não encontrado
- `src/test/support/mailhog.ts` — helper `waitForAdminCancellationNoticeEmail` para testes futuros

## Decisões

- Destinatário via `env.SMTP_USER` (não hardcoded) — se não definido, o email não é enviado
- Motivos de cancelamento traduzidos para PT-BR no corpo do email
- Testes seguem o padrão mock-based existente em `listeners.test.ts`

## Test plan

- [x] 12 testes passando em `listeners.test.ts` (9 existentes + 3 novos)
- [x] Lint passa (`npx ultracite check`)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)