### PR TITLE
fix(auth): add rate limit for verification email resend endpoint

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -468,6 +468,7 @@ export const auth = betterAuth({
       "/sign-up/*": { window: 60, max: 3 },
       "/two-factor/*": { window: 60, max: 3 },
       "/forgot-password/*": { window: 300, max: 3 },
+      "/send-verification-email": { window: 300, max: 3 },
       "/get-session": false,
     },
   },


### PR DESCRIPTION
Prevents abuse of the /send-verification-email endpoint by limiting to 3 requests per 5-minute window, matching the forgot-password policy.