### PR TITLE
fix(plans): prevent default trial plan from being archived on plan ch…

### DIFF
--- a/src/db/migrations/0038_fix-default-trial-plan-archived.sql
+++ b/src/db/migrations/0038_fix-default-trial-plan-archived.sql
@@ -1,0 +1,14 @@
+-- Fix: restore default trial plan that was incorrectly archived.
+--
+-- Root cause: subscription-mutation.service.ts and plan-change.service.ts
+-- archived any plan with is_public=false when a subscription changed plans.
+-- The default trial plan (plan-trial) has is_public=false but is a shared
+-- plan (organization_id IS NULL) — it should never be archived.
+--
+-- The archiving code has been fixed to only archive org-specific plans
+-- (organization_id IS NOT NULL).
+
+UPDATE "subscription_plans"
+SET "archived_at" = NULL
+WHERE "id" = 'plan-trial'
+  AND "archived_at" IS NOT NULL;

--- a/src/modules/payments/plan-change/__tests__/execute-scheduled-change.test.ts
+++ b/src/modules/payments/plan-change/__tests__/execute-scheduled-change.test.ts
@@ -478,9 +478,13 @@ describe("PlanChangeService.executeScheduledChange", () => {
       emailVerified: true,
     });
 
-    // Create a PRIVATE plan (custom plan for the org)
+    // Create a PRIVATE plan (org-specific custom plan — has organizationId)
     const { plan: privatePlan, tiers: privateTiers } =
-      await PlanFactory.createPaid("diamond", { isPublic: false });
+      await PlanFactory.createCustom({
+        organizationId,
+        basePlanId: "plan-diamond",
+        type: "diamond",
+      });
 
     // Create a PUBLIC catalog plan to downgrade to
     const { plan: publicPlan, tiers: publicTiers } =
@@ -595,6 +599,61 @@ describe("PlanChangeService.executeScheduledChange", () => {
       .limit(1);
 
     expect(diamondPlanAfter.archivedAt).toBeNull();
+
+    cancelSpy.mockRestore();
+  });
+
+  test("should NOT archive default trial plan after executing scheduled change", async () => {
+    const { organizationId } = await UserFactory.createWithOrganization({
+      emailVerified: true,
+    });
+
+    // Create a trial plan (no organizationId — shared default)
+    const { plan: trialPlan, tiers: trialTiers } =
+      await PlanFactory.createTrial();
+
+    // Create a PUBLIC catalog plan to change to
+    const { plan: paidPlan, tiers: paidTiers } =
+      await PlanFactory.createPaid("gold");
+
+    const subscriptionId = await SubscriptionFactory.createActive(
+      organizationId,
+      trialPlan.id
+    );
+
+    // Schedule a change to the paid plan
+    const scheduledAt = new Date();
+    scheduledAt.setDate(scheduledAt.getDate() - 1);
+
+    await db
+      .update(schema.orgSubscriptions)
+      .set({
+        pendingPlanId: paidPlan.id,
+        pendingBillingCycle: "monthly",
+        pendingPricingTierId: paidTiers[0].id,
+        pricingTierId: trialTiers[0].id,
+        planChangeAt: scheduledAt,
+      })
+      .where(eq(schema.orgSubscriptions.id, subscriptionId));
+
+    // Mock Pagarme cancel
+    const { PagarmeClient } = await import("@/modules/payments/pagarme/client");
+    const cancelSpy = spyOn(
+      PagarmeClient,
+      "cancelSubscription"
+    ).mockResolvedValue({} as never);
+
+    // Execute the scheduled change
+    await PlanChangeService.executeScheduledChange(subscriptionId);
+
+    // Verify the default trial plan was NOT archived
+    const [trialPlanAfter] = await db
+      .select()
+      .from(schema.subscriptionPlans)
+      .where(eq(schema.subscriptionPlans.id, trialPlan.id))
+      .limit(1);
+
+    expect(trialPlanAfter.archivedAt).toBeNull();
 
     cancelSpy.mockRestore();
   });

--- a/src/modules/payments/plan-change/plan-change.service.ts
+++ b/src/modules/payments/plan-change/plan-change.service.ts
@@ -1006,27 +1006,22 @@ export abstract class PlanChangeService {
   }
 
   /**
-   * Archives a private (custom) plan by setting archivedAt.
-   * Public plans are left untouched.
+   * Archives an org-specific (custom) plan by setting archivedAt.
+   * Plans without organizationId (shared/default plans) are never archived.
    */
   private static async archivePrivatePlan(
     tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
     planId: string
   ): Promise<void> {
-    const [plan] = await tx
-      .select({
-        id: schema.subscriptionPlans.id,
-        isPublic: schema.subscriptionPlans.isPublic,
-      })
-      .from(schema.subscriptionPlans)
-      .where(eq(schema.subscriptionPlans.id, planId));
-
-    if (plan && !plan.isPublic) {
-      await tx
-        .update(schema.subscriptionPlans)
-        .set({ archivedAt: new Date() })
-        .where(eq(schema.subscriptionPlans.id, plan.id));
-    }
+    await tx
+      .update(schema.subscriptionPlans)
+      .set({ archivedAt: new Date() })
+      .where(
+        and(
+          eq(schema.subscriptionPlans.id, planId),
+          isNotNull(schema.subscriptionPlans.organizationId)
+        )
+      );
   }
 
   /**

--- a/src/modules/payments/subscription/__tests__/subscription.service.test.ts
+++ b/src/modules/payments/subscription/__tests__/subscription.service.test.ts
@@ -634,11 +634,11 @@ describe("SubscriptionService", () => {
     test("should archive private plan when subscription changes to a different plan", async () => {
       const org = await OrganizationFactory.create();
 
-      // Create a private (custom) plan
-      const privatePlanResult = await PlanFactory.create({
+      // Create a private (org-specific custom) plan
+      const privatePlanResult = await PlanFactory.createCustom({
+        organizationId: org.id,
+        basePlanId: "plan-gold",
         type: "gold",
-        isPublic: false,
-        name: `custom-private-${crypto.randomUUID().slice(0, 8)}`,
       });
 
       // Create subscription on the private plan
@@ -709,6 +709,41 @@ describe("SubscriptionService", () => {
         .limit(1);
 
       expect(publicPlan.archivedAt).toBeNull();
+    });
+
+    test("should NOT archive default trial plan when subscription migrates to paid plan", async () => {
+      const org = await OrganizationFactory.create();
+
+      // Create subscription on the default trial plan (no organizationId)
+      await SubscriptionFactory.create(org.id, trialPlanResult.plan.id, {
+        status: "active",
+      });
+
+      // Create a paid plan to switch to
+      const paidPlanResult = await PlanFactory.createPaid("gold");
+
+      const periodStart = new Date();
+      const periodEnd = new Date();
+      periodEnd.setDate(periodEnd.getDate() + 30);
+
+      // Activate with the paid plan (simulates successful checkout after trial)
+      await SubscriptionService.activate({
+        organizationId: org.id,
+        pagarmeSubscriptionId: `sub_trial_to_paid_${crypto.randomUUID().slice(0, 8)}`,
+        periodStart,
+        periodEnd,
+        planId: paidPlanResult.plan.id,
+        pricingTierId: paidPlanResult.tiers[0].id,
+      });
+
+      // Verify the default trial plan was NOT archived
+      const [trialPlan] = await db
+        .select({ archivedAt: schema.subscriptionPlans.archivedAt })
+        .from(schema.subscriptionPlans)
+        .where(eq(schema.subscriptionPlans.id, trialPlanResult.plan.id))
+        .limit(1);
+
+      expect(trialPlan.archivedAt).toBeNull();
     });
   });
 

--- a/src/modules/payments/subscription/subscription-mutation.service.ts
+++ b/src/modules/payments/subscription/subscription-mutation.service.ts
@@ -312,25 +312,21 @@ export abstract class SubscriptionMutationService {
 
     const updatedSubscription = await updateById(subscription.id, updateData);
 
-    // Archive previous private plan if subscription changed to a different plan
+    // Archive previous private plan if subscription changed to a different plan.
+    // Only archive org-specific plans (organizationId set) — the default trial
+    // plan (organizationId=NULL) is shared and must never be archived.
     if (planId && subscription.planId !== planId) {
-      const { eq } = await import("drizzle-orm");
+      const { eq, and, isNotNull } = await import("drizzle-orm");
 
-      const [previousPlan] = await db
-        .select({
-          id: schema.subscriptionPlans.id,
-          isPublic: schema.subscriptionPlans.isPublic,
-        })
-        .from(schema.subscriptionPlans)
-        .where(eq(schema.subscriptionPlans.id, subscription.planId))
-        .limit(1);
-
-      if (previousPlan && !previousPlan.isPublic) {
-        await db
-          .update(schema.subscriptionPlans)
-          .set({ archivedAt: new Date() })
-          .where(eq(schema.subscriptionPlans.id, previousPlan.id));
-      }
+      await db
+        .update(schema.subscriptionPlans)
+        .set({ archivedAt: new Date() })
+        .where(
+          and(
+            eq(schema.subscriptionPlans.id, subscription.planId),
+            isNotNull(schema.subscriptionPlans.organizationId)
+          )
+        );
     }
 
     if (updatedSubscription) {


### PR DESCRIPTION
…ange

The archiving logic used !isPublic to identify private plans, but the default trial plan (plan-trial) has isPublic=false while being a shared plan (organizationId=NULL). Changed condition to isNotNull(organizationId) so only org-specific custom plans are archived. Includes migration to restore the archived trial plan and regression tests.