### PR TITLE
fix(promotions): change salary fields from string to number in API

### DIFF
--- a/src/modules/occurrences/promotions/__tests__/create-promotion.test.ts
+++ b/src/modules/occurrences/promotions/__tests__/create-promotion.test.ts
@@ -30,8 +30,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: "job-position-123",
           newJobPositionId: "job-position-456",
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -51,8 +51,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: "job-position-123",
           newJobPositionId: "job-position-456",
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -92,8 +92,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: "",
           newJobPositionId: "",
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -127,8 +127,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: "job-position-123",
           newJobPositionId: "job-position-456",
           promotionDate: futureDateStr,
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -161,8 +161,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -196,8 +196,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: "job-position-nonexistent",
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -231,8 +231,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: "job-position-nonexistent",
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -266,8 +266,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: jobPosition.id,
           newJobPositionId: jobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -307,8 +307,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3000.00",
+          previousSalary: 3000,
+          newSalary: 3000,
         }),
       })
     );
@@ -348,8 +348,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
           reason: "Promoção por mérito",
           notes: "Excelente desempenho no último ano",
         }),
@@ -405,8 +405,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: prevPos1.id,
           newJobPositionId: newPos1.id,
           promotionDate: "2024-02-20",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -433,8 +433,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: prevPos2.id,
           newJobPositionId: newPos2.id,
           promotionDate: "2024-02-20",
-          previousSalary: "3600.00",
-          newSalary: "4200.00",
+          previousSalary: 3600,
+          newSalary: 4200,
         }),
       })
     );
@@ -478,8 +478,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -524,8 +524,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -578,8 +578,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -630,8 +630,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: previousJobPosition.id,
           newJobPositionId: newJobPosition.id,
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -665,8 +665,8 @@ describe("POST /v1/promotions", () => {
           previousJobPositionId: "job-position-123",
           newJobPositionId: "job-position-456",
           promotionDate: "2024-01-15",
-          previousSalary: "3000.00",
-          newSalary: "3600.00",
+          previousSalary: 3000,
+          newSalary: 3600,
         }),
       })
     );
@@ -674,5 +674,98 @@ describe("POST /v1/promotions", () => {
     expect(response.status).toBe(403);
     const body = await response.json();
     expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  test("should reject string salary values", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/promotions`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: "employee-123",
+          previousJobPositionId: "job-position-123",
+          newJobPositionId: "job-position-456",
+          promotionDate: "2024-01-15",
+          previousSalary: "3000.00",
+          newSalary: "3600.00",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  test("should reject negative salary values", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/promotions`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: "employee-123",
+          previousJobPositionId: "job-position-123",
+          newJobPositionId: "job-position-456",
+          promotionDate: "2024-01-15",
+          previousSalary: -100,
+          newSalary: 3600,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  test("should create promotion with decimal salary values", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const previousJobPosition = await createTestJobPosition({
+      organizationId,
+      userId: user.id,
+      name: "Analista Júnior",
+    });
+
+    const newJobPosition = await createTestJobPosition({
+      organizationId,
+      userId: user.id,
+      name: "Analista Pleno",
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/promotions`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          previousJobPositionId: previousJobPosition.id,
+          newJobPositionId: newJobPosition.id,
+          promotionDate: "2024-01-15",
+          previousSalary: 2608.6,
+          newSalary: 3100.0,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.previousSalary).toBeString();
+    expect(body.data.newSalary).toBeString();
   });
 });

--- a/src/modules/occurrences/promotions/__tests__/update-promotion.test.ts
+++ b/src/modules/occurrences/promotions/__tests__/update-promotion.test.ts
@@ -346,4 +346,59 @@ describe("PUT /v1/promotions/:id", () => {
     const body = await response.json();
     expect(body.error.code).toBe("FORBIDDEN");
   });
+
+  test("should update salary with number values", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { promotion } = await createTestPromotion({
+      organizationId,
+      userId: user.id,
+      previousSalary: 3000,
+      newSalary: 3600,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/promotions/${promotion.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          previousSalary: 3500,
+          newSalary: 4200,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.previousSalary).toBeString();
+    expect(body.data.newSalary).toBeString();
+  });
+
+  test("should reject update when new salary is not greater than previous", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { promotion } = await createTestPromotion({
+      organizationId,
+      userId: user.id,
+      previousSalary: 3000,
+      newSalary: 3600,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/promotions/${promotion.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          newSalary: 2000,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("INVALID_PROMOTION_DATA");
+  });
 });

--- a/src/modules/occurrences/promotions/promotion.model.ts
+++ b/src/modules/occurrences/promotions/promotion.model.ts
@@ -24,24 +24,12 @@ export const createPromotionSchema = z.object({
     .min(1, "ID do novo cargo é obrigatório")
     .describe("ID do novo cargo"),
   previousSalary: z
-    .string()
-    .refine(
-      (val) =>
-        !Number.isNaN(Number.parseFloat(val)) && Number.parseFloat(val) >= 0,
-      {
-        message: "Salário anterior deve ser um número válido e não negativo",
-      }
-    )
+    .number()
+    .min(0, "Salário anterior não pode ser negativo")
     .describe("Salário anterior"),
   newSalary: z
-    .string()
-    .refine(
-      (val) =>
-        !Number.isNaN(Number.parseFloat(val)) && Number.parseFloat(val) >= 0,
-      {
-        message: "Novo salário deve ser um número válido e não negativo",
-      }
-    )
+    .number()
+    .min(0, "Novo salário não pode ser negativo")
     .describe("Novo salário"),
   reason: z
     .string()

--- a/src/modules/occurrences/promotions/promotion.service.ts
+++ b/src/modules/occurrences/promotions/promotion.service.ts
@@ -15,6 +15,7 @@ import type {
   CreatePromotionInput,
   DeletedPromotionData,
   PromotionData,
+  UpdatePromotion,
   UpdatePromotionInput,
 } from "./promotion.model";
 
@@ -177,14 +178,47 @@ export abstract class PromotionService {
     return result ?? null;
   }
 
-  private static validateSalaryIncrease(
-    previousSalary: string,
-    newSalary: string
-  ): void {
-    const parsedPrevious = Number.parseFloat(previousSalary);
-    const parsedNew = Number.parseFloat(newSalary);
+  private static buildUpdateData(
+    data: UpdatePromotion,
+    userId: string
+  ): Record<string, unknown> {
+    const updateData: Record<string, unknown> = {
+      updatedBy: userId,
+    };
 
-    if (parsedNew <= parsedPrevious) {
+    if (data.employeeId !== undefined) {
+      updateData.employeeId = data.employeeId;
+    }
+    if (data.promotionDate !== undefined) {
+      updateData.promotionDate = data.promotionDate;
+    }
+    if (data.previousJobPositionId !== undefined) {
+      updateData.previousJobPositionId = data.previousJobPositionId;
+    }
+    if (data.newJobPositionId !== undefined) {
+      updateData.newJobPositionId = data.newJobPositionId;
+    }
+    if (data.previousSalary !== undefined) {
+      updateData.previousSalary = data.previousSalary.toString();
+    }
+    if (data.newSalary !== undefined) {
+      updateData.newSalary = data.newSalary.toString();
+    }
+    if (data.reason !== undefined) {
+      updateData.reason = data.reason;
+    }
+    if (data.notes !== undefined) {
+      updateData.notes = data.notes;
+    }
+
+    return updateData;
+  }
+
+  private static validateSalaryIncrease(
+    previousSalary: number,
+    newSalary: number
+  ): void {
+    if (newSalary <= previousSalary) {
       throw new InvalidPromotionDataError(
         "O novo salário deve ser maior que o salário anterior",
         { previousSalary, newSalary }
@@ -268,8 +302,8 @@ export abstract class PromotionService {
         promotionDate,
         previousJobPositionId,
         newJobPositionId,
-        previousSalary,
-        newSalary,
+        previousSalary: previousSalary.toString(),
+        newSalary: newSalary.toString(),
         reason: reason ?? null,
         notes: notes ?? null,
         createdBy: userId,
@@ -414,10 +448,11 @@ export abstract class PromotionService {
       );
     }
 
-    if (data.previousSalary || data.newSalary) {
+    if (data.previousSalary !== undefined || data.newSalary !== undefined) {
       const effectivePreviousSalary =
-        data.previousSalary ?? existing.previousSalary;
-      const effectiveNewSalary = data.newSalary ?? existing.newSalary;
+        data.previousSalary ?? Number.parseFloat(existing.previousSalary);
+      const effectiveNewSalary =
+        data.newSalary ?? Number.parseFloat(existing.newSalary);
       PromotionService.validateSalaryIncrease(
         effectivePreviousSalary,
         effectiveNewSalary
@@ -435,10 +470,7 @@ export abstract class PromotionService {
 
     await db
       .update(schema.promotions)
-      .set({
-        ...data,
-        updatedBy: userId,
-      })
+      .set(PromotionService.buildUpdateData(data, userId))
       .where(
         and(
           eq(schema.promotions.id, id),

--- a/src/test/helpers/promotion.ts
+++ b/src/test/helpers/promotion.ts
@@ -15,8 +15,8 @@ type PromotionOverrides = {
   previousJobPositionId?: string;
   newJobPositionId?: string;
   promotionDate?: string;
-  previousSalary?: string;
-  newSalary?: string;
+  previousSalary?: number;
+  newSalary?: number;
   reason?: string;
   notes?: string;
 };
@@ -94,9 +94,8 @@ export async function createTestPromotion(
     dependencies
   );
 
-  const previousSalary = overrides.previousSalary ?? "3000.00";
-  const newSalary =
-    overrides.newSalary ?? (Number.parseFloat(previousSalary) * 1.2).toFixed(2);
+  const previousSalary = overrides.previousSalary ?? 3000;
+  const newSalary = overrides.newSalary ?? previousSalary * 1.2;
 
   const promotion = await PromotionService.create({
     organizationId,


### PR DESCRIPTION
Fixes production crash where Brazilian decimal format (comma separator) passed string validation but was rejected by PostgreSQL. Salary fields now use z.number() with .toString() conversion in service, matching the established pattern from the employees module. Adds tests for string rejection, negative values, and decimal salary values.