### PR TITLE
fix: validate employee count before checkout and plan changes

### DIFF
--- a/src/modules/payments/CLAUDE.md
+++ b/src/modules/payments/CLAUDE.md
@@ -11,6 +11,8 @@ Assinaturas, checkout, billing e integração Pagar.me. Módulo mais crítico do
 - Subscriptions ativas referenciam tiers arquivados normalmente (grandfathering)
 - Trial (default): exatamente 1 tier (0-10). Trial (privado/provision): 1 tier customizado. Paid: >= 1 tier, contíguos, sem gaps/overlaps, min >= 0, min <= max
 - Employee count não pode exceder `tier.maxEmployees`
+- Checkout (self-service e admin) valida que employee count cabe no `tier.maxEmployees` antes de criar payment link
+- Plan-change valida employee count em todas as mudancas (upgrade e downgrade), nao apenas downgrades
 - Webhooks são idempotentes (mesmo evento processado uma vez)
 - Customer ID e plan changes são atômicos (proteção contra race condition)
 - Preço customizado rastreado via `priceAtPurchase` e `isCustomPrice` em `org_subscriptions`

--- a/src/modules/payments/__tests__/downgrade-use-case.test.ts
+++ b/src/modules/payments/__tests__/downgrade-use-case.test.ts
@@ -572,7 +572,7 @@ describe("Downgrade Use Case: Bloqueio por Limite de Funcionários", () => {
       expect(response.status).toBe(400);
 
       const body = await response.json();
-      expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_NEW_PLAN_LIMIT");
+      expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT");
     });
 
     test("should allow downgrade to tier that fits employees", async () => {

--- a/src/modules/payments/admin-checkout/CLAUDE.md
+++ b/src/modules/payments/admin-checkout/CLAUDE.md
@@ -9,6 +9,7 @@ Cria um **plano privado dedicado** (`isPublic=false`) com faixa de funcionários
 - Organização NÃO pode ter subscription paga ativa (trial é permitido)
 - `basePlanId` deve referenciar plano ativo e não-trial (herda features via `plan_features`)
 - `minEmployees >= 0`, `maxEmployees > minEmployees` (faixa livre, não precisa existir no catálogo)
+- Employee count da org deve ser <= `maxEmployees` informado (validado antes de criar plano privado)
 - `customPriceMonthly >= 100` centavos (R$ 1,00)
 - Preço anual: `calculateYearlyPrice(customPriceMonthly, basePlan.yearlyDiscountPercent)` — usa o desconto do plano base. Fallback: **20%** se o plano base não definir `yearlyDiscountPercent`
 - Billing profile obrigatório — admin pode enviar dados de billing no payload para criação automática

--- a/src/modules/payments/admin-checkout/__tests__/admin-checkout.test.ts
+++ b/src/modules/payments/admin-checkout/__tests__/admin-checkout.test.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { env } from "@/env";
+import { EmployeeFactory } from "@/test/factories/employee.factory";
 import { OrganizationFactory } from "@/test/factories/organization.factory";
 import { BillingProfileFactory } from "@/test/factories/payments/billing-profile.factory";
 import {
@@ -313,6 +314,61 @@ describe("POST /v1/payments/admin/checkout", () => {
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error.code).toBe("BILLING_PROFILE_REQUIRED");
+  });
+
+  test("should reject admin checkout when employee count exceeds maxEmployees", async () => {
+    const { headers: adminHeaders } = await UserFactory.createAdmin();
+    const { organizationId, userId } =
+      await UserFactory.createWithOrganization();
+
+    // Create trial subscription
+    await SubscriptionFactory.createTrial(
+      organizationId,
+      trialPlanResult.plan.id
+    );
+
+    // Patch subscription to reference a gold tier with large maxEmployees
+    // so EmployeeFactory (which calls requireEmployeeLimit) can create employees.
+    // The second gold tier has maxEmployees=20, enough to hold 15 employees.
+    const secondTier = goldPlanResult.tiers[1];
+    if (!secondTier) {
+      throw new Error("goldPlanResult must have at least 2 tiers");
+    }
+    await db
+      .update(schema.orgSubscriptions)
+      .set({ pricingTierId: secondTier.id })
+      .where(eq(schema.orgSubscriptions.organizationId, organizationId));
+
+    // Create billing profile
+    await BillingProfileFactory.create({ organizationId });
+
+    // Create 15 employees (will exceed maxEmployees=10 in the payload)
+    await EmployeeFactory.createMany({
+      organizationId,
+      userId,
+      count: 15,
+    });
+
+    const response = await app.handle(
+      new Request(ENDPOINT, {
+        method: "POST",
+        headers: {
+          ...adminHeaders,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(
+          buildPayload({
+            organizationId,
+            basePlanId: goldPlanResult.plan.id,
+            maxEmployees: 10,
+          })
+        ),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT");
   });
 
   // ── Success — Pagarme integration ───────────────────────────────

--- a/src/modules/payments/admin-checkout/admin-checkout.service.ts
+++ b/src/modules/payments/admin-checkout/admin-checkout.service.ts
@@ -9,6 +9,7 @@ import {
   OrganizationNotFoundError,
   TrialPlanAsBaseError,
 } from "@/modules/payments/errors";
+import { LimitsService } from "@/modules/payments/limits/limits.service";
 import {
   PAGARME_RETRY_CONFIG,
   PagarmeClient,
@@ -63,6 +64,12 @@ export abstract class AdminCheckoutService {
     if (basePlan.isTrial) {
       throw new TrialPlanAsBaseError(basePlanId);
     }
+
+    // 3b. Validate employee count fits in the requested tier
+    await LimitsService.requireEmployeeCountFitsInTier(
+      organizationId,
+      maxEmployees
+    );
 
     // 4. Handle billing profile
     await AdminCheckoutService.ensureBillingProfile(organizationId, billing);

--- a/src/modules/payments/checkout/CLAUDE.md
+++ b/src/modules/payments/checkout/CLAUDE.md
@@ -10,6 +10,7 @@ Criação de links de pagamento via Pagar.me para ativação de assinatura.
 - Pricing tier deve existir
 - Billing cycle: `monthly` | `yearly`
 - Pending checkout expira em 24 horas
+- Employee count da org deve ser <= `tier.maxEmployees` do tier selecionado (validado antes de criar payment link)
 
 ## Flow
 
@@ -31,3 +32,4 @@ Criação de links de pagamento via Pagar.me para ativação de assinatura.
 
 - `EmailNotVerifiedError`, `SubscriptionAlreadyActiveError`
 - `PlanNotFoundError`, `PricingTierNotFoundError`
+- `EmployeeCountExceedsTierLimitError`

--- a/src/modules/payments/checkout/__tests__/create-checkout.test.ts
+++ b/src/modules/payments/checkout/__tests__/create-checkout.test.ts
@@ -4,6 +4,7 @@ import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { billingProfiles } from "@/db/schema/billing-profiles";
 import { env } from "@/env";
+import { EmployeeFactory } from "@/test/factories/employee.factory";
 import { OrganizationFactory } from "@/test/factories/organization.factory";
 import { BillingProfileFactory } from "@/test/factories/payments/billing-profile.factory";
 import {
@@ -779,5 +780,64 @@ describe("POST /v1/payments/checkout", () => {
     expect(response.status).toBe(404);
     const body = await response.json();
     expect(body.error.code).toBe("BILLING_PROFILE_NOT_FOUND");
+  });
+
+  test("should reject checkout when employee count exceeds tier maxEmployees", async () => {
+    const { headers, organizationId, userId } =
+      await UserFactory.createWithOrganization();
+
+    // Gold tier 0-10: maxEmployees=10. Use second gold tier (11-20) as subscription
+    // tier so EmployeeFactory can create 11 employees without hitting the limit.
+    const firstTier = PlanFactory.getFirstTier(goldPlanResult);
+    const secondTier = goldPlanResult.tiers[1];
+    if (!secondTier) {
+      throw new Error("goldPlanResult must have at least 2 tiers");
+    }
+
+    // Create trial subscription with a tier that allows >10 employees
+    await SubscriptionFactory.createTrial(
+      organizationId,
+      trialPlanResult.plan.id
+    );
+
+    // Also need an active subscription referencing a tier with enough capacity
+    // so EmployeeFactory (which calls requireEmployeeLimit) can insert employees.
+    // Patch the subscription to reference a gold tier with maxEmployees=20.
+    await db
+      .update(schema.orgSubscriptions)
+      .set({ pricingTierId: secondTier.id })
+      .where(eq(schema.orgSubscriptions.organizationId, organizationId));
+
+    // Verify email
+    await db
+      .update(schema.users)
+      .set({ emailVerified: true })
+      .where(eq(schema.users.id, userId));
+
+    // Create 11 employees — exceeds the first tier's maxEmployees (10)
+    await EmployeeFactory.createMany({
+      organizationId,
+      userId,
+      count: firstTier.maxEmployees + 1,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/payments/checkout`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          planId: goldPlanResult.plan.id,
+          tierId: firstTier.id,
+          successUrl: "https://example.com/success",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT");
   });
 });

--- a/src/modules/payments/checkout/checkout.service.ts
+++ b/src/modules/payments/checkout/checkout.service.ts
@@ -5,6 +5,7 @@ import { sendCheckoutLinkEmail } from "@/lib/email";
 import { Retry } from "@/lib/utils/retry";
 import { CustomerService } from "@/modules/payments/customer/customer.service";
 import { EmailNotVerifiedError } from "@/modules/payments/errors";
+import { LimitsService } from "@/modules/payments/limits/limits.service";
 import {
   PAGARME_RETRY_CONFIG,
   PagarmeClient,
@@ -42,6 +43,11 @@ export abstract class CheckoutService {
 
     const plan = await PlansService.getAvailableById(planId);
     const tier = await PlansService.getTierById(tierId);
+
+    await LimitsService.requireEmployeeCountFitsInTier(
+      organizationId,
+      tier.maxEmployees
+    );
 
     const pagarmePlanId = await PagarmePlanService.ensurePlan(
       tierId,

--- a/src/modules/payments/errors.ts
+++ b/src/modules/payments/errors.ts
@@ -458,6 +458,18 @@ export class EmployeeCountExceedsNewPlanLimitError extends PaymentError {
   }
 }
 
+export class EmployeeCountExceedsTierLimitError extends PaymentError {
+  status = 400;
+
+  constructor(currentCount: number, maxEmployees: number) {
+    super(
+      `A organização possui ${currentCount} funcionários ativos, mas o plano selecionado suporta até ${maxEmployees}. Remova ${currentCount - maxEmployees} funcionário(s) ou escolha um plano com limite maior.`,
+      "EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT",
+      { currentCount, maxEmployees, toRemove: currentCount - maxEmployees }
+    );
+  }
+}
+
 // Plans Module - Tier Errors
 
 export class TrialPlanNotFoundError extends PaymentError {

--- a/src/modules/payments/limits/limits.service.ts
+++ b/src/modules/payments/limits/limits.service.ts
@@ -371,6 +371,35 @@ export abstract class LimitsService {
     return Math.round((current / limit) * 100);
   }
 
+  /**
+   * Throws EmployeeCountExceedsTierLimitError if the organization's current
+   * employee count exceeds the given maxEmployees.
+   * Used to validate checkout/plan-change before creating payment links.
+   */
+  static async requireEmployeeCountFitsInTier(
+    organizationId: string,
+    maxEmployees: number
+  ): Promise<void> {
+    const [countResult] = await db
+      .select({ value: count() })
+      .from(schema.employees)
+      .where(
+        and(
+          eq(schema.employees.organizationId, organizationId),
+          isNull(schema.employees.deletedAt)
+        )
+      );
+
+    const current = countResult?.value ?? 0;
+
+    if (current > maxEmployees) {
+      const { EmployeeCountExceedsTierLimitError } = await import(
+        "@/modules/payments/errors"
+      );
+      throw new EmployeeCountExceedsTierLimitError(current, maxEmployees);
+    }
+  }
+
   private static async getPlanFeatures(
     organizationId: string
   ): Promise<string[]> {

--- a/src/modules/payments/limits/limits.service.ts
+++ b/src/modules/payments/limits/limits.service.ts
@@ -2,6 +2,7 @@ import { and, asc, count, eq, isNull, like } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import {
+  EmployeeCountExceedsTierLimitError,
   EmployeeLimitReachedError,
   FeatureNotAvailableError,
 } from "@/modules/payments/errors";
@@ -393,9 +394,6 @@ export abstract class LimitsService {
     const current = countResult?.value ?? 0;
 
     if (current > maxEmployees) {
-      const { EmployeeCountExceedsTierLimitError } = await import(
-        "@/modules/payments/errors"
-      );
       throw new EmployeeCountExceedsTierLimitError(current, maxEmployees);
     }
   }

--- a/src/modules/payments/plan-change/CLAUDE.md
+++ b/src/modules/payments/plan-change/CLAUDE.md
@@ -15,6 +15,12 @@ Upgrades imediatos e downgrades agendados com proration.
 - **Prioridade 2**: mesmo cycle, compara preço mensal normalizado
 - **Default**: upgrade se mesmo preço/cycle
 
+## Employee Count Validation
+
+- Valida employee count em **todas** as mudancas (upgrade e downgrade), nao apenas downgrades
+- Impede mudanca se `currentEmployeeCount > newTier.maxEmployees`
+- Erro: `EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT`
+
 ## Upgrade (imediato)
 
 - Proration: `(newPrice - currentPrice) × (remainingDays / totalDays)`
@@ -24,7 +30,6 @@ Upgrades imediatos e downgrades agendados com proration.
 
 ## Downgrade (agendado)
 
-- Valida se employee count cabe no novo tier
 - Armazena: `pendingPlanId`, `pendingBillingCycle`, `pendingPricingTierId`, `planChangeAt`
 - User mantém plano atual até fim do período
 - Job executa no fim do período: cancela Pagar.me atual, ativa novo plano

--- a/src/modules/payments/plan-change/__tests__/change-subscription.test.ts
+++ b/src/modules/payments/plan-change/__tests__/change-subscription.test.ts
@@ -284,7 +284,7 @@ describe("POST /v1/payments/subscription/change", () => {
       expect(body.error.code).toBe("YEARLY_BILLING_NOT_AVAILABLE");
     });
 
-    test("should return EMPLOYEE_COUNT_EXCEEDS_NEW_PLAN_LIMIT on downgrade with too many employees", async () => {
+    test("should return EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT on downgrade with too many employees", async () => {
       const result = await UserFactory.createWithOrganization({
         emailVerified: true,
       });
@@ -328,7 +328,71 @@ describe("POST /v1/payments/subscription/change", () => {
 
       expect(response.status).toBe(400);
       const body = await response.json();
-      expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_NEW_PLAN_LIMIT");
+      expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT");
+    });
+
+    test("should return EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT on upgrade with too many employees for target tier", async () => {
+      const result = await UserFactory.createWithOrganization({
+        emailVerified: true,
+      });
+
+      // Create two plans: gold (lower price) and diamond (higher price)
+      const { plan: goldPlan, tiers: goldTiers } =
+        await PlanFactory.createPaid("gold");
+      const { plan: diamondPlan, tiers: diamondTiers } =
+        await PlanFactory.createPaid("diamond");
+
+      const goldTier = goldTiers[1]; // 11-20 employees
+      const diamondTier = diamondTiers[0]; // 0-10 employees
+
+      // Make gold more expensive so that switching to diamond is a downgrade-by-price — wait, we need upgrade
+      // Make diamond more expensive (higher price = upgrade direction)
+      await db
+        .update(schema.planPricingTiers)
+        .set({ priceMonthly: 3000 })
+        .where(eq(schema.planPricingTiers.id, goldTier.id));
+
+      await db
+        .update(schema.planPricingTiers)
+        .set({ priceMonthly: 10_000 })
+        .where(eq(schema.planPricingTiers.id, diamondTier.id));
+
+      // Start on gold tier (11-20 employees, maxEmployees=20)
+      await SubscriptionFactory.create(result.organizationId, goldPlan.id, {
+        pricingTierId: goldTier.id,
+      });
+
+      // Create 15 employees — fits in goldTier (max 20) but not in diamondTier (max 10)
+      const { createTestEmployees } = await import("@/test/helpers/employee");
+      await createTestEmployees({
+        organizationId: result.organizationId,
+        userId: result.user.id,
+        count: 15,
+      });
+
+      await BillingProfileFactory.create({
+        organizationId: result.organizationId,
+      });
+
+      // Attempt upgrade to diamond plan with lower-capacity tier
+      const response = await app.handle(
+        new Request(ENDPOINT, {
+          method: "POST",
+          headers: {
+            ...result.headers,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            newPlanId: diamondPlan.id,
+            newTierId: diamondTier.id,
+            successUrl: "https://example.com/success",
+          }),
+        })
+      );
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body.error.code).toBe("EMPLOYEE_COUNT_EXCEEDS_TIER_LIMIT");
     });
 
     test("should return PLAN_NOT_FOUND for non-existent plan", async () => {

--- a/src/modules/payments/plan-change/plan-change.service.ts
+++ b/src/modules/payments/plan-change/plan-change.service.ts
@@ -119,13 +119,11 @@ export abstract class PlanChangeService {
       newBillingCycle: resolved.finalBillingCycle,
     });
 
-    // 8. If downgrade, validate employee count fits in new tier
-    if (changeType === "downgrade") {
-      await PlanChangeService.validateEmployeeCountForDowngrade(
-        organizationId,
-        newTier.maxEmployees
-      );
-    }
+    // 8. Validate employee count fits in new tier (all change types)
+    await LimitsService.requireEmployeeCountFitsInTier(
+      organizationId,
+      newTier.maxEmployees
+    );
 
     // 9. Process upgrade or schedule downgrade
     const planData = {

--- a/src/modules/payments/subscription/subscription-mutation.service.ts
+++ b/src/modules/payments/subscription/subscription-mutation.service.ts
@@ -312,6 +312,16 @@ export abstract class SubscriptionMutationService {
 
     const updatedSubscription = await updateById(subscription.id, updateData);
 
+    // Safety net: warn if employee count exceeds new tier limit
+    if (pricingTierId) {
+      await SubscriptionMutationService.warnIfEmployeeCountExceedsTier({
+        pricingTierId,
+        organizationId,
+        subscriptionId: subscription.id,
+        planId,
+      });
+    }
+
     // Archive previous private plan if subscription changed to a different plan.
     // Only archive org-specific plans (organizationId set) — the default trial
     // plan (organizationId=NULL) is shared and must never be archived.
@@ -336,6 +346,55 @@ export abstract class SubscriptionMutationService {
     }
 
     return updatedSubscription;
+  }
+
+  /**
+   * Logs a warning if the active employee count exceeds the tier's maxEmployees.
+   * Called after activation as a non-blocking safety net for edge cases where
+   * employees were added between checkout creation and payment completion.
+   */
+  private static async warnIfEmployeeCountExceedsTier(input: {
+    pricingTierId: string;
+    organizationId: string;
+    subscriptionId: string;
+    planId?: string;
+  }): Promise<void> {
+    const { pricingTierId, organizationId, subscriptionId, planId } = input;
+    const { eq, and, isNull, count: countFn } = await import("drizzle-orm");
+
+    const [tierInfo] = await db
+      .select({ maxEmployees: schema.planPricingTiers.maxEmployees })
+      .from(schema.planPricingTiers)
+      .where(eq(schema.planPricingTiers.id, pricingTierId))
+      .limit(1);
+
+    if (!tierInfo) {
+      return;
+    }
+
+    const [empCount] = await db
+      .select({ value: countFn() })
+      .from(schema.employees)
+      .where(
+        and(
+          eq(schema.employees.organizationId, organizationId),
+          isNull(schema.employees.deletedAt)
+        )
+      );
+
+    const currentEmployees = empCount?.value ?? 0;
+    if (currentEmployees > tierInfo.maxEmployees) {
+      const { logger } = await import("@/lib/logger");
+      logger.warn({
+        type: "subscription:activate:employee-count-exceeds-tier",
+        organizationId,
+        subscriptionId,
+        currentEmployees,
+        tierMaxEmployees: tierInfo.maxEmployees,
+        pricingTierId,
+        planId,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `EmployeeCountExceedsTierLimitError` and `LimitsService.requireEmployeeCountFitsInTier()` helper
- Guards **self-service checkout** — rejects if org has more employees than the selected tier's `maxEmployees`
- Guards **admin-checkout** — rejects if org has more employees than the specified `maxEmployees`
- Guards **all plan-change types** (upgrade + downgrade) — previously only downgrades validated employee count
- Adds **warning log** in `activate()` (webhook path) as safety net when employee count exceeds tier after payment

### Root cause

Investigation revealed that an org was provisioned with a trial tier (`maxEmployees=300`), registered 220 employees, then migrated to a paid plan with `maxEmployees=200` — no validation existed on checkout creation or subscription activation to prevent this mismatch.

### Pending: production data cleanup

3 orphan tiers on `plan-trial` from the legacy admin-provision approach need manual cleanup:

```sql
-- Verify references first
SELECT t.id, t.max_employees, s.id AS subscription_id
FROM plan_pricing_tiers t
LEFT JOIN org_subscriptions s ON s.pricing_tier_id = t.id
WHERE t.plan_id = 'plan-trial' AND t.id != 'tier-trial-0-10';

-- Delete unreferenced, archive referenced
DELETE FROM plan_pricing_tiers
WHERE plan_id = 'plan-trial' AND id != 'tier-trial-0-10'
  AND id NOT IN (SELECT pricing_tier_id FROM org_subscriptions WHERE pricing_tier_id IS NOT NULL);
```

## Test plan

- [x] Self-service checkout rejects when employees > tier maxEmployees
- [x] Admin-checkout rejects when employees > specified maxEmployees
- [x] Plan-change rejects upgrade when employees > new tier maxEmployees
- [x] Plan-change rejects downgrade when employees > new tier maxEmployees (existing, updated assertion)
- [x] All checkout tests pass (24/24)
- [x] All admin-checkout tests pass (24/24)
- [x] All plan-change tests pass (17/17)
- [x] All subscription tests pass (113/113)
- [x] All employee tests pass (64/64) — no regressions
- [x] Lint clean (`ultracite check`)
- [x] Type check clean (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)