### PR TITLE
feat: sync employee status on termination/vacation + CPF reuse

### DIFF
--- a/src/db/migrations/0027_panoramic_the_stranger.sql
+++ b/src/db/migrations/0027_panoramic_the_stranger.sql
@@ -1,0 +1,2 @@
+DROP INDEX "employees_cpf_org_unique_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "employees_cpf_org_unique_idx" ON "employees" USING btree ("cpf","organization_id") WHERE deleted_at IS NULL AND status != 'TERMINATED';

--- a/src/db/migrations/meta/0027_snapshot.json
+++ b/src/db/migrations/meta/0027_snapshot.json
@@ -1,594 +1,11 @@
 {
-  "id": "4d8c54c1-98c6-441b-9762-5f940fadc2a7",
-  "prevId": "83b005e7-5554-4eff-87ac-18a942b729c1",
+  "id": "2ad4eea0-efcb-458b-89ff-46d5059ba544",
+  "prevId": "4d8c54c1-98c6-441b-9762-5f940fadc2a7",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
-    "public.cost_centers": {
-      "name": "cost_centers",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "cost_centers_organization_id_idx": {
-          "name": "cost_centers_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "cost_centers_name_idx": {
-          "name": "cost_centers_name_idx",
-          "columns": [
-            {
-              "expression": "name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "cost_centers_organization_id_organizations_id_fk": {
-          "name": "cost_centers_organization_id_organizations_id_fk",
-          "tableFrom": "cost_centers",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.project_employees": {
-      "name": "project_employees",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "project_id": {
-          "name": "project_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "employee_id": {
-          "name": "employee_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "project_employees_organization_id_idx": {
-          "name": "project_employees_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "project_employees_project_id_idx": {
-          "name": "project_employees_project_id_idx",
-          "columns": [
-            {
-              "expression": "project_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "project_employees_employee_id_idx": {
-          "name": "project_employees_employee_id_idx",
-          "columns": [
-            {
-              "expression": "employee_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "project_employees_unique_idx": {
-          "name": "project_employees_unique_idx",
-          "columns": [
-            {
-              "expression": "project_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "employee_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "deleted_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "project_employees_organization_id_organizations_id_fk": {
-          "name": "project_employees_organization_id_organizations_id_fk",
-          "tableFrom": "project_employees",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "project_employees_project_id_projects_id_fk": {
-          "name": "project_employees_project_id_projects_id_fk",
-          "tableFrom": "project_employees",
-          "tableTo": "projects",
-          "columnsFrom": [
-            "project_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "project_employees_employee_id_employees_id_fk": {
-          "name": "project_employees_employee_id_employees_id_fk",
-          "tableFrom": "project_employees",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.branches": {
-      "name": "branches",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "tax_id": {
-          "name": "tax_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "street": {
-          "name": "street",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "number": {
-          "name": "number",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "complement": {
-          "name": "complement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "neighborhood": {
-          "name": "neighborhood",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "city": {
-          "name": "city",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "state": {
-          "name": "state",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "zip_code": {
-          "name": "zip_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "phone": {
-          "name": "phone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mobile": {
-          "name": "mobile",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "founded_at": {
-          "name": "founded_at",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "branches_organization_id_idx": {
-          "name": "branches_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "branches_tax_id_idx": {
-          "name": "branches_tax_id_idx",
-          "columns": [
-            {
-              "expression": "tax_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "branches_tax_id_unique_idx": {
-          "name": "branches_tax_id_unique_idx",
-          "columns": [
-            {
-              "expression": "tax_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "deleted_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "branches_organization_id_organizations_id_fk": {
-          "name": "branches_organization_id_organizations_id_fk",
-          "tableFrom": "branches",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.cbo_occupations": {
-      "name": "cbo_occupations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "code": {
-          "name": "code",
-          "type": "varchar(7)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "title": {
-          "name": "title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "family_code": {
-          "name": "family_code",
-          "type": "varchar(4)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "family_title": {
-          "name": "family_title",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "cbo_occupations_code_idx": {
-          "name": "cbo_occupations_code_idx",
-          "columns": [
-            {
-              "expression": "code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "cbo_occupations_title_idx": {
-          "name": "cbo_occupations_title_idx",
-          "columns": [
-            {
-              "expression": "title",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "cbo_occupations_family_code_idx": {
-          "name": "cbo_occupations_family_code_idx",
-          "columns": [
-            {
-              "expression": "family_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.medical_certificates": {
-      "name": "medical_certificates",
+    "public.absences": {
+      "name": "absences",
       "schema": "",
       "columns": {
         "id": {
@@ -621,26 +38,14 @@
           "primaryKey": false,
           "notNull": true
         },
-        "days_off": {
-          "name": "days_off",
-          "type": "integer",
+        "type": {
+          "name": "type",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "cid": {
-          "name": "cid",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "doctor_name": {
-          "name": "doctor_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "doctor_crm": {
-          "name": "doctor_crm",
+        "reason": {
+          "name": "reason",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -691,8 +96,8 @@
         }
       },
       "indexes": {
-        "medical_certificates_organization_id_idx": {
-          "name": "medical_certificates_organization_id_idx",
+        "absences_organization_id_idx": {
+          "name": "absences_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -706,8 +111,8 @@
           "method": "btree",
           "with": {}
         },
-        "medical_certificates_employee_id_idx": {
-          "name": "medical_certificates_employee_id_idx",
+        "absences_employee_id_idx": {
+          "name": "absences_employee_id_idx",
           "columns": [
             {
               "expression": "employee_id",
@@ -723,9 +128,9 @@
         }
       },
       "foreignKeys": {
-        "medical_certificates_organization_id_organizations_id_fk": {
-          "name": "medical_certificates_organization_id_organizations_id_fk",
-          "tableFrom": "medical_certificates",
+        "absences_organization_id_organizations_id_fk": {
+          "name": "absences_organization_id_organizations_id_fk",
+          "tableFrom": "absences",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
@@ -736,9 +141,9 @@
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "medical_certificates_employee_id_employees_id_fk": {
-          "name": "medical_certificates_employee_id_employees_id_fk",
-          "tableFrom": "medical_certificates",
+        "absences_employee_id_employees_id_fk": {
+          "name": "absences_employee_id_employees_id_fk",
+          "tableFrom": "absences",
           "tableTo": "employees",
           "columnsFrom": [
             "employee_id"
@@ -750,144 +155,6 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.audit_logs": {
-      "name": "audit_logs",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "action": {
-          "name": "action",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource": {
-          "name": "resource",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "resource_id": {
-          "name": "resource_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "changes": {
-          "name": "changes",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "ip_address": {
-          "name": "ip_address",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "user_agent": {
-          "name": "user_agent",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "audit_logs_org_date_idx": {
-          "name": "audit_logs_org_date_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "audit_logs_resource_idx": {
-          "name": "audit_logs_resource_idx",
-          "columns": [
-            {
-              "expression": "resource",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "resource_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "audit_logs_user_idx": {
-          "name": "audit_logs_user_idx",
-          "columns": [
-            {
-              "expression": "user_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
@@ -1072,8 +339,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.sectors": {
-      "name": "sectors",
+    "public.admin_org_provisions": {
+      "name": "admin_org_provisions",
       "schema": "",
       "columns": {
         "id": {
@@ -1082,118 +349,10 @@
           "primaryKey": true,
           "notNull": true
         },
-        "organization_id": {
-          "name": "organization_id",
+        "user_id": {
+          "name": "user_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "sectors_organization_id_idx": {
-          "name": "sectors_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "sectors_name_idx": {
-          "name": "sectors_name_idx",
-          "columns": [
-            {
-              "expression": "name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "sectors_organization_id_organizations_id_fk": {
-          "name": "sectors_organization_id_organizations_id_fk",
-          "tableFrom": "sectors",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.cpf_analyses": {
-      "name": "cpf_analyses",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
           "notNull": true
         },
         "organization_id": {
@@ -1202,46 +361,59 @@
           "primaryKey": false,
           "notNull": true
         },
-        "employee_id": {
-          "name": "employee_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "analysis_date": {
-          "name": "analysis_date",
-          "type": "date",
+        "type": {
+          "name": "type",
+          "type": "provision_type",
+          "typeSchema": "public",
           "primaryKey": false,
           "notNull": true
         },
         "status": {
           "name": "status",
-          "type": "cpf_analysis_status",
+          "type": "provision_status",
           "typeSchema": "public",
           "primaryKey": false,
-          "notNull": true
+          "notNull": true,
+          "default": "'pending_activation'"
         },
-        "score": {
-          "name": "score",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "risk_level": {
-          "name": "risk_level",
-          "type": "risk_level",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "observations": {
-          "name": "observations",
+        "activation_url": {
+          "name": "activation_url",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "external_reference": {
-          "name": "external_reference",
+        "activation_sent_at": {
+          "name": "activation_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkout_url": {
+          "name": "checkout_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkout_expires_at": {
+          "name": "checkout_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_checkout_id": {
+          "name": "pending_checkout_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -1286,8 +458,23 @@
         }
       },
       "indexes": {
-        "cpf_analyses_organization_id_idx": {
-          "name": "cpf_analyses_organization_id_idx",
+        "admin_org_provisions_user_id_idx": {
+          "name": "admin_org_provisions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_org_provisions_organization_id_idx": {
+          "name": "admin_org_provisions_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -1301,11 +488,11 @@
           "method": "btree",
           "with": {}
         },
-        "cpf_analyses_employee_id_idx": {
-          "name": "cpf_analyses_employee_id_idx",
+        "admin_org_provisions_created_by_idx": {
+          "name": "admin_org_provisions_created_by_idx",
           "columns": [
             {
-              "expression": "employee_id",
+              "expression": "created_by",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1316,8 +503,8 @@
           "method": "btree",
           "with": {}
         },
-        "cpf_analyses_status_idx": {
-          "name": "cpf_analyses_status_idx",
+        "admin_org_provisions_status_idx": {
+          "name": "admin_org_provisions_status_idx",
           "columns": [
             {
               "expression": "status",
@@ -1330,59 +517,17 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "cpf_analyses_analysis_date_idx": {
-          "name": "cpf_analyses_analysis_date_idx",
-          "columns": [
-            {
-              "expression": "analysis_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
-      "foreignKeys": {
-        "cpf_analyses_organization_id_organizations_id_fk": {
-          "name": "cpf_analyses_organization_id_organizations_id_fk",
-          "tableFrom": "cpf_analyses",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "cpf_analyses_employee_id_employees_id_fk": {
-          "name": "cpf_analyses_employee_id_employees_id_fk",
-          "tableFrom": "cpf_analyses",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.organization_profiles": {
-      "name": "organization_profiles",
+    "public.audit_logs": {
+      "name": "audit_logs",
       "schema": "",
       "columns": {
         "id": {
@@ -1395,167 +540,49 @@
           "name": "organization_id",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
-        "trade_name": {
-          "name": "trade_name",
+        "user_id": {
+          "name": "user_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "legal_name": {
-          "name": "legal_name",
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "tax_id": {
-          "name": "tax_id",
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "street": {
-          "name": "street",
+        "user_agent": {
+          "name": "user_agent",
           "type": "text",
           "primaryKey": false,
           "notNull": false
-        },
-        "number": {
-          "name": "number",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "complement": {
-          "name": "complement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "neighborhood": {
-          "name": "neighborhood",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "city": {
-          "name": "city",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "state": {
-          "name": "state",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "zip_code": {
-          "name": "zip_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "phone": {
-          "name": "phone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "mobile": {
-          "name": "mobile",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "tax_regime": {
-          "name": "tax_regime",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "state_registration": {
-          "name": "state_registration",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "main_activity_code": {
-          "name": "main_activity_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "founding_date": {
-          "name": "founding_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "revenue": {
-          "name": "revenue",
-          "type": "numeric(10, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "industry": {
-          "name": "industry",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "business_area": {
-          "name": "business_area",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "max_users": {
-          "name": "max_users",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 4
-        },
-        "max_employees": {
-          "name": "max_employees",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false,
-          "default": 10
-        },
-        "logo_url": {
-          "name": "logo_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "pb_url": {
-          "name": "pb_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "pagarme_customer_id": {
-          "name": "pagarme_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "status": {
-          "name": "status",
-          "type": "organization_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'ACTIVE'"
         },
         "created_at": {
           "name": "created_at",
@@ -1563,60 +590,20 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
-        "organization_profiles_organization_id_idx": {
-          "name": "organization_profiles_organization_id_idx",
+        "audit_logs_org_date_idx": {
+          "name": "audit_logs_org_date_idx",
           "columns": [
             {
               "expression": "organization_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "organization_profiles_tax_id_idx": {
-          "name": "organization_profiles_tax_id_idx",
-          "columns": [
+            },
             {
-              "expression": "tax_id",
+              "expression": "created_at",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1627,11 +614,17 @@
           "method": "btree",
           "with": {}
         },
-        "organization_profiles_status_idx": {
-          "name": "organization_profiles_status_idx",
+        "audit_logs_resource_idx": {
+          "name": "audit_logs_resource_idx",
           "columns": [
             {
-              "expression": "status",
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1642,11 +635,17 @@
           "method": "btree",
           "with": {}
         },
-        "organization_profiles_industry_idx": {
-          "name": "organization_profiles_industry_idx",
+        "audit_logs_user_idx": {
+          "name": "audit_logs_user_idx",
           "columns": [
             {
-              "expression": "industry",
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -1658,31 +657,9 @@
           "with": {}
         }
       },
-      "foreignKeys": {
-        "organization_profiles_organization_id_organizations_id_fk": {
-          "name": "organization_profiles_organization_id_organizations_id_fk",
-          "tableFrom": "organization_profiles",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "organization_profiles_tax_id_unique": {
-          "name": "organization_profiles_tax_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "tax_id"
-          ]
-        }
-      },
+      "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -2731,14 +1708,32 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.newsletter_subscribers": {
-      "name": "newsletter_subscribers",
+    "public.billing_profiles": {
+      "name": "billing_profiles",
       "schema": "",
       "columns": {
         "id": {
           "name": "id",
           "type": "text",
           "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
           "notNull": true
         },
         "email": {
@@ -2747,94 +1742,56 @@
           "primaryKey": false,
           "notNull": true
         },
-        "status": {
-          "name": "status",
-          "type": "newsletter_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'active'"
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "newsletter_subscribers_email_unique_idx": {
-          "name": "newsletter_subscribers_email_unique_idx",
-          "columns": [
-            {
-              "expression": "email",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.absences": {
-      "name": "absences",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
+        "phone": {
+          "name": "phone",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "employee_id": {
-          "name": "employee_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "start_date": {
-          "name": "start_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "end_date": {
-          "name": "end_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
+        "street": {
+          "name": "street",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "notes": {
-          "name": "notes",
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complement": {
+          "name": "complement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagarme_customer_id": {
+          "name": "pagarme_customer_id",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -2879,8 +1836,8 @@
         }
       },
       "indexes": {
-        "absences_organization_id_idx": {
-          "name": "absences_organization_id_idx",
+        "billing_profiles_organization_id_idx": {
+          "name": "billing_profiles_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -2894,11 +1851,26 @@
           "method": "btree",
           "with": {}
         },
-        "absences_employee_id_idx": {
-          "name": "absences_employee_id_idx",
+        "billing_profiles_tax_id_idx": {
+          "name": "billing_profiles_tax_id_idx",
           "columns": [
             {
-              "expression": "employee_id",
+              "expression": "tax_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_profiles_pagarme_customer_id_idx": {
+          "name": "billing_profiles_pagarme_customer_id_idx",
+          "columns": [
+            {
+              "expression": "pagarme_customer_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -2911,9 +1883,9 @@
         }
       },
       "foreignKeys": {
-        "absences_organization_id_organizations_id_fk": {
-          "name": "absences_organization_id_organizations_id_fk",
-          "tableFrom": "absences",
+        "billing_profiles_organization_id_organizations_id_fk": {
+          "name": "billing_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "billing_profiles",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
@@ -2923,29 +1895,24 @@
           ],
           "onDelete": "cascade",
           "onUpdate": "no action"
-        },
-        "absences_employee_id_employees_id_fk": {
-          "name": "absences_employee_id_employees_id_fk",
-          "tableFrom": "absences",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "billing_profiles_organization_id_unique": {
+          "name": "billing_profiles_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.ppe_job_positions": {
-      "name": "ppe_job_positions",
+    "public.branches": {
+      "name": "branches",
       "schema": "",
       "columns": {
         "id": {
@@ -2960,223 +1927,75 @@
           "primaryKey": false,
           "notNull": true
         },
-        "ppe_item_id": {
-          "name": "ppe_item_id",
+        "name": {
+          "name": "name",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "job_position_id": {
-          "name": "job_position_id",
+        "tax_id": {
+          "name": "tax_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
+        "street": {
+          "name": "street",
+          "type": "text",
           "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
+          "notNull": true
         },
-        "created_by": {
-          "name": "created_by",
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "complement": {
+          "name": "complement",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "ppe_job_positions_organization_id_idx": {
-          "name": "ppe_job_positions_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ppe_job_positions_ppe_item_id_idx": {
-          "name": "ppe_job_positions_ppe_item_id_idx",
-          "columns": [
-            {
-              "expression": "ppe_item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ppe_job_positions_job_position_id_idx": {
-          "name": "ppe_job_positions_job_position_id_idx",
-          "columns": [
-            {
-              "expression": "job_position_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ppe_job_positions_unique_idx": {
-          "name": "ppe_job_positions_unique_idx",
-          "columns": [
-            {
-              "expression": "ppe_item_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "job_position_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "where": "deleted_at IS NULL",
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "ppe_job_positions_organization_id_organizations_id_fk": {
-          "name": "ppe_job_positions_organization_id_organizations_id_fk",
-          "tableFrom": "ppe_job_positions",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "ppe_job_positions_ppe_item_id_ppe_items_id_fk": {
-          "name": "ppe_job_positions_ppe_item_id_ppe_items_id_fk",
-          "tableFrom": "ppe_job_positions",
-          "tableTo": "ppe_items",
-          "columnsFrom": [
-            "ppe_item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "ppe_job_positions_job_position_id_job_positions_id_fk": {
-          "name": "ppe_job_positions_job_position_id_job_positions_id_fk",
-          "tableFrom": "ppe_job_positions",
-          "tableTo": "job_positions",
-          "columnsFrom": [
-            "job_position_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.terminations": {
-      "name": "terminations",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
+        "mobile": {
+          "name": "mobile",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "employee_id": {
-          "name": "employee_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "termination_date": {
-          "name": "termination_date",
+        "founded_at": {
+          "name": "founded_at",
           "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "termination_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "notice_period_days": {
-          "name": "notice_period_days",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "notice_period_worked": {
-          "name": "notice_period_worked",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "last_working_day": {
-          "name": "last_working_day",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
           "primaryKey": false,
           "notNull": false
         },
@@ -3220,8 +2039,8 @@
         }
       },
       "indexes": {
-        "terminations_organization_id_idx": {
-          "name": "terminations_organization_id_idx",
+        "branches_organization_id_idx": {
+          "name": "branches_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -3235,11 +2054,11 @@
           "method": "btree",
           "with": {}
         },
-        "terminations_employee_id_idx": {
-          "name": "terminations_employee_id_idx",
+        "branches_tax_id_idx": {
+          "name": "branches_tax_id_idx",
           "columns": [
             {
-              "expression": "employee_id",
+              "expression": "tax_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -3250,418 +2069,11 @@
           "method": "btree",
           "with": {}
         },
-        "terminations_termination_date_idx": {
-          "name": "terminations_termination_date_idx",
+        "branches_tax_id_unique_idx": {
+          "name": "branches_tax_id_unique_idx",
           "columns": [
             {
-              "expression": "termination_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "terminations_type_idx": {
-          "name": "terminations_type_idx",
-          "columns": [
-            {
-              "expression": "type",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "terminations_organization_id_organizations_id_fk": {
-          "name": "terminations_organization_id_organizations_id_fk",
-          "tableFrom": "terminations",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "terminations_employee_id_employees_id_fk": {
-          "name": "terminations_employee_id_employees_id_fk",
-          "tableFrom": "terminations",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.ppe_deliveries": {
-      "name": "ppe_deliveries",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "employee_id": {
-          "name": "employee_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "delivery_date": {
-          "name": "delivery_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "delivered_by": {
-          "name": "delivered_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "ppe_deliveries_organization_id_idx": {
-          "name": "ppe_deliveries_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ppe_deliveries_employee_id_idx": {
-          "name": "ppe_deliveries_employee_id_idx",
-          "columns": [
-            {
-              "expression": "employee_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "ppe_deliveries_delivery_date_idx": {
-          "name": "ppe_deliveries_delivery_date_idx",
-          "columns": [
-            {
-              "expression": "delivery_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "ppe_deliveries_organization_id_organizations_id_fk": {
-          "name": "ppe_deliveries_organization_id_organizations_id_fk",
-          "tableFrom": "ppe_deliveries",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "ppe_deliveries_employee_id_employees_id_fk": {
-          "name": "ppe_deliveries_employee_id_employees_id_fk",
-          "tableFrom": "ppe_deliveries",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.labor_lawsuits": {
-      "name": "labor_lawsuits",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "employee_id": {
-          "name": "employee_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "process_number": {
-          "name": "process_number",
-          "type": "varchar(25)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "court": {
-          "name": "court",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "filing_date": {
-          "name": "filing_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "knowledge_date": {
-          "name": "knowledge_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "plaintiff": {
-          "name": "plaintiff",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "defendant": {
-          "name": "defendant",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "plaintiff_lawyer": {
-          "name": "plaintiff_lawyer",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "defendant_lawyer": {
-          "name": "defendant_lawyer",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "claim_amount": {
-          "name": "claim_amount",
-          "type": "numeric(12, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "progress": {
-          "name": "progress",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "decision": {
-          "name": "decision",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "conclusion_date": {
-          "name": "conclusion_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "appeals": {
-          "name": "appeals",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "costs_expenses": {
-          "name": "costs_expenses",
-          "type": "numeric(12, 2)",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "labor_lawsuits_organization_id_idx": {
-          "name": "labor_lawsuits_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "labor_lawsuits_employee_id_idx": {
-          "name": "labor_lawsuits_employee_id_idx",
-          "columns": [
-            {
-              "expression": "employee_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "labor_lawsuits_process_number_unique_idx": {
-          "name": "labor_lawsuits_process_number_unique_idx",
-          "columns": [
-            {
-              "expression": "process_number",
+              "expression": "tax_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -3672,43 +2084,15 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
-        },
-        "labor_lawsuits_filing_date_idx": {
-          "name": "labor_lawsuits_filing_date_idx",
-          "columns": [
-            {
-              "expression": "filing_date",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
         }
       },
       "foreignKeys": {
-        "labor_lawsuits_organization_id_organizations_id_fk": {
-          "name": "labor_lawsuits_organization_id_organizations_id_fk",
-          "tableFrom": "labor_lawsuits",
+        "branches_organization_id_organizations_id_fk": {
+          "name": "branches_organization_id_organizations_id_fk",
+          "tableFrom": "branches",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "labor_lawsuits_employee_id_employees_id_fk": {
-          "name": "labor_lawsuits_employee_id_employees_id_fk",
-          "tableFrom": "labor_lawsuits",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
           ],
           "columnsTo": [
             "id"
@@ -3723,8 +2107,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.admin_org_provisions": {
-      "name": "admin_org_provisions",
+    "public.cbo_occupations": {
+      "name": "cbo_occupations",
       "schema": "",
       "columns": {
         "id": {
@@ -3733,74 +2117,29 @@
           "primaryKey": true,
           "notNull": true
         },
-        "user_id": {
-          "name": "user_id",
+        "code": {
+          "name": "code",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
+        "family_code": {
+          "name": "family_code",
+          "type": "varchar(4)",
           "primaryKey": false,
           "notNull": true
         },
-        "type": {
-          "name": "type",
-          "type": "provision_type",
-          "typeSchema": "public",
+        "family_title": {
+          "name": "family_title",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "provision_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'pending_activation'"
-        },
-        "activation_url": {
-          "name": "activation_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "activation_sent_at": {
-          "name": "activation_sent_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "activated_at": {
-          "name": "activated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "checkout_url": {
-          "name": "checkout_url",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "checkout_expires_at": {
-          "name": "checkout_expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "pending_checkout_id": {
-          "name": "pending_checkout_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -3815,38 +2154,29 @@
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {
-        "admin_org_provisions_user_id_idx": {
-          "name": "admin_org_provisions_user_id_idx",
+        "cbo_occupations_code_idx": {
+          "name": "cbo_occupations_code_idx",
           "columns": [
             {
-              "expression": "user_id",
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cbo_occupations_title_idx": {
+          "name": "cbo_occupations_title_idx",
+          "columns": [
+            {
+              "expression": "title",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -3857,41 +2187,11 @@
           "method": "btree",
           "with": {}
         },
-        "admin_org_provisions_organization_id_idx": {
-          "name": "admin_org_provisions_organization_id_idx",
+        "cbo_occupations_family_code_idx": {
+          "name": "cbo_occupations_family_code_idx",
           "columns": [
             {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "admin_org_provisions_created_by_idx": {
-          "name": "admin_org_provisions_created_by_idx",
-          "columns": [
-            {
-              "expression": "created_by",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "admin_org_provisions_status_idx": {
-          "name": "admin_org_provisions_status_idx",
-          "columns": [
-            {
-              "expression": "status",
+              "expression": "family_code",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -3910,8 +2210,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.warnings": {
-      "name": "warnings",
+    "public.cost_centers": {
+      "name": "cost_centers",
       "schema": "",
       "columns": {
         "id": {
@@ -3926,61 +2226,11 @@
           "primaryKey": false,
           "notNull": true
         },
-        "employee_id": {
-          "name": "employee_id",
+        "name": {
+          "name": "name",
           "type": "text",
           "primaryKey": false,
           "notNull": true
-        },
-        "date": {
-          "name": "date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "warning_type",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "reason": {
-          "name": "reason",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "witness_name": {
-          "name": "witness_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "acknowledged": {
-          "name": "acknowledged",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "acknowledged_at": {
-          "name": "acknowledged_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         },
         "created_at": {
           "name": "created_at",
@@ -4022,8 +2272,8 @@
         }
       },
       "indexes": {
-        "warnings_organization_id_idx": {
-          "name": "warnings_organization_id_idx",
+        "cost_centers_organization_id_idx": {
+          "name": "cost_centers_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -4037,26 +2287,11 @@
           "method": "btree",
           "with": {}
         },
-        "warnings_employee_id_idx": {
-          "name": "warnings_employee_id_idx",
+        "cost_centers_name_idx": {
+          "name": "cost_centers_name_idx",
           "columns": [
             {
-              "expression": "employee_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "warnings_date_idx": {
-          "name": "warnings_date_idx",
-          "columns": [
-            {
-              "expression": "date",
+              "expression": "name",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -4069,25 +2304,12 @@
         }
       },
       "foreignKeys": {
-        "warnings_organization_id_organizations_id_fk": {
-          "name": "warnings_organization_id_organizations_id_fk",
-          "tableFrom": "warnings",
+        "cost_centers_organization_id_organizations_id_fk": {
+          "name": "cost_centers_organization_id_organizations_id_fk",
+          "tableFrom": "cost_centers",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "warnings_employee_id_employees_id_fk": {
-          "name": "warnings_employee_id_employees_id_fk",
-          "tableFrom": "warnings",
-          "tableTo": "employees",
-          "columnsFrom": [
-            "employee_id"
           ],
           "columnsTo": [
             "id"
@@ -4102,8 +2324,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.vacations": {
-      "name": "vacations",
+    "public.cpf_analyses": {
+      "name": "cpf_analyses",
       "schema": "",
       "columns": {
         "id": {
@@ -4124,64 +2346,40 @@
           "primaryKey": false,
           "notNull": true
         },
-        "start_date": {
-          "name": "start_date",
+        "analysis_date": {
+          "name": "analysis_date",
           "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "end_date": {
-          "name": "end_date",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "days_used": {
-          "name": "days_used",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "acquisition_period_start": {
-          "name": "acquisition_period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "acquisition_period_end": {
-          "name": "acquisition_period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "concessive_period_start": {
-          "name": "concessive_period_start",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "concessive_period_end": {
-          "name": "concessive_period_end",
-          "type": "date",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "days_entitled": {
-          "name": "days_entitled",
-          "type": "integer",
           "primaryKey": false,
           "notNull": true
         },
         "status": {
           "name": "status",
-          "type": "vacation_status",
+          "type": "cpf_analysis_status",
           "typeSchema": "public",
           "primaryKey": false,
-          "notNull": true,
-          "default": "'scheduled'"
+          "notNull": true
         },
-        "notes": {
-          "name": "notes",
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_level": {
+          "name": "risk_level",
+          "type": "risk_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observations": {
+          "name": "observations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference": {
+          "name": "external_reference",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -4226,8 +2424,8 @@
         }
       },
       "indexes": {
-        "vacations_organization_id_idx": {
-          "name": "vacations_organization_id_idx",
+        "cpf_analyses_organization_id_idx": {
+          "name": "cpf_analyses_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -4241,8 +2439,8 @@
           "method": "btree",
           "with": {}
         },
-        "vacations_employee_id_idx": {
-          "name": "vacations_employee_id_idx",
+        "cpf_analyses_employee_id_idx": {
+          "name": "cpf_analyses_employee_id_idx",
           "columns": [
             {
               "expression": "employee_id",
@@ -4256,8 +2454,8 @@
           "method": "btree",
           "with": {}
         },
-        "vacations_status_idx": {
-          "name": "vacations_status_idx",
+        "cpf_analyses_status_idx": {
+          "name": "cpf_analyses_status_idx",
           "columns": [
             {
               "expression": "status",
@@ -4271,11 +2469,11 @@
           "method": "btree",
           "with": {}
         },
-        "vacations_start_date_idx": {
-          "name": "vacations_start_date_idx",
+        "cpf_analyses_analysis_date_idx": {
+          "name": "cpf_analyses_analysis_date_idx",
           "columns": [
             {
-              "expression": "start_date",
+              "expression": "analysis_date",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -4288,9 +2486,9 @@
         }
       },
       "foreignKeys": {
-        "vacations_organization_id_organizations_id_fk": {
-          "name": "vacations_organization_id_organizations_id_fk",
-          "tableFrom": "vacations",
+        "cpf_analyses_organization_id_organizations_id_fk": {
+          "name": "cpf_analyses_organization_id_organizations_id_fk",
+          "tableFrom": "cpf_analyses",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
@@ -4301,9 +2499,9 @@
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "vacations_employee_id_employees_id_fk": {
-          "name": "vacations_employee_id_employees_id_fk",
-          "tableFrom": "vacations",
+        "cpf_analyses_employee_id_employees_id_fk": {
+          "name": "cpf_analyses_employee_id_employees_id_fk",
+          "tableFrom": "cpf_analyses",
           "tableTo": "employees",
           "columnsFrom": [
             "employee_id"
@@ -4837,7 +3035,7 @@
             }
           ],
           "isUnique": true,
-          "where": "deleted_at IS NULL",
+          "where": "deleted_at IS NULL AND status != 'TERMINATED'",
           "concurrently": false,
           "method": "btree",
           "with": {}
@@ -4929,8 +3127,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.ppe_delivery_logs": {
-      "name": "ppe_delivery_logs",
+    "public.job_classifications": {
+      "name": "job_classifications",
       "schema": "",
       "columns": {
         "id": {
@@ -4939,22 +3137,148 @@
           "primaryKey": true,
           "notNull": true
         },
-        "ppe_delivery_id": {
-          "name": "ppe_delivery_id",
+        "organization_id": {
+          "name": "organization_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "ppe_item_id": {
-          "name": "ppe_item_id",
+        "name": {
+          "name": "name",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "action": {
-          "name": "action",
-          "type": "ppe_delivery_action",
-          "typeSchema": "public",
+        "cbo_occupation_id": {
+          "name": "cbo_occupation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "job_classifications_organization_id_idx": {
+          "name": "job_classifications_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "job_classifications_name_idx": {
+          "name": "job_classifications_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_classifications_organization_id_organizations_id_fk": {
+          "name": "job_classifications_organization_id_organizations_id_fk",
+          "tableFrom": "job_classifications",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "job_classifications_cbo_occupation_id_cbo_occupations_id_fk": {
+          "name": "job_classifications_cbo_occupation_id_cbo_occupations_id_fk",
+          "tableFrom": "job_classifications",
+          "tableTo": "cbo_occupations",
+          "columnsFrom": [
+            "cbo_occupation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_positions": {
+      "name": "job_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
@@ -4971,19 +3295,44 @@
           "notNull": true,
           "default": "now()"
         },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
         "created_by": {
           "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
           "type": "text",
           "primaryKey": false,
           "notNull": false
         }
       },
       "indexes": {
-        "ppe_delivery_logs_ppe_delivery_id_idx": {
-          "name": "ppe_delivery_logs_ppe_delivery_id_idx",
+        "job_positions_organization_id_idx": {
+          "name": "job_positions_organization_id_idx",
           "columns": [
             {
-              "expression": "ppe_delivery_id",
+              "expression": "organization_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -4994,11 +3343,11 @@
           "method": "btree",
           "with": {}
         },
-        "ppe_delivery_logs_ppe_item_id_idx": {
-          "name": "ppe_delivery_logs_ppe_item_id_idx",
+        "job_positions_name_idx": {
+          "name": "job_positions_name_idx",
           "columns": [
             {
-              "expression": "ppe_item_id",
+              "expression": "name",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -5011,25 +3360,12 @@
         }
       },
       "foreignKeys": {
-        "ppe_delivery_logs_ppe_delivery_id_ppe_deliveries_id_fk": {
-          "name": "ppe_delivery_logs_ppe_delivery_id_ppe_deliveries_id_fk",
-          "tableFrom": "ppe_delivery_logs",
-          "tableTo": "ppe_deliveries",
+        "job_positions_organization_id_organizations_id_fk": {
+          "name": "job_positions_organization_id_organizations_id_fk",
+          "tableFrom": "job_positions",
+          "tableTo": "organizations",
           "columnsFrom": [
-            "ppe_delivery_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "ppe_delivery_logs_ppe_item_id_ppe_items_id_fk": {
-          "name": "ppe_delivery_logs_ppe_item_id_ppe_items_id_fk",
-          "tableFrom": "ppe_delivery_logs",
-          "tableTo": "ppe_items",
-          "columnsFrom": [
-            "ppe_item_id"
+            "organization_id"
           ],
           "columnsTo": [
             "id"
@@ -5044,8 +3380,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.promotions": {
-      "name": "promotions",
+    "public.labor_lawsuits": {
+      "name": "labor_lawsuits",
       "schema": "",
       "columns": {
         "id": {
@@ -5066,38 +3402,286 @@
           "primaryKey": false,
           "notNull": true
         },
-        "promotion_date": {
-          "name": "promotion_date",
+        "process_number": {
+          "name": "process_number",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court": {
+          "name": "court",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filing_date": {
+          "name": "filing_date",
           "type": "date",
           "primaryKey": false,
           "notNull": true
         },
-        "previous_job_position_id": {
-          "name": "previous_job_position_id",
+        "knowledge_date": {
+          "name": "knowledge_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant": {
+          "name": "defendant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plaintiff_lawyer": {
+          "name": "plaintiff_lawyer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "defendant_lawyer": {
+          "name": "defendant_lawyer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "new_job_position_id": {
-          "name": "new_job_position_id",
+        "claim_amount": {
+          "name": "claim_amount",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conclusion_date": {
+          "name": "conclusion_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appeals": {
+          "name": "appeals",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "costs_expenses": {
+          "name": "costs_expenses",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "labor_lawsuits_organization_id_idx": {
+          "name": "labor_lawsuits_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labor_lawsuits_employee_id_idx": {
+          "name": "labor_lawsuits_employee_id_idx",
+          "columns": [
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labor_lawsuits_process_number_unique_idx": {
+          "name": "labor_lawsuits_process_number_unique_idx",
+          "columns": [
+            {
+              "expression": "process_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labor_lawsuits_filing_date_idx": {
+          "name": "labor_lawsuits_filing_date_idx",
+          "columns": [
+            {
+              "expression": "filing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labor_lawsuits_organization_id_organizations_id_fk": {
+          "name": "labor_lawsuits_organization_id_organizations_id_fk",
+          "tableFrom": "labor_lawsuits",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labor_lawsuits_employee_id_employees_id_fk": {
+          "name": "labor_lawsuits_employee_id_employees_id_fk",
+          "tableFrom": "labor_lawsuits",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medical_certificates": {
+      "name": "medical_certificates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "previous_salary": {
-          "name": "previous_salary",
-          "type": "numeric(12, 2)",
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "new_salary": {
-          "name": "new_salary",
-          "type": "numeric(12, 2)",
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
           "primaryKey": false,
           "notNull": true
         },
-        "reason": {
-          "name": "reason",
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_off": {
+          "name": "days_off",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cid": {
+          "name": "cid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_name": {
+          "name": "doctor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "doctor_crm": {
+          "name": "doctor_crm",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -5148,8 +3732,8 @@
         }
       },
       "indexes": {
-        "promotions_organization_id_idx": {
-          "name": "promotions_organization_id_idx",
+        "medical_certificates_organization_id_idx": {
+          "name": "medical_certificates_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -5163,8 +3747,8 @@
           "method": "btree",
           "with": {}
         },
-        "promotions_employee_id_idx": {
-          "name": "promotions_employee_id_idx",
+        "medical_certificates_employee_id_idx": {
+          "name": "medical_certificates_employee_id_idx",
           "columns": [
             {
               "expression": "employee_id",
@@ -5180,9 +3764,9 @@
         }
       },
       "foreignKeys": {
-        "promotions_organization_id_organizations_id_fk": {
-          "name": "promotions_organization_id_organizations_id_fk",
-          "tableFrom": "promotions",
+        "medical_certificates_organization_id_organizations_id_fk": {
+          "name": "medical_certificates_organization_id_organizations_id_fk",
+          "tableFrom": "medical_certificates",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
@@ -5193,9 +3777,9 @@
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "promotions_employee_id_employees_id_fk": {
-          "name": "promotions_employee_id_employees_id_fk",
-          "tableFrom": "promotions",
+        "medical_certificates_employee_id_employees_id_fk": {
+          "name": "medical_certificates_employee_id_employees_id_fk",
+          "tableFrom": "medical_certificates",
           "tableTo": "employees",
           "columnsFrom": [
             "employee_id"
@@ -5205,36 +3789,372 @@
           ],
           "onDelete": "cascade",
           "onUpdate": "no action"
-        },
-        "promotions_previous_job_position_id_job_positions_id_fk": {
-          "name": "promotions_previous_job_position_id_job_positions_id_fk",
-          "tableFrom": "promotions",
-          "tableTo": "job_positions",
-          "columnsFrom": [
-            "previous_job_position_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        },
-        "promotions_new_job_position_id_job_positions_id_fk": {
-          "name": "promotions_new_job_position_id_job_positions_id_fk",
-          "tableFrom": "promotions",
-          "tableTo": "job_positions",
-          "columnsFrom": [
-            "new_job_position_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "newsletter_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "newsletter_subscribers_email_unique_idx": {
+          "name": "newsletter_subscribers_email_unique_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_profiles": {
+      "name": "organization_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trade_name": {
+          "name": "trade_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_id": {
+          "name": "tax_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complement": {
+          "name": "complement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "neighborhood": {
+          "name": "neighborhood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zip_code": {
+          "name": "zip_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mobile": {
+          "name": "mobile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_regime": {
+          "name": "tax_regime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state_registration": {
+          "name": "state_registration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "main_activity_code": {
+          "name": "main_activity_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founding_date": {
+          "name": "founding_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "business_area": {
+          "name": "business_area",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_users": {
+          "name": "max_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 4
+        },
+        "max_employees": {
+          "name": "max_employees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pb_url": {
+          "name": "pb_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pagarme_customer_id": {
+          "name": "pagarme_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "organization_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "organization_profiles_organization_id_idx": {
+          "name": "organization_profiles_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_profiles_tax_id_idx": {
+          "name": "organization_profiles_tax_id_idx",
+          "columns": [
+            {
+              "expression": "tax_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_profiles_status_idx": {
+          "name": "organization_profiles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_profiles_industry_idx": {
+          "name": "organization_profiles_industry_idx",
+          "columns": [
+            {
+              "expression": "industry",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_profiles_organization_id_organizations_id_fk": {
+          "name": "organization_profiles_organization_id_organizations_id_fk",
+          "tableFrom": "organization_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_profiles_tax_id_unique": {
+          "name": "organization_profiles_tax_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tax_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -6760,8 +5680,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.job_classifications": {
-      "name": "job_classifications",
+    "public.ppe_deliveries": {
+      "name": "ppe_deliveries",
       "schema": "",
       "columns": {
         "id": {
@@ -6776,160 +5696,27 @@
           "primaryKey": false,
           "notNull": true
         },
-        "name": {
-          "name": "name",
+        "employee_id": {
+          "name": "employee_id",
           "type": "text",
           "primaryKey": false,
           "notNull": true
         },
-        "cbo_occupation_id": {
-          "name": "cbo_occupation_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "job_classifications_organization_id_idx": {
-          "name": "job_classifications_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "job_classifications_name_idx": {
-          "name": "job_classifications_name_idx",
-          "columns": [
-            {
-              "expression": "name",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "job_classifications_organization_id_organizations_id_fk": {
-          "name": "job_classifications_organization_id_organizations_id_fk",
-          "tableFrom": "job_classifications",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "job_classifications_cbo_occupation_id_cbo_occupations_id_fk": {
-          "name": "job_classifications_cbo_occupation_id_cbo_occupations_id_fk",
-          "tableFrom": "job_classifications",
-          "tableTo": "cbo_occupations",
-          "columnsFrom": [
-            "cbo_occupation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "no action",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.projects": {
-      "name": "projects",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "varchar(255)",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "start_date": {
-          "name": "start_date",
+        "delivery_date": {
+          "name": "delivery_date",
           "type": "date",
           "primaryKey": false,
           "notNull": true
         },
-        "cno": {
-          "name": "cno",
-          "type": "varchar(12)",
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_by": {
+          "name": "delivered_by",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },
@@ -6973,8 +5760,8 @@
         }
       },
       "indexes": {
-        "projects_organization_id_idx": {
-          "name": "projects_organization_id_idx",
+        "ppe_deliveries_organization_id_idx": {
+          "name": "ppe_deliveries_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -6988,11 +5775,11 @@
           "method": "btree",
           "with": {}
         },
-        "projects_cno_idx": {
-          "name": "projects_cno_idx",
+        "ppe_deliveries_employee_id_idx": {
+          "name": "ppe_deliveries_employee_id_idx",
           "columns": [
             {
-              "expression": "cno",
+              "expression": "employee_id",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -7003,11 +5790,11 @@
           "method": "btree",
           "with": {}
         },
-        "projects_start_date_idx": {
-          "name": "projects_start_date_idx",
+        "ppe_deliveries_delivery_date_idx": {
+          "name": "ppe_deliveries_delivery_date_idx",
           "columns": [
             {
-              "expression": "start_date",
+              "expression": "delivery_date",
               "isExpression": false,
               "asc": true,
               "nulls": "last"
@@ -7020,12 +5807,25 @@
         }
       },
       "foreignKeys": {
-        "projects_organization_id_organizations_id_fk": {
-          "name": "projects_organization_id_organizations_id_fk",
-          "tableFrom": "projects",
+        "ppe_deliveries_organization_id_organizations_id_fk": {
+          "name": "ppe_deliveries_organization_id_organizations_id_fk",
+          "tableFrom": "ppe_deliveries",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ppe_deliveries_employee_id_employees_id_fk": {
+          "name": "ppe_deliveries_employee_id_employees_id_fk",
+          "tableFrom": "ppe_deliveries",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
           ],
           "columnsTo": [
             "id"
@@ -7036,209 +5836,6 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.billing_profiles": {
-      "name": "billing_profiles",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "organization_id": {
-          "name": "organization_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "legal_name": {
-          "name": "legal_name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "tax_id": {
-          "name": "tax_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "email": {
-          "name": "email",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "phone": {
-          "name": "phone",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "street": {
-          "name": "street",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "number": {
-          "name": "number",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "complement": {
-          "name": "complement",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "neighborhood": {
-          "name": "neighborhood",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "city": {
-          "name": "city",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "state": {
-          "name": "state",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "zip_code": {
-          "name": "zip_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "pagarme_customer_id": {
-          "name": "pagarme_customer_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "created_by": {
-          "name": "created_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "updated_by": {
-          "name": "updated_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_at": {
-          "name": "deleted_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "deleted_by": {
-          "name": "deleted_by",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "billing_profiles_organization_id_idx": {
-          "name": "billing_profiles_organization_id_idx",
-          "columns": [
-            {
-              "expression": "organization_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "billing_profiles_tax_id_idx": {
-          "name": "billing_profiles_tax_id_idx",
-          "columns": [
-            {
-              "expression": "tax_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "billing_profiles_pagarme_customer_id_idx": {
-          "name": "billing_profiles_pagarme_customer_id_idx",
-          "columns": [
-            {
-              "expression": "pagarme_customer_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "billing_profiles_organization_id_organizations_id_fk": {
-          "name": "billing_profiles_organization_id_organizations_id_fk",
-          "tableFrom": "billing_profiles",
-          "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {
-        "billing_profiles_organization_id_unique": {
-          "name": "billing_profiles_organization_id_unique",
-          "nullsNotDistinct": false,
-          "columns": [
-            "organization_id"
-          ]
-        }
-      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -7413,6 +6010,121 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.ppe_delivery_logs": {
+      "name": "ppe_delivery_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ppe_delivery_id": {
+          "name": "ppe_delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ppe_item_id": {
+          "name": "ppe_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "ppe_delivery_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ppe_delivery_logs_ppe_delivery_id_idx": {
+          "name": "ppe_delivery_logs_ppe_delivery_id_idx",
+          "columns": [
+            {
+              "expression": "ppe_delivery_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ppe_delivery_logs_ppe_item_id_idx": {
+          "name": "ppe_delivery_logs_ppe_item_id_idx",
+          "columns": [
+            {
+              "expression": "ppe_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ppe_delivery_logs_ppe_delivery_id_ppe_deliveries_id_fk": {
+          "name": "ppe_delivery_logs_ppe_delivery_id_ppe_deliveries_id_fk",
+          "tableFrom": "ppe_delivery_logs",
+          "tableTo": "ppe_deliveries",
+          "columnsFrom": [
+            "ppe_delivery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ppe_delivery_logs_ppe_item_id_ppe_items_id_fk": {
+          "name": "ppe_delivery_logs_ppe_item_id_ppe_items_id_fk",
+          "tableFrom": "ppe_delivery_logs",
+          "tableTo": "ppe_items",
+          "columnsFrom": [
+            "ppe_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.ppe_items": {
       "name": "ppe_items",
       "schema": "",
@@ -7539,8 +6251,348 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.job_positions": {
-      "name": "job_positions",
+    "public.ppe_job_positions": {
+      "name": "ppe_job_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ppe_item_id": {
+          "name": "ppe_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "job_position_id": {
+          "name": "job_position_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ppe_job_positions_organization_id_idx": {
+          "name": "ppe_job_positions_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ppe_job_positions_ppe_item_id_idx": {
+          "name": "ppe_job_positions_ppe_item_id_idx",
+          "columns": [
+            {
+              "expression": "ppe_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ppe_job_positions_job_position_id_idx": {
+          "name": "ppe_job_positions_job_position_id_idx",
+          "columns": [
+            {
+              "expression": "job_position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ppe_job_positions_unique_idx": {
+          "name": "ppe_job_positions_unique_idx",
+          "columns": [
+            {
+              "expression": "ppe_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ppe_job_positions_organization_id_organizations_id_fk": {
+          "name": "ppe_job_positions_organization_id_organizations_id_fk",
+          "tableFrom": "ppe_job_positions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ppe_job_positions_ppe_item_id_ppe_items_id_fk": {
+          "name": "ppe_job_positions_ppe_item_id_ppe_items_id_fk",
+          "tableFrom": "ppe_job_positions",
+          "tableTo": "ppe_items",
+          "columnsFrom": [
+            "ppe_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ppe_job_positions_job_position_id_job_positions_id_fk": {
+          "name": "ppe_job_positions_job_position_id_job_positions_id_fk",
+          "tableFrom": "ppe_job_positions",
+          "tableTo": "job_positions",
+          "columnsFrom": [
+            "job_position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_employees": {
+      "name": "project_employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "project_employees_organization_id_idx": {
+          "name": "project_employees_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_employees_project_id_idx": {
+          "name": "project_employees_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_employees_employee_id_idx": {
+          "name": "project_employees_employee_id_idx",
+          "columns": [
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_employees_unique_idx": {
+          "name": "project_employees_unique_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "deleted_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_employees_organization_id_organizations_id_fk": {
+          "name": "project_employees_organization_id_organizations_id_fk",
+          "tableFrom": "project_employees",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_employees_project_id_projects_id_fk": {
+          "name": "project_employees_project_id_projects_id_fk",
+          "tableFrom": "project_employees",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_employees_employee_id_employees_id_fk": {
+          "name": "project_employees_employee_id_employees_id_fk",
+          "tableFrom": "project_employees",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
       "schema": "",
       "columns": {
         "id": {
@@ -7557,12 +6609,195 @@
         },
         "name": {
           "name": "name",
-          "type": "text",
+          "type": "varchar(255)",
           "primaryKey": false,
           "notNull": true
         },
         "description": {
           "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cno": {
+          "name": "cno",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "projects_organization_id_idx": {
+          "name": "projects_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cno_idx": {
+          "name": "projects_cno_idx",
+          "columns": [
+            {
+              "expression": "cno",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_start_date_idx": {
+          "name": "projects_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_organization_id_organizations_id_fk": {
+          "name": "projects_organization_id_organizations_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promotions": {
+      "name": "promotions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "promotion_date": {
+          "name": "promotion_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_job_position_id": {
+          "name": "previous_job_position_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_job_position_id": {
+          "name": "new_job_position_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_salary": {
+          "name": "previous_salary",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_salary": {
+          "name": "new_salary",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
           "type": "text",
           "primaryKey": false,
           "notNull": false
@@ -7607,8 +6842,8 @@
         }
       },
       "indexes": {
-        "job_positions_organization_id_idx": {
-          "name": "job_positions_organization_id_idx",
+        "promotions_organization_id_idx": {
+          "name": "promotions_organization_id_idx",
           "columns": [
             {
               "expression": "organization_id",
@@ -7622,8 +6857,161 @@
           "method": "btree",
           "with": {}
         },
-        "job_positions_name_idx": {
-          "name": "job_positions_name_idx",
+        "promotions_employee_id_idx": {
+          "name": "promotions_employee_id_idx",
+          "columns": [
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "promotions_organization_id_organizations_id_fk": {
+          "name": "promotions_organization_id_organizations_id_fk",
+          "tableFrom": "promotions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promotions_employee_id_employees_id_fk": {
+          "name": "promotions_employee_id_employees_id_fk",
+          "tableFrom": "promotions",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promotions_previous_job_position_id_job_positions_id_fk": {
+          "name": "promotions_previous_job_position_id_job_positions_id_fk",
+          "tableFrom": "promotions",
+          "tableTo": "job_positions",
+          "columnsFrom": [
+            "previous_job_position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "promotions_new_job_position_id_job_positions_id_fk": {
+          "name": "promotions_new_job_position_id_job_positions_id_fk",
+          "tableFrom": "promotions",
+          "tableTo": "job_positions",
+          "columnsFrom": [
+            "new_job_position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sectors": {
+      "name": "sectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sectors_organization_id_idx": {
+          "name": "sectors_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sectors_name_idx": {
+          "name": "sectors_name_idx",
           "columns": [
             {
               "expression": "name",
@@ -7639,9 +7027,9 @@
         }
       },
       "foreignKeys": {
-        "job_positions_organization_id_organizations_id_fk": {
-          "name": "job_positions_organization_id_organizations_id_fk",
-          "tableFrom": "job_positions",
+        "sectors_organization_id_organizations_id_fk": {
+          "name": "sectors_organization_id_organizations_id_fk",
+          "tableFrom": "sectors",
           "tableTo": "organizations",
           "columnsFrom": [
             "organization_id"
@@ -7658,15 +7046,686 @@
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
+    },
+    "public.terminations": {
+      "name": "terminations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "termination_date": {
+          "name": "termination_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "termination_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notice_period_days": {
+          "name": "notice_period_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notice_period_worked": {
+          "name": "notice_period_worked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_working_day": {
+          "name": "last_working_day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "terminations_organization_id_idx": {
+          "name": "terminations_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminations_employee_id_idx": {
+          "name": "terminations_employee_id_idx",
+          "columns": [
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminations_termination_date_idx": {
+          "name": "terminations_termination_date_idx",
+          "columns": [
+            {
+              "expression": "termination_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "terminations_type_idx": {
+          "name": "terminations_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "terminations_organization_id_organizations_id_fk": {
+          "name": "terminations_organization_id_organizations_id_fk",
+          "tableFrom": "terminations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminations_employee_id_employees_id_fk": {
+          "name": "terminations_employee_id_employees_id_fk",
+          "tableFrom": "terminations",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vacations": {
+      "name": "vacations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_used": {
+          "name": "days_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acquisition_period_start": {
+          "name": "acquisition_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquisition_period_end": {
+          "name": "acquisition_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concessive_period_start": {
+          "name": "concessive_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "concessive_period_end": {
+          "name": "concessive_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "days_entitled": {
+          "name": "days_entitled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "vacation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "vacations_organization_id_idx": {
+          "name": "vacations_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vacations_employee_id_idx": {
+          "name": "vacations_employee_id_idx",
+          "columns": [
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vacations_status_idx": {
+          "name": "vacations_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vacations_start_date_idx": {
+          "name": "vacations_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vacations_organization_id_organizations_id_fk": {
+          "name": "vacations_organization_id_organizations_id_fk",
+          "tableFrom": "vacations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vacations_employee_id_employees_id_fk": {
+          "name": "vacations_employee_id_employees_id_fk",
+          "tableFrom": "vacations",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.warnings": {
+      "name": "warnings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "warning_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "witness_name": {
+          "name": "witness_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged": {
+          "name": "acknowledged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "warnings_organization_id_idx": {
+          "name": "warnings_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "warnings_employee_id_idx": {
+          "name": "warnings_employee_id_idx",
+          "columns": [
+            {
+              "expression": "employee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "warnings_date_idx": {
+          "name": "warnings_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "warnings_organization_id_organizations_id_fk": {
+          "name": "warnings_organization_id_organizations_id_fk",
+          "tableFrom": "warnings",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "warnings_employee_id_employees_id_fk": {
+          "name": "warnings_employee_id_employees_id_fk",
+          "tableFrom": "warnings",
+          "tableTo": "employees",
+          "columnsFrom": [
+            "employee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
   "enums": {
+    "public.provision_status": {
+      "name": "provision_status",
+      "schema": "public",
+      "values": [
+        "pending_payment",
+        "pending_activation",
+        "active",
+        "deleted"
+      ]
+    },
+    "public.provision_type": {
+      "name": "provision_type",
+      "schema": "public",
+      "values": [
+        "trial",
+        "checkout"
+      ]
+    },
+    "public.member_role": {
+      "name": "member_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "manager",
+        "supervisor",
+        "viewer"
+      ]
+    },
+    "public.cpf_analysis_status": {
+      "name": "cpf_analysis_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "review"
+      ]
+    },
+    "public.risk_level": {
+      "name": "risk_level",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
     "public.contract_type": {
       "name": "contract_type",
       "schema": "public",
       "values": [
         "CLT",
         "PJ"
+      ]
+    },
+    "public.disability_type": {
+      "name": "disability_type",
+      "schema": "public",
+      "values": [
+        "AUDITIVA",
+        "VISUAL",
+        "FISICA",
+        "INTELECTUAL",
+        "MENTAL",
+        "MULTIPLA"
       ]
     },
     "public.education_level": {
@@ -7714,6 +7773,16 @@
         "SEPARATED"
       ]
     },
+    "public.work_shift": {
+      "name": "work_shift",
+      "schema": "public",
+      "values": [
+        "TWELVE_THIRTY_SIX",
+        "SIX_ONE",
+        "FIVE_TWO",
+        "FOUR_THREE"
+      ]
+    },
     "public.newsletter_status": {
       "name": "newsletter_status",
       "schema": "public",
@@ -7738,24 +7807,6 @@
       "values": [
         "ADDED",
         "REMOVED"
-      ]
-    },
-    "public.provision_status": {
-      "name": "provision_status",
-      "schema": "public",
-      "values": [
-        "pending_payment",
-        "pending_activation",
-        "active",
-        "deleted"
-      ]
-    },
-    "public.provision_type": {
-      "name": "provision_type",
-      "schema": "public",
-      "values": [
-        "trial",
-        "checkout"
       ]
     },
     "public.termination_type": {
@@ -7786,57 +7837,6 @@
         "verbal",
         "written",
         "suspension"
-      ]
-    },
-    "public.work_shift": {
-      "name": "work_shift",
-      "schema": "public",
-      "values": [
-        "TWELVE_THIRTY_SIX",
-        "SIX_ONE",
-        "FIVE_TWO",
-        "FOUR_THREE"
-      ]
-    },
-    "public.cpf_analysis_status": {
-      "name": "cpf_analysis_status",
-      "schema": "public",
-      "values": [
-        "pending",
-        "approved",
-        "rejected",
-        "review"
-      ]
-    },
-    "public.risk_level": {
-      "name": "risk_level",
-      "schema": "public",
-      "values": [
-        "low",
-        "medium",
-        "high"
-      ]
-    },
-    "public.member_role": {
-      "name": "member_role",
-      "schema": "public",
-      "values": [
-        "owner",
-        "manager",
-        "supervisor",
-        "viewer"
-      ]
-    },
-    "public.disability_type": {
-      "name": "disability_type",
-      "schema": "public",
-      "values": [
-        "AUDITIVA",
-        "VISUAL",
-        "FISICA",
-        "INTELECTUAL",
-        "MENTAL",
-        "MULTIPLA"
       ]
     },
     "public.adjustment_type": {

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1773069821829,
       "tag": "0027_absurd_eternals",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1773144458436,
+      "tag": "0027_panoramic_the_stranger",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/employees.ts
+++ b/src/db/schema/employees.ts
@@ -186,7 +186,7 @@ export const employees = pgTable(
     index("employees_job_position_id_idx").on(table.jobPositionId),
     uniqueIndex("employees_cpf_org_unique_idx")
       .on(table.cpf, table.organizationId)
-      .where(sql`deleted_at IS NULL`),
+      .where(sql`deleted_at IS NULL AND status != 'TERMINATED'`),
   ]
 );
 

--- a/src/lib/cron-plugin.ts
+++ b/src/lib/cron-plugin.ts
@@ -69,4 +69,36 @@ export const cronPlugin = new Elysia({ name: "cron-jobs" })
         });
       },
     })
+  )
+  .use(
+    cron({
+      name: "activate-scheduled-vacations",
+      pattern: "0 3 * * *", // 03:00 UTC = 00:00 BRT
+      async run() {
+        const { VacationJobsService } = await import(
+          "@/modules/occurrences/vacations/vacation-jobs.service"
+        );
+        const result = await VacationJobsService.activateScheduledVacations();
+        logger.info({
+          type: "cron:activate-scheduled-vacations",
+          updated: result.updated.length,
+        });
+      },
+    })
+  )
+  .use(
+    cron({
+      name: "complete-expired-vacations",
+      pattern: "0 3 * * *", // 03:00 UTC = 00:00 BRT
+      async run() {
+        const { VacationJobsService } = await import(
+          "@/modules/occurrences/vacations/vacation-jobs.service"
+        );
+        const result = await VacationJobsService.completeExpiredVacations();
+        logger.info({
+          type: "cron:complete-expired-vacations",
+          updated: result.updated.length,
+        });
+      },
+    })
   );

--- a/src/modules/employees/CLAUDE.md
+++ b/src/modules/employees/CLAUDE.md
@@ -5,7 +5,7 @@ Cadastro e gestão de funcionários vinculados a uma organização.
 ## Business Rules
 
 - Employee pertence a uma organization (multi-tenant via session.activeOrganizationId)
-- CPF é único por organização (não global) — validado em create e update
+- CPF é único por organização entre funcionários não-demitidos — funcionários com status `TERMINATED` não bloqueiam novo cadastro (recontratação). Validado em create, update e import bulk. Unique index parcial no DB: `WHERE deleted_at IS NULL AND status != 'TERMINATED'`
 - Criação verifica limite do plano de assinatura via `LimitsService.requireEmployeeLimit()`
 - Soft delete — nunca hard delete
 

--- a/src/modules/employees/__tests__/create-employee.test.ts
+++ b/src/modules/employees/__tests__/create-employee.test.ts
@@ -1,4 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { generateCpf } from "@/test/helpers/faker";
@@ -243,6 +246,63 @@ describe("POST /v1/employees", () => {
     expect(response.status).toBe(409);
     const body = await response.json();
     expect(body.error.code).toBe("EMPLOYEE_CPF_ALREADY_EXISTS");
+  });
+
+  test("should allow duplicate CPF when existing employee is TERMINATED", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const deps = await createTestDependencies(organizationId, user.id);
+
+    const sharedCpf = generateCpf();
+    const employeeData = createValidEmployeeData({
+      cpf: sharedCpf,
+      ...deps,
+    });
+
+    // Create first employee
+    const firstResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/employees`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(employeeData),
+      })
+    );
+    const firstBody = await firstResponse.json();
+    const firstEmployeeId = firstBody.data.id;
+
+    // Terminate the first employee
+    await db
+      .update(schema.employees)
+      .set({ status: "TERMINATED" })
+      .where(eq(schema.employees.id, firstEmployeeId));
+
+    // Create second employee with same CPF — should succeed
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/employees`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...employeeData,
+          name: "Recontratação",
+          email: "recontratacao@example.com",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.cpf).toBe(sharedCpf);
   });
 
   test("should reject invalid sector", async () => {

--- a/src/modules/employees/employee.service.ts
+++ b/src/modules/employees/employee.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, ne } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import type { EntityReference } from "@/lib/schemas/relationships";
@@ -264,7 +264,8 @@ export abstract class EmployeeService {
         and(
           eq(schema.employees.cpf, cpf),
           eq(schema.employees.organizationId, organizationId),
-          isNull(schema.employees.deletedAt)
+          isNull(schema.employees.deletedAt),
+          ne(schema.employees.status, "TERMINATED")
         )
       )
       .limit(1);

--- a/src/modules/employees/import/__tests__/import.service.test.ts
+++ b/src/modules/employees/import/__tests__/import.service.test.ts
@@ -298,6 +298,81 @@ describe("ImportService.importFromFile", () => {
     ).rejects.toBeInstanceOf(EmployeeImportLimitExceededError);
   });
 
+  test("allows import of CPF already used by a TERMINATED employee", async () => {
+    const cpf = generateCpf();
+
+    // Create an employee with this CPF directly in the DB, then terminate them
+    const employeeId = `employee-${crypto.randomUUID()}`;
+    await db.insert(schema.employees).values({
+      id: employeeId,
+      organizationId,
+      name: "Terminated Employee",
+      email: `terminated-${crypto.randomUUID().slice(0, 8)}@test.com`,
+      mobile: "11999887766",
+      birthDate: "1990-01-15",
+      gender: "MALE",
+      maritalStatus: "SINGLE",
+      birthplace: "São Paulo",
+      nationality: "Brasileiro",
+      motherName: "Maria",
+      cpf,
+      identityCard: "123456789",
+      pis: "12345678901",
+      workPermitNumber: "1234567",
+      workPermitSeries: "0001",
+      street: "Rua Test",
+      streetNumber: "1",
+      neighborhood: "Centro",
+      city: "São Paulo",
+      state: "SP",
+      zipCode: "01234567",
+      hireDate: "2024-01-15",
+      contractType: "CLT",
+      salary: "5000",
+      status: "TERMINATED",
+      sectorId: (
+        await db
+          .select({ id: schema.sectors.id })
+          .from(schema.sectors)
+          .where(eq(schema.sectors.organizationId, organizationId))
+          .limit(1)
+      )[0].id,
+      jobPositionId: (
+        await db
+          .select({ id: schema.jobPositions.id })
+          .from(schema.jobPositions)
+          .where(eq(schema.jobPositions.organizationId, organizationId))
+          .limit(1)
+      )[0].id,
+      jobClassificationId: (
+        await db
+          .select({ id: schema.jobClassifications.id })
+          .from(schema.jobClassifications)
+          .where(eq(schema.jobClassifications.organizationId, organizationId))
+          .limit(1)
+      )[0].id,
+      workShift: "FIVE_TWO",
+      weeklyHours: "44",
+      educationLevel: "BACHELOR",
+      hasSpecialNeeds: false,
+      hasChildren: false,
+      createdBy: userId,
+    });
+
+    // Import a new employee with the same CPF
+    const rows = [validRow({ cpf })];
+    const buffer = await buildWorkbookWithRows(templateBuffer, rows);
+
+    const result = await ImportService.importFromFile({
+      buffer,
+      organizationId,
+      userId,
+    });
+
+    expect(result.imported).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
   test("generates vacation acquisition periods for imported employees", async () => {
     const { registerEmployeeListeners } = await import(
       "@/modules/employees/hooks/listeners"

--- a/src/modules/employees/import/import.service.ts
+++ b/src/modules/employees/import/import.service.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne } from "drizzle-orm";
 import ExcelJS from "exceljs";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
@@ -272,7 +272,8 @@ export abstract class ImportService {
         and(
           eq(schema.employees.organizationId, organizationId),
           inArray(schema.employees.cpf, cpfs),
-          isNull(schema.employees.deletedAt)
+          isNull(schema.employees.deletedAt),
+          ne(schema.employees.status, "TERMINATED")
         )
       );
 

--- a/src/modules/occurrences/terminations/CLAUDE.md
+++ b/src/modules/occurrences/terminations/CLAUDE.md
@@ -8,6 +8,8 @@ Registro de desligamentos de funcionários.
 - `noticePeriodDays` (inteiro ≥ 0, opcional) + `noticePeriodWorked` (boolean, default false)
 - `reason` (max 1000), `notes` (max 2000) — opcionais
 - Um employee só pode ter um desligamento ativo (não deletado) — tentativa de criar segundo lança `TerminationAlreadyExistsError`
+- Criar desligamento altera automaticamente o status do funcionário para `TERMINATED`
+- Deletar (soft delete) desligamento reverte o status do funcionário para `ACTIVE`
 - Sem verificação de status do employee no create (diferente dos demais sub-módulos)
 - Permissão usa resource genérico `occurrence`, não `termination`
 - Listagem ordenada por `terminationDate`

--- a/src/modules/occurrences/terminations/__tests__/create-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/create-termination.test.ts
@@ -352,6 +352,47 @@ describe("POST /v1/terminations", () => {
     expect(body.error.code).toBe("TERMINATION_ALREADY_EXISTS");
   });
 
+  test("should set employee status to TERMINATED after creating termination", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const [beforeEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(beforeEmployee.status).toBe("ACTIVE");
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: "2024-02-15",
+          type: "RESIGNATION",
+          lastWorkingDay: "2024-02-15",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [afterEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(afterEmployee.status).toBe("TERMINATED");
+  });
+
   test("should allow creating termination when previous was soft-deleted", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({

--- a/src/modules/occurrences/terminations/__tests__/delete-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/delete-termination.test.ts
@@ -217,6 +217,41 @@ describe("DELETE /v1/terminations/:id", () => {
     expect(body.data.deletedBy).toBe(managerResult.user.id);
   });
 
+  test("should revert employee status to ACTIVE after deleting termination", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const termination = await createTestTermination({
+      organizationId,
+      userId: user.id,
+    });
+
+    const [beforeEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, termination.employee.id))
+      .limit(1);
+    expect(beforeEmployee.status).toBe("TERMINATED");
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations/${termination.id}`, {
+        method: "DELETE",
+        headers,
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [afterEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, termination.employee.id))
+      .limit(1);
+    expect(afterEmployee.status).toBe("ACTIVE");
+  });
+
   test("should not list deleted termination", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({

--- a/src/modules/occurrences/terminations/termination.service.ts
+++ b/src/modules/occurrences/terminations/termination.service.ts
@@ -176,6 +176,16 @@ export abstract class TerminationService {
       })
       .returning();
 
+    await db
+      .update(schema.employees)
+      .set({ status: "TERMINATED", updatedBy: userId })
+      .where(
+        and(
+          eq(schema.employees.id, employeeId),
+          eq(schema.employees.organizationId, organizationId)
+        )
+      );
+
     return {
       id: termination.id,
       organizationId: termination.organizationId,
@@ -297,6 +307,16 @@ export abstract class TerminationService {
         )
       )
       .returning();
+
+    await db
+      .update(schema.employees)
+      .set({ status: "ACTIVE", updatedBy: userId })
+      .where(
+        and(
+          eq(schema.employees.id, existing.employee.id),
+          eq(schema.employees.organizationId, organizationId)
+        )
+      );
 
     return {
       ...existing,

--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -20,6 +20,18 @@ Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias.
 - Listagem ordenada por `startDate`
 - Listagem por funcionario via `GET /v1/vacations/employee/:employeeId` -- retorna historico completo de ferias do employee
 
+## Employee Status Sync
+
+Criar, atualizar status ou deletar ferias sincroniza automaticamente o status do funcionario via `syncEmployeeStatus`:
+
+| Status da ferias | Status do funcionario |
+|---|---|
+| `scheduled` | `VACATION_SCHEDULED` |
+| `in_progress` | `ON_VACATION` |
+| `completed` / `canceled` / deletado | `ACTIVE` (se nao houver outras ferias ativas) |
+
+Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as ferias ativas (nao deletadas, nao canceladas, nao completadas) do funcionario para determinar o status correto.
+
 ## Enums
 
 - status: definido via `vacationStatusEnum` no DB (default: `scheduled`)
@@ -44,3 +56,14 @@ Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias.
 - `VacationConcessiveBeforeAcquisitionError` (422) -- concessivePeriodStart <= acquisitionPeriodEnd
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)
 - `EmployeeTerminatedError` (422) -- shared, from `src/lib/errors/employee-status-errors.ts`
+
+## Scheduled Jobs
+
+Jobs automaticos em `vacation-jobs.service.ts`, registrados em `src/lib/cron-plugin.ts` (03:00 UTC / 00:00 BRT diariamente):
+
+| Job | Acao |
+|---|---|
+| `activateScheduledVacations` | `scheduled` → `in_progress` quando `startDate <= hoje` |
+| `completeExpiredVacations` | `in_progress` → `completed` quando `endDate < hoje` |
+
+Ambos sincronizam o status do funcionario apos a transicao via `syncEmployeeStatus`.

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -521,4 +521,40 @@ describe("POST /v1/vacations", () => {
     const body = await response.json();
     expect(body.error.code).toBe("VACATION_CONCESSIVE_BEFORE_ACQUISITION");
   });
+
+  test("should set employee status to VACATION_SCHEDULED after creating vacation", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const startDate = "2025-06-01";
+    const endDate = "2025-06-10";
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate,
+          endDate,
+          daysEntitled: 10,
+          daysUsed: 0,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [updatedEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(updatedEmployee.status).toBe("VACATION_SCHEDULED");
+  });
 });

--- a/src/modules/occurrences/vacations/__tests__/delete-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/delete-vacation.test.ts
@@ -1,4 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestEmployee } from "@/test/helpers/employee";
@@ -241,5 +244,93 @@ describe("DELETE /v1/vacations/:id", () => {
     const body = await response.json();
     expect(body.success).toBe(true);
     expect(body.data.id).toBe(vacation.id);
+  });
+
+  test("should revert employee status to ACTIVE after deleting vacation", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const vacation = await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+    });
+
+    const [beforeEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(beforeEmployee.status).toBe("VACATION_SCHEDULED");
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${vacation.id}`, {
+        method: "DELETE",
+        headers,
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [afterEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(afterEmployee.status).toBe("ACTIVE");
+  });
+
+  test("should keep VACATION_SCHEDULED if another scheduled vacation exists after delete", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2020-01-01",
+    });
+
+    const vacation1 = await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-10",
+      daysEntitled: 10,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-09-01",
+      endDate: "2025-09-10",
+      daysEntitled: 10,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${vacation1.id}`, {
+        method: "DELETE",
+        headers,
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [afterEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(afterEmployee.status).toBe("VACATION_SCHEDULED");
   });
 });

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -1,4 +1,7 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
 import { env } from "@/env";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestEmployee } from "@/test/helpers/employee";
@@ -473,5 +476,126 @@ describe("PUT /v1/vacations/:id", () => {
     expect(response.status).toBe(422);
     const body = await response.json();
     expect(body.error.code).toBe("VACATION_CONCESSIVE_BEFORE_ACQUISITION");
+  });
+
+  test("should set employee status to ON_VACATION when vacation status changes to in_progress", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const vacation = await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      status: "scheduled",
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${vacation.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "in_progress" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [updatedEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(updatedEmployee.status).toBe("ON_VACATION");
+  });
+
+  test("should revert employee status to ACTIVE when vacation is completed", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const vacation = await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      status: "in_progress",
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${vacation.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "completed" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [updatedEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(updatedEmployee.status).toBe("ACTIVE");
+  });
+
+  test("should keep employee ON_VACATION if another vacation is in_progress when canceling one", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2020-01-01",
+    });
+
+    // First vacation: in_progress
+    await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-03-01",
+      endDate: "2025-03-10",
+      daysEntitled: 10,
+      daysUsed: 0,
+      status: "in_progress",
+    });
+
+    // Second vacation: scheduled (non-overlapping)
+    const secondVacation = await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-07-01",
+      endDate: "2025-07-10",
+      daysEntitled: 10,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    // Cancel the second vacation
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${secondVacation.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "canceled" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [updatedEmployee] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id))
+      .limit(1);
+    expect(updatedEmployee.status).toBe("ON_VACATION");
   });
 });

--- a/src/modules/occurrences/vacations/__tests__/vacation-jobs.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/vacation-jobs.test.ts
@@ -1,0 +1,210 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { createTestEmployee } from "@/test/helpers/employee";
+import { createTestUserWithOrganization } from "@/test/helpers/user";
+import { createTestVacation } from "@/test/helpers/vacation";
+import { VacationJobsService } from "../vacation-jobs.service";
+
+describe("VacationJobsService", () => {
+  let organizationId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const result = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+    organizationId = result.organizationId;
+    userId = result.user.id;
+  });
+
+  describe("activateScheduledVacations", () => {
+    test("should activate scheduled vacations where startDate <= today", async () => {
+      const { employee } = await createTestEmployee({
+        organizationId,
+        userId,
+      });
+
+      const today = new Date();
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      const startDate = yesterday.toISOString().split("T")[0];
+      const endDate = new Date(today.getTime() + 5 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split("T")[0];
+      const daysEntitled =
+        Math.round(
+          (new Date(`${endDate}T00:00:00Z`).getTime() -
+            new Date(`${startDate}T00:00:00Z`).getTime()) /
+            (1000 * 60 * 60 * 24)
+        ) + 1;
+
+      const vacation = await createTestVacation({
+        organizationId,
+        userId,
+        employeeId: employee.id,
+        startDate,
+        endDate,
+        daysEntitled,
+        daysUsed: 0,
+        status: "scheduled",
+      });
+
+      const result = await VacationJobsService.activateScheduledVacations();
+
+      expect(result.updated).toContain(vacation.id);
+
+      const [updatedVacation] = await db
+        .select({ status: schema.vacations.status })
+        .from(schema.vacations)
+        .where(eq(schema.vacations.id, vacation.id))
+        .limit(1);
+      expect(updatedVacation.status).toBe("in_progress");
+
+      const [updatedEmployee] = await db
+        .select({ status: schema.employees.status })
+        .from(schema.employees)
+        .where(eq(schema.employees.id, employee.id))
+        .limit(1);
+      expect(updatedEmployee.status).toBe("ON_VACATION");
+    });
+
+    test("should not activate future scheduled vacations", async () => {
+      const { employee } = await createTestEmployee({
+        organizationId,
+        userId,
+      });
+
+      const future = new Date();
+      future.setDate(future.getDate() + 30);
+      const startDate = future.toISOString().split("T")[0];
+      const endDateObj = new Date(future);
+      endDateObj.setDate(future.getDate() + 10);
+      const endDate = endDateObj.toISOString().split("T")[0];
+      const daysEntitled =
+        Math.round(
+          (new Date(`${endDate}T00:00:00Z`).getTime() -
+            new Date(`${startDate}T00:00:00Z`).getTime()) /
+            (1000 * 60 * 60 * 24)
+        ) + 1;
+
+      const vacation = await createTestVacation({
+        organizationId,
+        userId,
+        employeeId: employee.id,
+        startDate,
+        endDate,
+        daysEntitled,
+        daysUsed: 0,
+        status: "scheduled",
+      });
+
+      const result = await VacationJobsService.activateScheduledVacations();
+
+      expect(result.updated).not.toContain(vacation.id);
+
+      const [unchangedVacation] = await db
+        .select({ status: schema.vacations.status })
+        .from(schema.vacations)
+        .where(eq(schema.vacations.id, vacation.id))
+        .limit(1);
+      expect(unchangedVacation.status).toBe("scheduled");
+    });
+  });
+
+  describe("completeExpiredVacations", () => {
+    test("should complete in_progress vacations where endDate < today", async () => {
+      const { employee } = await createTestEmployee({
+        organizationId,
+        userId,
+      });
+
+      const today = new Date();
+      const startDate = new Date(today);
+      startDate.setDate(today.getDate() - 10);
+      const endDate = new Date(today);
+      endDate.setDate(today.getDate() - 1);
+      const startStr = startDate.toISOString().split("T")[0];
+      const endStr = endDate.toISOString().split("T")[0];
+      const daysEntitled =
+        Math.round(
+          (new Date(`${endStr}T00:00:00Z`).getTime() -
+            new Date(`${startStr}T00:00:00Z`).getTime()) /
+            (1000 * 60 * 60 * 24)
+        ) + 1;
+
+      const vacation = await createTestVacation({
+        organizationId,
+        userId,
+        employeeId: employee.id,
+        startDate: startStr,
+        endDate: endStr,
+        daysEntitled,
+        daysUsed: 0,
+        status: "in_progress",
+      });
+
+      const result = await VacationJobsService.completeExpiredVacations();
+
+      expect(result.updated).toContain(vacation.id);
+
+      const [updatedVacation] = await db
+        .select({ status: schema.vacations.status })
+        .from(schema.vacations)
+        .where(eq(schema.vacations.id, vacation.id))
+        .limit(1);
+      expect(updatedVacation.status).toBe("completed");
+
+      const [updatedEmployee] = await db
+        .select({ status: schema.employees.status })
+        .from(schema.employees)
+        .where(eq(schema.employees.id, employee.id))
+        .limit(1);
+      expect(updatedEmployee.status).toBe("ACTIVE");
+    });
+
+    test("should not complete in_progress vacations where endDate >= today", async () => {
+      const { employee } = await createTestEmployee({
+        organizationId,
+        userId,
+      });
+
+      const today = new Date();
+      const startDate = new Date(today);
+      startDate.setDate(today.getDate() - 5);
+      const endDate = new Date(today);
+      endDate.setDate(today.getDate() + 5);
+      const startStr = startDate.toISOString().split("T")[0];
+      const endStr = endDate.toISOString().split("T")[0];
+      const daysEntitled =
+        Math.round(
+          (new Date(`${endStr}T00:00:00Z`).getTime() -
+            new Date(`${startStr}T00:00:00Z`).getTime()) /
+            (1000 * 60 * 60 * 24)
+        ) + 1;
+
+      const vacation = await createTestVacation({
+        organizationId,
+        userId,
+        employeeId: employee.id,
+        startDate: startStr,
+        endDate: endStr,
+        daysEntitled,
+        daysUsed: 0,
+        status: "in_progress",
+      });
+
+      const result = await VacationJobsService.completeExpiredVacations();
+
+      expect(result.updated).not.toContain(vacation.id);
+
+      const [unchangedVacation] = await db
+        .select({ status: schema.vacations.status })
+        .from(schema.vacations)
+        .where(eq(schema.vacations.id, vacation.id))
+        .limit(1);
+      expect(unchangedVacation.status).toBe("in_progress");
+    });
+  });
+});

--- a/src/modules/occurrences/vacations/vacation-jobs.service.ts
+++ b/src/modules/occurrences/vacations/vacation-jobs.service.ts
@@ -1,0 +1,149 @@
+import { and, eq, isNull, lte, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { logger } from "@/lib/logger";
+
+type VacationJobResult = {
+  processed: number;
+  updated: string[];
+};
+
+export abstract class VacationJobsService {
+  private static async syncEmployeeStatus(
+    employeeId: string,
+    organizationId: string
+  ): Promise<void> {
+    const activeVacations = await db
+      .select({ status: schema.vacations.status })
+      .from(schema.vacations)
+      .where(
+        and(
+          eq(schema.vacations.employeeId, employeeId),
+          eq(schema.vacations.organizationId, organizationId),
+          isNull(schema.vacations.deletedAt),
+          sql`${schema.vacations.status} NOT IN ('canceled', 'completed')`
+        )
+      );
+
+    let employeeStatus: "ACTIVE" | "ON_VACATION" | "VACATION_SCHEDULED" =
+      "ACTIVE";
+
+    if (activeVacations.some((v) => v.status === "in_progress")) {
+      employeeStatus = "ON_VACATION";
+    } else if (activeVacations.some((v) => v.status === "scheduled")) {
+      employeeStatus = "VACATION_SCHEDULED";
+    }
+
+    await db
+      .update(schema.employees)
+      .set({ status: employeeStatus })
+      .where(
+        and(
+          eq(schema.employees.id, employeeId),
+          eq(schema.employees.organizationId, organizationId)
+        )
+      );
+  }
+
+  static async activateScheduledVacations(): Promise<VacationJobResult> {
+    const today = new Date().toISOString().split("T")[0];
+
+    const vacationsToActivate = await db
+      .select({
+        id: schema.vacations.id,
+        employeeId: schema.vacations.employeeId,
+        organizationId: schema.vacations.organizationId,
+      })
+      .from(schema.vacations)
+      .where(
+        and(
+          eq(schema.vacations.status, "scheduled"),
+          lte(schema.vacations.startDate, today),
+          isNull(schema.vacations.deletedAt)
+        )
+      );
+
+    const updated: string[] = [];
+
+    for (const vacation of vacationsToActivate) {
+      try {
+        await db
+          .update(schema.vacations)
+          .set({ status: "in_progress" })
+          .where(eq(schema.vacations.id, vacation.id));
+
+        await VacationJobsService.syncEmployeeStatus(
+          vacation.employeeId,
+          vacation.organizationId
+        );
+
+        updated.push(vacation.id);
+      } catch (error) {
+        logger.error({
+          type: "job:activate-vacation:failed",
+          vacationId: vacation.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    logger.info({
+      type: "job:activate-scheduled-vacations:complete",
+      processed: vacationsToActivate.length,
+      updated: updated.length,
+    });
+
+    return { processed: vacationsToActivate.length, updated };
+  }
+
+  static async completeExpiredVacations(): Promise<VacationJobResult> {
+    const today = new Date().toISOString().split("T")[0];
+
+    const vacationsToComplete = await db
+      .select({
+        id: schema.vacations.id,
+        employeeId: schema.vacations.employeeId,
+        organizationId: schema.vacations.organizationId,
+      })
+      .from(schema.vacations)
+      .where(
+        and(
+          eq(schema.vacations.status, "in_progress"),
+          sql`${schema.vacations.endDate} < ${today}`,
+          isNull(schema.vacations.deletedAt)
+        )
+      );
+
+    const updated: string[] = [];
+
+    for (const vacation of vacationsToComplete) {
+      try {
+        await db
+          .update(schema.vacations)
+          .set({ status: "completed" })
+          .where(eq(schema.vacations.id, vacation.id));
+
+        await VacationJobsService.syncEmployeeStatus(
+          vacation.employeeId,
+          vacation.organizationId
+        );
+
+        updated.push(vacation.id);
+      } catch (error) {
+        logger.error({
+          type: "job:complete-vacation:failed",
+          vacationId: vacation.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    logger.info({
+      type: "job:complete-expired-vacations:complete",
+      processed: vacationsToComplete.length,
+      updated: updated.length,
+    });
+
+    return { processed: vacationsToComplete.length, updated };
+  }
+}

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -188,6 +188,43 @@ export abstract class VacationService {
     }
   }
 
+  private static async syncEmployeeStatus(
+    employeeId: string,
+    organizationId: string,
+    userId: string
+  ): Promise<void> {
+    const activeVacations = await db
+      .select({ status: schema.vacations.status })
+      .from(schema.vacations)
+      .where(
+        and(
+          eq(schema.vacations.employeeId, employeeId),
+          eq(schema.vacations.organizationId, organizationId),
+          isNull(schema.vacations.deletedAt),
+          sql`${schema.vacations.status} NOT IN ('canceled', 'completed')`
+        )
+      );
+
+    let employeeStatus: "ACTIVE" | "ON_VACATION" | "VACATION_SCHEDULED" =
+      "ACTIVE";
+
+    if (activeVacations.some((v) => v.status === "in_progress")) {
+      employeeStatus = "ON_VACATION";
+    } else if (activeVacations.some((v) => v.status === "scheduled")) {
+      employeeStatus = "VACATION_SCHEDULED";
+    }
+
+    await db
+      .update(schema.employees)
+      .set({ status: employeeStatus, updatedBy: userId })
+      .where(
+        and(
+          eq(schema.employees.id, employeeId),
+          eq(schema.employees.organizationId, organizationId)
+        )
+      );
+  }
+
   private static async ensureNoOverlap(params: {
     organizationId: string;
     employeeId: string;
@@ -273,6 +310,12 @@ export abstract class VacationService {
       notes: data.notes,
       createdBy: userId,
     });
+
+    await VacationService.syncEmployeeStatus(
+      data.employeeId,
+      organizationId,
+      userId
+    );
 
     return {
       id: vacationId,
@@ -474,6 +517,14 @@ export abstract class VacationService {
         )
       );
 
+    if (data.status !== undefined) {
+      await VacationService.syncEmployeeStatus(
+        existing.employee.id,
+        organizationId,
+        userId
+      );
+    }
+
     return VacationService.findByIdOrThrow(id, organizationId);
   }
 
@@ -508,6 +559,12 @@ export abstract class VacationService {
         )
       )
       .returning();
+
+    await VacationService.syncEmployeeStatus(
+      existing.employee.id,
+      organizationId,
+      userId
+    );
 
     return {
       ...existing,


### PR DESCRIPTION
## Summary

- **CPF reuse para recontratação**: funcionários com status `TERMINATED` não bloqueiam mais cadastro com mesmo CPF (service, import bulk, e unique index no DB atualizados)
- **Termination → employee status**: criar desligamento seta `TERMINATED`, deletar reverte para `ACTIVE`
- **Vacation → employee status**: criar/atualizar/deletar férias sincroniza status do funcionário (`VACATION_SCHEDULED`, `ON_VACATION`, `ACTIVE`) com prioridade entre múltiplas férias ativas
- **Jobs automáticos de férias**: transição diária `scheduled→in_progress` (startDate<=hoje) e `in_progress→completed` (endDate<hoje) às 00:00 BRT
- **Migration 0027**: unique index `employees_cpf_org_unique_idx` agora exclui `TERMINATED`

## Test plan

- [x] Teste: CPF duplicado com funcionário TERMINATED permite novo cadastro (200)
- [x] Teste: CPF duplicado com funcionário ACTIVE bloqueia (409)
- [x] Teste: Import bulk aceita CPF de funcionário TERMINATED
- [x] Teste: Criar desligamento → status TERMINATED
- [x] Teste: Deletar desligamento → status ACTIVE
- [x] Teste: Criar férias → VACATION_SCHEDULED
- [x] Teste: Update férias in_progress → ON_VACATION
- [x] Teste: Update férias completed → ACTIVE
- [x] Teste: Prioridade in_progress > scheduled
- [x] Teste: Deletar férias → ACTIVE
- [x] Teste: Deletar férias com outra scheduled → mantém VACATION_SCHEDULED
- [x] Teste: Job ativa férias scheduled com startDate <= hoje
- [x] Teste: Job não ativa férias futuras
- [x] Teste: Job completa férias in_progress com endDate < hoje
- [x] Teste: Job não completa férias ainda em andamento

🤖 Generated with [Claude Code](https://claude.com/claude-code)