### PR TITLE
feat(payments): admin endpoint to adjust trial limits

### DIFF
--- a/src/modules/admin/organizations/__tests__/admin-organization-details.test.ts
+++ b/src/modules/admin/organizations/__tests__/admin-organization-details.test.ts
@@ -161,11 +161,12 @@ describe("GET /v1/admin/organizations/:id", () => {
     const { headers } = await createTestAdminUser();
     const organization = await createTestOrganization();
 
-    const { plan } = await PlanFactory.createPaid("gold");
+    const { plan, tiers } = await PlanFactory.createPaid("gold");
+    const tier = tiers[0];
     const subscriptionId = await SubscriptionFactory.createActive(
       organization.id,
       plan.id,
-      { billingCycle: "monthly" }
+      { billingCycle: "monthly", pricingTierId: tier.id }
     );
 
     const response = await app.handle(
@@ -187,6 +188,43 @@ describe("GET /v1/admin/organizations/:id", () => {
     expect(subscription.isTrial).toBe(false);
     expect(subscription.billingCycle).toBe("monthly");
     expect(subscription.isCustomPrice).toBe(false);
+    expect(subscription.maxEmployees).toBe(tier.maxEmployees);
+    expect(subscription.trialDays).toBeNull();
+    expect(subscription.trialEnd).toBeNull();
+  });
+
+  test("should return trial subscription with trialDays, trialEnd and maxEmployees", async () => {
+    const { headers } = await createTestAdminUser();
+    const organization = await createTestOrganization();
+
+    const { plan, tiers } = await PlanFactory.createTrial();
+    const tier = tiers[0];
+    await SubscriptionFactory.createTrial(organization.id, plan.id);
+
+    // Set pricingTierId to the trial tier
+    await db
+      .update(schema.orgSubscriptions)
+      .set({ pricingTierId: tier.id })
+      .where(eq(schema.orgSubscriptions.organizationId, organization.id));
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/admin/organizations/${organization.id}`, {
+        method: "GET",
+        headers,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    const { subscription } = body.data;
+    expect(subscription).not.toBeNull();
+    expect(subscription.isTrial).toBe(true);
+    expect(subscription.maxEmployees).toBe(tier.maxEmployees);
+    expect(subscription.trialDays).toBe(14);
+    expect(subscription.trialEnd).toBeDefined();
+    expect(subscription.trialEnd).not.toBeNull();
   });
 });
 

--- a/src/modules/admin/organizations/admin-organization.model.ts
+++ b/src/modules/admin/organizations/admin-organization.model.ts
@@ -135,6 +135,9 @@ const subscriptionDataSchema = z.object({
   priceAtPurchase: z.number().nullable(),
   isCustomPrice: z.boolean(),
   startDate: z.coerce.date().nullable(),
+  maxEmployees: z.number().nullable(),
+  trialDays: z.number().nullable(),
+  trialEnd: z.coerce.date().nullable(),
 });
 
 const organizationDetailsDataSchema = z.object({

--- a/src/modules/admin/organizations/admin-organization.service.ts
+++ b/src/modules/admin/organizations/admin-organization.service.ts
@@ -258,20 +258,42 @@ export abstract class AdminOrganizationService {
         priceAtPurchase: schema.orgSubscriptions.priceAtPurchase,
         isCustomPrice: schema.orgSubscriptions.isCustomPrice,
         startDate: schema.orgSubscriptions.currentPeriodStart,
+        maxEmployees: schema.planPricingTiers.maxEmployees,
+        trialStart: schema.orgSubscriptions.trialStart,
+        trialEnd: schema.orgSubscriptions.trialEnd,
       })
       .from(schema.orgSubscriptions)
       .innerJoin(
         schema.subscriptionPlans,
         eq(schema.orgSubscriptions.planId, schema.subscriptionPlans.id)
       )
+      .leftJoin(
+        schema.planPricingTiers,
+        eq(schema.orgSubscriptions.pricingTierId, schema.planPricingTiers.id)
+      )
       .where(eq(schema.orgSubscriptions.organizationId, organizationId))
       .limit(1);
 
     const subscription = subscriptionRow
       ? {
-          ...subscriptionRow,
+          id: subscriptionRow.id,
+          planName: subscriptionRow.planName,
+          status: subscriptionRow.status,
+          isTrial: subscriptionRow.isTrial,
           billingCycle: subscriptionRow.billingCycle ?? null,
           priceAtPurchase: subscriptionRow.priceAtPurchase ?? null,
+          isCustomPrice: subscriptionRow.isCustomPrice,
+          startDate: subscriptionRow.startDate,
+          maxEmployees: subscriptionRow.maxEmployees ?? null,
+          trialDays:
+            subscriptionRow.trialStart && subscriptionRow.trialEnd
+              ? Math.round(
+                  (subscriptionRow.trialEnd.getTime() -
+                    subscriptionRow.trialStart.getTime()) /
+                    (1000 * 60 * 60 * 24)
+                )
+              : null,
+          trialEnd: subscriptionRow.trialEnd ?? null,
         }
       : null;
 

--- a/src/modules/payments/admin-checkout/CLAUDE.md
+++ b/src/modules/payments/admin-checkout/CLAUDE.md
@@ -6,13 +6,15 @@ Cria um **plano privado dedicado** (`isPublic=false`) com faixa de funcionários
 ## Business Rules
 
 - Admin autenticado (role = admin ou super_admin)
-- Organização NÃO pode ter subscription paga ativa
+- Organização NÃO pode ter subscription paga ativa (trial é permitido)
 - `basePlanId` deve referenciar plano ativo e não-trial (herda features via `plan_features`)
 - `minEmployees >= 0`, `maxEmployees > minEmployees` (faixa livre, não precisa existir no catálogo)
 - `customPriceMonthly >= 100` centavos (R$ 1,00)
-- Preço anual: `calculateYearlyPrice(customPriceMonthly, basePlan.yearlyDiscountPercent)` — usa o desconto do plano base
+- Preço anual: `calculateYearlyPrice(customPriceMonthly, basePlan.yearlyDiscountPercent)` — usa o desconto do plano base. Fallback: **20%** se o plano base não definir `yearlyDiscountPercent`
 - Billing profile obrigatório — admin pode enviar dados de billing no payload para criação automática
 - Um plano Pagar.me dedicado é criado para cada checkout (não cacheado no tier)
+- Link de checkout expira em **24 horas** (`CHECKOUT_EXPIRATION_HOURS = 24`)
+- `discountPercentage` é calculado comparando `customPriceMonthly` com o `priceMonthly` do tier de catálogo que tem a mesma faixa (`minEmployees`/`maxEmployees`). Se não houver tier correspondente, retorna 0
 
 ## Invariantes do plano privado
 
@@ -27,11 +29,11 @@ Cria um **plano privado dedicado** (`isPublic=false`) com faixa de funcionários
 1. Validar admin + organização + plano base (ativo, não-trial)
 2. Garantir billing profile (criar se billing data informado, erro se ausente)
 3. Get/create customer no Pagar.me (via CustomerService)
-4. Calcular preço anual customizado
+4. Calcular preço anual customizado e desconto vs. catálogo
 5. Criar plano privado (`subscription_plans`) + 1 tier (`plan_pricing_tiers`) + copiar `plan_features` do plano base em transação
 6. Criar plano customizado no Pagar.me (`PagarmePlanService.createCustomPlan`)
 7. Criar payment link com metadata apontando para o plano privado
-8. Salvar pending checkout referenciando plano privado
+8. Salvar `pending_checkouts` com: `planId` (privado), `pricingTierId` (privado), `billingCycle`, `customPriceMonthly`, `customPriceYearly`, `pagarmePlanId`, `createdByAdminId`, `notes`, `expiresAt`
 9. Retornar link + dados do plano privado
 
 ## Input
@@ -40,7 +42,7 @@ Cria um **plano privado dedicado** (`isPublic=false`) com faixa de funcionários
 
 ## Output
 
-`checkoutUrl`, `paymentLinkId`, `privatePlanId`, `privateTierId`, `customPriceMonthly`, `customPriceYearly`, `basePlanDisplayName`, `minEmployees`, `maxEmployees`, `expiresAt`
+`checkoutUrl`, `paymentLinkId`, `privatePlanId`, `privateTierId`, `customPriceMonthly`, `customPriceYearly`, `catalogPriceMonthly`, `discountPercentage`, `basePlanDisplayName`, `minEmployees`, `maxEmployees`, `expiresAt`
 
 ## Payment Link Metadata
 
@@ -55,6 +57,10 @@ O webhook `subscription.created` resolve via metadata (`plan_id`, `pricing_tier_
 - `organizationId` no plano privado: org dona do plano
 - `basePlanId` no plano privado: plano público de origem (herança de features)
 - `archivedAt`: preenchido automaticamente quando subscription migra para outro plano
+
+## Consumidores
+
+- `AdminProvisionService.createWithCheckout()` — chama `AdminCheckoutService.create()` com `minEmployees: 0` fixo e `successUrl` construído automaticamente (`APP_URL/ativacao?email=<ownerEmail>`)
 
 ## Endpoint
 

--- a/src/modules/payments/admin-subscription/CLAUDE.md
+++ b/src/modules/payments/admin-subscription/CLAUDE.md
@@ -1,0 +1,49 @@
+# Admin Subscription
+
+Ajuste de limites de trial (maxEmployees e trialDays) em subscriptions existentes, pelo admin.
+
+## Endpoint
+
+| Método | Rota | Descrição |
+|--------|------|-----------|
+| PATCH | `/admin/subscriptions/:organizationId/trial-limits` | Ajusta maxEmployees e/ou trialDays de um trial |
+
+## Business Rules
+
+- Apenas admin (`requireAdmin: true`)
+- Subscription deve existir para a organização
+- Plano deve ser trial (`isTrial === true`)
+- Status aceitos: `active` ou `expired` (rejeita `canceled` e `past_due`)
+- `maxEmployees` >= quantidade atual de funcionários da org
+- Novo `trialEnd` (trialStart + trialDays) deve ser no futuro
+- Se trial expirado e novo `trialEnd` é futuro → reativa para `active`
+
+## Tier Imutável
+
+Quando `maxEmployees` é alterado, um **novo tier dedicado** é criado (preço 0, vinculado ao plano trial) e o `pricingTierId` da subscription é atualizado. O tier anterior não é modificado nem arquivado (pode ser compartilhado).
+
+## Input
+
+Ambos opcionais, mas pelo menos um obrigatório:
+- `maxEmployees` (1-1000) — novo limite de funcionários
+- `trialDays` (1-365) — nova duração, recalcula `trialEnd` a partir de `trialStart`
+
+## Response
+
+```json
+{
+  "organizationId": "string",
+  "status": "active",
+  "planName": "Trial",
+  "trialDays": 30,
+  "trialEnd": "2026-04-09T...",
+  "maxEmployees": 50,
+  "reactivated": false
+}
+```
+
+## Dependências
+
+- `SubscriptionNotFoundError` — `src/modules/payments/errors.ts`
+- `LimitsService.checkEmployeeLimit()` — `src/modules/payments/limits/limits.service.ts`
+- `PlansService.getTrialPlan()` — `src/modules/payments/plans/plans.service.ts`

--- a/src/modules/payments/admin-subscription/__tests__/update-trial-limits.test.ts
+++ b/src/modules/payments/admin-subscription/__tests__/update-trial-limits.test.ts
@@ -1,0 +1,354 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { env } from "@/env";
+import { EmployeeFactory } from "@/test/factories/employee.factory";
+import { PlanFactory } from "@/test/factories/payments/plan.factory";
+import { SubscriptionFactory } from "@/test/factories/payments/subscription.factory";
+import { UserFactory } from "@/test/factories/user.factory";
+import { createTestApp, type TestApp } from "@/test/support/app";
+
+const BASE_URL = env.API_URL;
+
+function buildEndpoint(organizationId: string) {
+  return `${BASE_URL}/v1/payments/admin/subscriptions/${organizationId}/trial-limits`;
+}
+
+async function createOrgWithTrialSubscription(
+  trialPlanId: string,
+  tierId: string
+) {
+  const { user, organizationId } = await UserFactory.createWithOrganization();
+  const orgId = organizationId as string;
+
+  await SubscriptionFactory.createTrial(orgId, trialPlanId);
+
+  await db
+    .update(schema.orgSubscriptions)
+    .set({ pricingTierId: tierId })
+    .where(eq(schema.orgSubscriptions.organizationId, orgId));
+
+  return { user, orgId };
+}
+
+describe("PATCH /admin/subscriptions/:organizationId/trial-limits", () => {
+  let app: TestApp;
+  let trialPlanResult: Awaited<ReturnType<typeof PlanFactory.createTrial>>;
+
+  beforeAll(async () => {
+    app = createTestApp();
+    trialPlanResult = await PlanFactory.createTrial();
+  });
+
+  // ── Authentication / Authorization ──────────────────────────────
+
+  test("should return 401 without session", async () => {
+    const response = await app.handle(
+      new Request(buildEndpoint("org-fake"), {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 50 }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("should return 403 for non-admin user", async () => {
+    const { headers } = await UserFactory.create();
+
+    const response = await app.handle(
+      new Request(buildEndpoint("org-fake"), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 50 }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  // ── Validation ──────────────────────────────────────────────────
+
+  test("should return 422 for empty body", async () => {
+    const { headers } = await UserFactory.createAdmin();
+
+    const response = await app.handle(
+      new Request(buildEndpoint("org-fake"), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  test("should return 422 for out-of-range values", async () => {
+    const { headers } = await UserFactory.createAdmin();
+
+    const response = await app.handle(
+      new Request(buildEndpoint("org-fake"), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 0, trialDays: 0 }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  // ── Business Rules ──────────────────────────────────────────────
+
+  test("should return 404 when subscription does not exist", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const randomOrgId = `org-${crypto.randomUUID()}`;
+
+    const response = await app.handle(
+      new Request(buildEndpoint(randomOrgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 50 }),
+      })
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error.code).toBe("SUBSCRIPTION_NOT_FOUND");
+  });
+
+  test("should return 400 when subscription is not trial", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const { organizationId } = await UserFactory.createWithOrganization();
+    const orgId = organizationId as string;
+
+    const paidPlan = await PlanFactory.createPaid("gold");
+    const tier = PlanFactory.getFirstTier(paidPlan);
+    await SubscriptionFactory.createActive(orgId, paidPlan.plan.id, {
+      pricingTierId: tier.id,
+    });
+
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 50 }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("SUBSCRIPTION_NOT_TRIAL");
+  });
+
+  test("should return 400 when trialDays results in past date", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const { organizationId } = await UserFactory.createWithOrganization();
+    const orgId = organizationId as string;
+
+    const subId = await SubscriptionFactory.createTrial(
+      orgId,
+      trialPlanResult.plan.id
+    );
+
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    await db
+      .update(schema.orgSubscriptions)
+      .set({ trialStart: thirtyDaysAgo })
+      .where(eq(schema.orgSubscriptions.id, subId));
+
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ trialDays: 5 }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("TRIAL_END_IN_PAST");
+  });
+
+  test("should return 400 when maxEmployees is less than current count", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const tier = PlanFactory.getFirstTier(trialPlanResult);
+    const { user, orgId } = await createOrgWithTrialSubscription(
+      trialPlanResult.plan.id,
+      tier.id
+    );
+
+    // Create 5 employees
+    for (let i = 0; i < 5; i++) {
+      await EmployeeFactory.create({
+        organizationId: orgId,
+        userId: user.id,
+      });
+    }
+
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 3 }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("TRIAL_MAX_EMPLOYEES_TOO_LOW");
+  });
+
+  // ── Success Cases ───────────────────────────────────────────────
+
+  test("should update maxEmployees only", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const tier = PlanFactory.getFirstTier(trialPlanResult);
+    const { orgId } = await createOrgWithTrialSubscription(
+      trialPlanResult.plan.id,
+      tier.id
+    );
+
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 50 }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.maxEmployees).toBe(50);
+    expect(body.data.reactivated).toBe(false);
+
+    // Verify DB: subscription points to new tier
+    const sub = await SubscriptionFactory.getByOrganizationId(orgId);
+    expect(sub?.pricingTierId).not.toBe(tier.id);
+
+    // Verify new tier has correct maxEmployees
+    const newTierId = sub?.pricingTierId ?? "";
+    const [newTier] = await db
+      .select()
+      .from(schema.planPricingTiers)
+      .where(eq(schema.planPricingTiers.id, newTierId))
+      .limit(1);
+    expect(newTier.maxEmployees).toBe(50);
+    expect(newTier.priceMonthly).toBe(0);
+
+    // Verify old tier was not modified
+    const [oldTier] = await db
+      .select()
+      .from(schema.planPricingTiers)
+      .where(eq(schema.planPricingTiers.id, tier.id))
+      .limit(1);
+    expect(oldTier.maxEmployees).toBe(tier.maxEmployees);
+  });
+
+  test("should update trialDays only", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const tier = PlanFactory.getFirstTier(trialPlanResult);
+    const { orgId } = await createOrgWithTrialSubscription(
+      trialPlanResult.plan.id,
+      tier.id
+    );
+
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ trialDays: 30 }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.trialDays).toBe(30);
+    expect(body.data.reactivated).toBe(false);
+
+    // Verify trialEnd was recalculated
+    const sub = await SubscriptionFactory.getByOrganizationId(orgId);
+    expect(sub).toBeDefined();
+    const trialStart = sub?.trialStart as Date;
+    const trialEnd = sub?.trialEnd as Date;
+    const expectedEnd = new Date(trialStart);
+    expectedEnd.setDate(expectedEnd.getDate() + 30);
+
+    // Allow 1 second tolerance for test execution time
+    expect(Math.abs(trialEnd.getTime() - expectedEnd.getTime())).toBeLessThan(
+      1000
+    );
+  });
+
+  test("should update both maxEmployees and trialDays", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const tier = PlanFactory.getFirstTier(trialPlanResult);
+    const { orgId } = await createOrgWithTrialSubscription(
+      trialPlanResult.plan.id,
+      tier.id
+    );
+
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ maxEmployees: 100, trialDays: 60 }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.maxEmployees).toBe(100);
+    expect(body.data.trialDays).toBe(60);
+    expect(body.data.reactivated).toBe(false);
+  });
+
+  test("should reactivate expired trial", async () => {
+    const { headers } = await UserFactory.createAdmin();
+    const { organizationId } = await UserFactory.createWithOrganization();
+    const orgId = organizationId as string;
+
+    const tier = PlanFactory.getFirstTier(trialPlanResult);
+
+    // Create expired trial
+    await SubscriptionFactory.createExpired(orgId, trialPlanResult.plan.id);
+
+    // Set trialStart to 20 days ago
+    const twentyDaysAgo = new Date();
+    twentyDaysAgo.setDate(twentyDaysAgo.getDate() - 20);
+    await db
+      .update(schema.orgSubscriptions)
+      .set({
+        trialStart: twentyDaysAgo,
+        pricingTierId: tier.id,
+      })
+      .where(eq(schema.orgSubscriptions.organizationId, orgId));
+
+    // Send trialDays: 30 → trialEnd = 20 days ago + 30 = 10 days from now
+    const response = await app.handle(
+      new Request(buildEndpoint(orgId), {
+        method: "PATCH",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ trialDays: 30 }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe("active");
+    expect(body.data.reactivated).toBe(true);
+    expect(body.data.trialDays).toBe(30);
+
+    // Verify DB status is active
+    const sub = await SubscriptionFactory.getByOrganizationId(orgId);
+    expect(sub?.status).toBe("active");
+  });
+});

--- a/src/modules/payments/admin-subscription/admin-subscription.model.ts
+++ b/src/modules/payments/admin-subscription/admin-subscription.model.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import { successResponseSchema } from "@/lib/responses/response.types";
+
+// ============================================================
+// INPUT
+// ============================================================
+
+export const updateTrialLimitsSchema = z
+  .object({
+    maxEmployees: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe("Novo limite máximo de funcionários"),
+    trialDays: z
+      .number()
+      .int()
+      .min(1)
+      .max(365)
+      .optional()
+      .describe(
+        "Nova duração do trial em dias (recalcula trialEnd a partir de trialStart)"
+      ),
+  })
+  .refine(
+    (data) => data.maxEmployees !== undefined || data.trialDays !== undefined,
+    {
+      message:
+        "Pelo menos um campo (maxEmployees ou trialDays) deve ser informado",
+    }
+  );
+
+export type UpdateTrialLimits = z.infer<typeof updateTrialLimitsSchema>;
+export type UpdateTrialLimitsInput = UpdateTrialLimits & {
+  organizationId: string;
+  adminUserId: string;
+};
+
+// ============================================================
+// RESPONSE
+// ============================================================
+
+export const trialLimitsDataSchema = z.object({
+  organizationId: z.string(),
+  status: z.string(),
+  planName: z.string(),
+  trialDays: z.number().int(),
+  trialEnd: z.string(),
+  maxEmployees: z.number().int(),
+  reactivated: z.boolean(),
+});
+
+export const updateTrialLimitsResponseSchema = successResponseSchema(
+  trialLimitsDataSchema
+);
+
+export type TrialLimitsData = z.infer<typeof trialLimitsDataSchema>;

--- a/src/modules/payments/admin-subscription/admin-subscription.service.ts
+++ b/src/modules/payments/admin-subscription/admin-subscription.service.ts
@@ -1,0 +1,176 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { SubscriptionNotFoundError } from "@/modules/payments/errors";
+import { LimitsService } from "@/modules/payments/limits/limits.service";
+import { PlansService } from "@/modules/payments/plans/plans.service";
+import type {
+  TrialLimitsData,
+  UpdateTrialLimitsInput,
+} from "./admin-subscription.model";
+import {
+  SubscriptionNotActiveOrExpiredError,
+  SubscriptionNotTrialError,
+  TrialEndInPastError,
+  TrialMaxEmployeesTooLowError,
+} from "./errors";
+
+type SubscriptionRow = {
+  subscription: typeof schema.orgSubscriptions.$inferSelect;
+  planName: string | null;
+  isTrial: boolean;
+  currentMaxEmployees: number | null;
+};
+
+async function fetchSubscriptionRow(
+  organizationId: string
+): Promise<SubscriptionRow> {
+  const [row] = await db
+    .select({
+      subscription: schema.orgSubscriptions,
+      planName: schema.subscriptionPlans.displayName,
+      isTrial: schema.subscriptionPlans.isTrial,
+      currentMaxEmployees: schema.planPricingTiers.maxEmployees,
+    })
+    .from(schema.orgSubscriptions)
+    .innerJoin(
+      schema.subscriptionPlans,
+      eq(schema.orgSubscriptions.planId, schema.subscriptionPlans.id)
+    )
+    .leftJoin(
+      schema.planPricingTiers,
+      eq(schema.orgSubscriptions.pricingTierId, schema.planPricingTiers.id)
+    )
+    .where(eq(schema.orgSubscriptions.organizationId, organizationId))
+    .limit(1);
+
+  if (!row) {
+    throw new SubscriptionNotFoundError(organizationId);
+  }
+
+  return row;
+}
+
+function validateSubscription(
+  row: SubscriptionRow,
+  organizationId: string
+): void {
+  if (!row.isTrial) {
+    throw new SubscriptionNotTrialError(organizationId);
+  }
+
+  const { status } = row.subscription;
+  if (status !== "active" && status !== "expired") {
+    throw new SubscriptionNotActiveOrExpiredError(status, organizationId);
+  }
+}
+
+async function validateMaxEmployees(
+  organizationId: string,
+  maxEmployees: number
+): Promise<void> {
+  const { current } = await LimitsService.checkEmployeeLimit(organizationId);
+  if (maxEmployees < current) {
+    throw new TrialMaxEmployeesTooLowError(maxEmployees, current);
+  }
+}
+
+function computeNewTrialEnd(
+  trialStart: Date | null,
+  trialDays: number
+): Date | undefined {
+  if (!trialStart) {
+    return;
+  }
+
+  const newTrialEnd = new Date(trialStart);
+  newTrialEnd.setDate(newTrialEnd.getDate() + trialDays);
+
+  if (newTrialEnd <= new Date()) {
+    throw new TrialEndInPastError(trialStart, newTrialEnd);
+  }
+
+  return newTrialEnd;
+}
+
+async function createDedicatedTier(maxEmployees: number): Promise<string> {
+  const trialPlan = await PlansService.getTrialPlan();
+  const tierId = `tier-${crypto.randomUUID()}`;
+  await db.insert(schema.planPricingTiers).values({
+    id: tierId,
+    planId: trialPlan.id,
+    minEmployees: 0,
+    maxEmployees,
+    priceMonthly: 0,
+    priceYearly: 0,
+  });
+  return tierId;
+}
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export abstract class AdminSubscriptionService {
+  static async updateTrialLimits(
+    input: UpdateTrialLimitsInput
+  ): Promise<TrialLimitsData> {
+    const { organizationId, maxEmployees, trialDays } = input;
+
+    const row = await fetchSubscriptionRow(organizationId);
+    validateSubscription(row, organizationId);
+
+    const { subscription, planName, currentMaxEmployees } = row;
+
+    if (maxEmployees !== undefined) {
+      await validateMaxEmployees(organizationId, maxEmployees);
+    }
+
+    const newTrialEnd =
+      trialDays !== undefined
+        ? computeNewTrialEnd(subscription.trialStart, trialDays)
+        : undefined;
+
+    const newTierId =
+      maxEmployees !== undefined
+        ? await createDedicatedTier(maxEmployees)
+        : undefined;
+
+    const wasExpired = subscription.status === "expired";
+    const reactivated = wasExpired && newTrialEnd !== undefined;
+
+    const updatePayload: Record<string, unknown> = {};
+    if (newTierId) {
+      updatePayload.pricingTierId = newTierId;
+    }
+    if (newTrialEnd) {
+      updatePayload.trialEnd = newTrialEnd;
+    }
+    if (reactivated) {
+      updatePayload.status = "active";
+    }
+
+    await db
+      .update(schema.orgSubscriptions)
+      .set(updatePayload)
+      .where(eq(schema.orgSubscriptions.organizationId, organizationId));
+
+    const finalMaxEmployees = maxEmployees ?? currentMaxEmployees ?? 0;
+    const finalTrialEnd = newTrialEnd ?? subscription.trialEnd;
+    const finalTrialDays =
+      subscription.trialStart && finalTrialEnd
+        ? Math.round(
+            (finalTrialEnd.getTime() - subscription.trialStart.getTime()) /
+              MS_PER_DAY
+          )
+        : 0;
+
+    return {
+      organizationId,
+      status: reactivated ? "active" : subscription.status,
+      planName: planName ?? "Trial",
+      trialDays: finalTrialDays,
+      trialEnd: finalTrialEnd?.toISOString() ?? "",
+      maxEmployees: finalMaxEmployees,
+      reactivated,
+    };
+  }
+}

--- a/src/modules/payments/admin-subscription/errors.ts
+++ b/src/modules/payments/admin-subscription/errors.ts
@@ -1,0 +1,52 @@
+import { PaymentError } from "@/modules/payments/errors";
+
+export class SubscriptionNotTrialError extends PaymentError {
+  status = 400;
+
+  constructor(organizationId: string) {
+    super(
+      `Assinatura da organização ${organizationId} não é um trial`,
+      "SUBSCRIPTION_NOT_TRIAL",
+      { organizationId }
+    );
+  }
+}
+
+export class TrialMaxEmployeesTooLowError extends PaymentError {
+  status = 400;
+
+  constructor(requested: number, current: number) {
+    super(
+      `Limite de funcionários (${requested}) não pode ser inferior à quantidade atual (${current})`,
+      "TRIAL_MAX_EMPLOYEES_TOO_LOW",
+      { requested, current }
+    );
+  }
+}
+
+export class TrialEndInPastError extends PaymentError {
+  status = 400;
+
+  constructor(trialStart: Date, computedTrialEnd: Date) {
+    super(
+      `A nova data de expiração do trial (${computedTrialEnd.toISOString()}) é no passado`,
+      "TRIAL_END_IN_PAST",
+      {
+        trialStart: trialStart.toISOString(),
+        computedTrialEnd: computedTrialEnd.toISOString(),
+      }
+    );
+  }
+}
+
+export class SubscriptionNotActiveOrExpiredError extends PaymentError {
+  status = 400;
+
+  constructor(status: string, organizationId: string) {
+    super(
+      `Assinatura com status "${status}" não pode ter limites ajustados`,
+      "SUBSCRIPTION_NOT_ACTIVE_OR_EXPIRED",
+      { status, organizationId }
+    );
+  }
+}

--- a/src/modules/payments/admin-subscription/index.ts
+++ b/src/modules/payments/admin-subscription/index.ts
@@ -1,0 +1,52 @@
+import { Elysia } from "elysia";
+import { isProduction } from "@/env";
+import { betterAuthPlugin } from "@/lib/auth-plugin";
+import { wrapSuccess } from "@/lib/responses/envelope";
+import {
+  badRequestErrorSchema,
+  forbiddenErrorSchema,
+  notFoundErrorSchema,
+  unauthorizedErrorSchema,
+  validationErrorSchema,
+} from "@/lib/responses/response.types";
+import {
+  updateTrialLimitsResponseSchema,
+  updateTrialLimitsSchema,
+} from "./admin-subscription.model";
+import { AdminSubscriptionService } from "./admin-subscription.service";
+
+export const adminSubscriptionController = new Elysia({
+  name: "admin-subscription",
+  prefix: "/admin/subscriptions",
+  detail: { tags: ["Payments - Admin Subscription"] },
+})
+  .use(betterAuthPlugin)
+  .patch(
+    "/:organizationId/trial-limits",
+    async ({ user, params, body }) =>
+      wrapSuccess(
+        await AdminSubscriptionService.updateTrialLimits({
+          ...body,
+          organizationId: params.organizationId,
+          adminUserId: user.id,
+        })
+      ),
+    {
+      auth: { requireAdmin: true },
+      body: updateTrialLimitsSchema,
+      response: {
+        200: updateTrialLimitsResponseSchema,
+        400: badRequestErrorSchema,
+        401: unauthorizedErrorSchema,
+        403: forbiddenErrorSchema,
+        404: notFoundErrorSchema,
+        422: validationErrorSchema,
+      },
+      detail: {
+        hide: isProduction,
+        summary: "Update trial limits",
+        description:
+          "Admin-only endpoint to adjust maxEmployees and/or trialDays on an active or expired trial subscription.",
+      },
+    }
+  );

--- a/src/modules/payments/index.ts
+++ b/src/modules/payments/index.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { adminCheckoutController } from "./admin-checkout";
 import { adminProvisionController } from "./admin-provision";
+import { adminSubscriptionController } from "./admin-subscription";
 import { billingController } from "./billing";
 import { checkoutController } from "./checkout";
 import { customerController } from "./customer";
@@ -29,6 +30,7 @@ export const paymentsController = new Elysia({
   .use(checkoutController)
   .use(adminCheckoutController)
   .use(adminProvisionController)
+  .use(adminSubscriptionController)
   .use(orphanedPlansController)
   .use(subscriptionController)
   .use(planChangeController)


### PR DESCRIPTION
## Summary

- Add `PATCH /v1/payments/admin/subscriptions/:organizationId/trial-limits` — admin-only endpoint to adjust `maxEmployees` and/or `trialDays` on existing trial subscriptions
- Expose `maxEmployees`, `trialDays`, and `trialEnd` in `GET /v1/admin/organizations/:id` subscription response
- Support reactivation of expired trials when new `trialEnd` is in the future

## Details

**New module `admin-subscription`:**
- `errors.ts` — 4 domain errors (not trial, max employees too low, trial end in past, invalid status)
- `admin-subscription.model.ts` — Zod schemas for input (both fields optional, at least one required) and response
- `admin-subscription.service.ts` — guards (trial-only, status active/expired, employee count, future trialEnd) + tier creation + subscription update
- `index.ts` — controller registered in payments module
- `CLAUDE.md` — module documentation

**Modified `admin/organizations`:**
- Added LEFT JOIN with `planPricingTiers` in details query
- Added `maxEmployees`, `trialDays`, `trialEnd` to subscription response schema

## Test plan

- [x] 12 tests for PATCH endpoint (401, 403, 422x2, 404, 400x3 guards, 200x4 success cases)
- [x] 13 tests for admin org details (existing 12 + 1 new for trial fields)
- [x] Lint passes (`npx ultracite check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)