### PR TITLE
feat(employees): auto-calculate probation dates (+44/+89) as backend source of truth

### DIFF
--- a/src/modules/employees/CLAUDE.md
+++ b/src/modules/employees/CLAUDE.md
@@ -9,6 +9,7 @@ Cadastro e gestão de funcionários vinculados a uma organização.
 - Criação verifica limite do plano de assinatura via `LimitsService.requireEmployeeLimit()`
 - Soft delete — nunca hard delete
 - Período aquisitivo manual (seed): `acquisitionPeriodStart` e `acquisitionPeriodEnd` opcionais, pair-or-nothing, datas >= `hireDate`. Usado como fallback no `lastAcquisitionPeriod` quando não há férias com período aquisitivo cadastrado
+- Período de experiência (`probation1ExpiryDate` / `probation2ExpiryDate`) é calculado automaticamente pelo backend via `hireDate + 44 / +89 dias` (contagem inclusiva, onde o dia da admissão é dia 1). Campos read-only na API — enviados via payload são silenciosamente ignorados (Zod strip). Frontend exibe em campo `disabled`
 
 ## Relationships (validated on create/update)
 
@@ -56,6 +57,7 @@ Alterado via `PATCH /:id/status` (endpoint dedicado, não pelo PUT geral)
 - FK fields (setor, cargo, CBO, filial, centro de custo) resolvidos por nome → ID
 - Datas no template: DD/MM/AAAA, parseadas para YYYY-MM-DD
 - CPF validado: formato + algoritmo + unicidade na org + unicidade no arquivo
+- Período de experiência (`probation1ExpiryDate` / `probation2ExpiryDate`): **NÃO** presente na planilha. Calculado pelo backend a partir de `hireDate` durante o insert (regra `hireDate + 44 / +89 dias`)
 
 ## Hooks System
 

--- a/src/modules/employees/__tests__/create-employee.test.ts
+++ b/src/modules/employees/__tests__/create-employee.test.ts
@@ -417,6 +417,100 @@ describe("POST /v1/employees", () => {
 
     expect(response.status).toBe(200);
   });
+
+  test("computes probation dates from hireDate using +44/+89 rule", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const deps = await createTestDependencies(organizationId, user.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/employees`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(
+          createValidEmployeeData({
+            hireDate: "2026-04-06",
+            cpf: generateCpf(),
+            ...deps,
+          })
+        ),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.probation1ExpiryDate).toBe("2026-05-20");
+    expect(body.data.probation2ExpiryDate).toBe("2026-07-04");
+  });
+
+  test("ignores probation dates in payload and calculates from hireDate", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const deps = await createTestDependencies(organizationId, user.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/employees`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(
+          createValidEmployeeData({
+            hireDate: "2026-03-03",
+            cpf: generateCpf(),
+            probation1ExpiryDate: "2099-01-01",
+            probation2ExpiryDate: "2099-01-01",
+            ...deps,
+          })
+        ),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.probation1ExpiryDate).toBe("2026-04-16");
+    expect(body.data.probation2ExpiryDate).toBe("2026-05-31");
+  });
+
+  test("persists computed probation dates in the database", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const deps = await createTestDependencies(organizationId, user.id);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/employees`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify(
+          createValidEmployeeData({
+            hireDate: "2026-04-06",
+            cpf: generateCpf(),
+            ...deps,
+          })
+        ),
+      })
+    );
+
+    const body = await response.json();
+    const [row] = await db
+      .select({
+        p1: schema.employees.probation1ExpiryDate,
+        p2: schema.employees.probation2ExpiryDate,
+      })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, body.data.id))
+      .limit(1);
+
+    expect(row.p1).toBe("2026-05-20");
+    expect(row.p2).toBe("2026-07-04");
+  });
 });
 
 describe("POST /v1/employees — acquisition period", () => {

--- a/src/modules/employees/__tests__/probation.test.ts
+++ b/src/modules/employees/__tests__/probation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { addDays, computeProbationDates } from "@/modules/employees/probation";
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("addDays", () => {
+  test("adds 44 days across months (Apr → May)", () => {
+    expect(addDays("2026-04-06", 44)).toBe("2026-05-20");
+  });
+
+  test("adds 44 days across months (Mar → Apr) — matches client-reported case", () => {
+    expect(addDays("2026-03-03", 44)).toBe("2026-04-16");
+  });
+
+  test("adds 89 days across three months (Mar → May)", () => {
+    expect(addDays("2026-03-03", 89)).toBe("2026-05-31");
+  });
+
+  test("handles 30-day month boundary (Apr 01 + 44 = May 15)", () => {
+    expect(addDays("2026-04-01", 44)).toBe("2026-05-15");
+  });
+
+  test("handles leap year (Jan 15 2024 + 44 = Feb 28 2024)", () => {
+    expect(addDays("2024-01-15", 44)).toBe("2024-02-28");
+  });
+
+  test("handles year boundary (Dec 10 + 44 = Jan 23 next year)", () => {
+    expect(addDays("2025-12-10", 44)).toBe("2026-01-23");
+  });
+
+  test("returns YYYY-MM-DD format", () => {
+    const result = addDays("2026-04-06", 44);
+    expect(result).toMatch(ISO_DATE_PATTERN);
+  });
+});
+
+describe("computeProbationDates", () => {
+  test("returns both probation dates using +44/+89 rule", () => {
+    expect(computeProbationDates("2026-04-06")).toEqual({
+      probation1ExpiryDate: "2026-05-20",
+      probation2ExpiryDate: "2026-07-04",
+    });
+  });
+
+  test("matches client-reported Rosangela case (hire 2026-03-03)", () => {
+    expect(computeProbationDates("2026-03-03")).toEqual({
+      probation1ExpiryDate: "2026-04-16",
+      probation2ExpiryDate: "2026-05-31",
+    });
+  });
+});

--- a/src/modules/employees/__tests__/update-employee.test.ts
+++ b/src/modules/employees/__tests__/update-employee.test.ts
@@ -531,4 +531,84 @@ describe("PUT /v1/employees/:id — acquisition period", () => {
 
     expect(response.status).toBe(422);
   });
+
+  test("recalculates probation dates when hireDate changes", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2025-04-06",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/employees/${employee.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ hireDate: "2025-05-01" }),
+      })
+    );
+
+    expect(updateResponse.status).toBe(200);
+    const { data: updated } = await updateResponse.json();
+    expect(updated.hireDate).toBe("2025-05-01");
+    expect(updated.probation1ExpiryDate).toBe("2025-06-14");
+    expect(updated.probation2ExpiryDate).toBe("2025-07-29");
+  });
+
+  test("does not recalculate probation when hireDate is unchanged", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2025-04-06",
+    });
+
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/employees/${employee.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Novo Nome" }),
+      })
+    );
+
+    const { data: updated } = await updateResponse.json();
+    expect(updated.name).toBe("Novo Nome");
+    expect(updated.probation1ExpiryDate).toBe(employee.probation1ExpiryDate);
+    expect(updated.probation2ExpiryDate).toBe(employee.probation2ExpiryDate);
+  });
+
+  test("ignores probation dates in update payload and recalculates from hireDate", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2025-04-06",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/employees/${employee.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          hireDate: "2025-03-03",
+          probation1ExpiryDate: "2099-01-01",
+          probation2ExpiryDate: "2099-01-01",
+        }),
+      })
+    );
+
+    const { data: updated } = await updateResponse.json();
+    expect(updated.probation1ExpiryDate).toBe("2025-04-16");
+    expect(updated.probation2ExpiryDate).toBe("2025-05-31");
+  });
 });

--- a/src/modules/employees/employee.model.ts
+++ b/src/modules/employees/employee.model.ts
@@ -293,16 +293,6 @@ const employeeFieldsSchema = z.object({
     .date("Data do exame demissional deve ser uma data válida")
     .optional()
     .describe("Data do exame demissional"),
-  probation1ExpiryDate: z
-    .string()
-    .date("Data de vencimento da experiência 1 deve ser uma data válida")
-    .optional()
-    .describe("Vencimento experiência 1"),
-  probation2ExpiryDate: z
-    .string()
-    .date("Data de vencimento da experiência 2 deve ser uma data válida")
-    .optional()
-    .describe("Vencimento experiência 2"),
 
   // Acquisition Period (manual seed)
   acquisitionPeriodStart: z
@@ -483,16 +473,6 @@ export const updateEmployeeSchema = employeeFieldsSchema.partial().extend({
   terminationExamDate: z
     .string()
     .date("Data do exame demissional deve ser uma data válida")
-    .nullable()
-    .optional(),
-  probation1ExpiryDate: z
-    .string()
-    .date("Data de vencimento da experiência 1 deve ser uma data válida")
-    .nullable()
-    .optional(),
-  probation2ExpiryDate: z
-    .string()
-    .date("Data de vencimento da experiência 2 deve ser uma data válida")
     .nullable()
     .optional(),
 

--- a/src/modules/employees/employee.service.ts
+++ b/src/modules/employees/employee.service.ts
@@ -792,8 +792,12 @@ export abstract class EmployeeService {
 
     const updateData = EmployeeService.buildUpdateData(data, userId);
 
-    if (data.hireDate && data.hireDate !== existingRaw.hireDate) {
-      Object.assign(updateData, computeProbationDates(data.hireDate));
+    const newHireDate = data.hireDate;
+    const hireDateChanged =
+      newHireDate !== undefined && newHireDate !== existingRaw.hireDate;
+
+    if (hireDateChanged) {
+      Object.assign(updateData, computeProbationDates(newHireDate));
     }
 
     const [updated] = await db
@@ -807,13 +811,13 @@ export abstract class EmployeeService {
       )
       .returning();
 
-    if (data.hireDate && data.hireDate !== existingRaw.hireDate) {
+    if (hireDateChanged) {
       const { EmployeeHooks } = await import("@/modules/employees/hooks");
       EmployeeHooks.emit("employee.hireDateUpdated", {
         employeeId: id,
         organizationId,
         oldHireDate: existingRaw.hireDate,
-        newHireDate: data.hireDate,
+        newHireDate,
       });
     }
 

--- a/src/modules/employees/employee.service.ts
+++ b/src/modules/employees/employee.service.ts
@@ -2,6 +2,7 @@ import { and, eq, isNull, ne } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import type { EntityReference } from "@/lib/schemas/relationships";
+import { computeProbationDates } from "@/modules/employees/probation";
 import type {
   CreateEmployeeInput,
   DeletedEmployeeData,
@@ -578,6 +579,7 @@ export abstract class EmployeeService {
         terminationExamDate: data.terminationExamDate,
         acquisitionPeriodStart: data.acquisitionPeriodStart,
         acquisitionPeriodEnd: data.acquisitionPeriodEnd,
+        ...computeProbationDates(data.hireDate),
         createdBy: userId,
       })
       .returning();

--- a/src/modules/employees/employee.service.ts
+++ b/src/modules/employees/employee.service.ts
@@ -792,6 +792,10 @@ export abstract class EmployeeService {
 
     const updateData = EmployeeService.buildUpdateData(data, userId);
 
+    if (data.hireDate && data.hireDate !== existingRaw.hireDate) {
+      Object.assign(updateData, computeProbationDates(data.hireDate));
+    }
+
     const [updated] = await db
       .update(schema.employees)
       .set(updateData)

--- a/src/modules/employees/employee.service.ts
+++ b/src/modules/employees/employee.service.ts
@@ -576,8 +576,6 @@ export abstract class EmployeeService {
         lastHealthExamDate: data.lastHealthExamDate,
         admissionExamDate: data.admissionExamDate,
         terminationExamDate: data.terminationExamDate,
-        probation1ExpiryDate: data.probation1ExpiryDate,
-        probation2ExpiryDate: data.probation2ExpiryDate,
         acquisitionPeriodStart: data.acquisitionPeriodStart,
         acquisitionPeriodEnd: data.acquisitionPeriodEnd,
         createdBy: userId,
@@ -700,8 +698,6 @@ export abstract class EmployeeService {
       lastHealthExamDate: data.lastHealthExamDate,
       admissionExamDate: data.admissionExamDate,
       terminationExamDate: data.terminationExamDate,
-      probation1ExpiryDate: data.probation1ExpiryDate,
-      probation2ExpiryDate: data.probation2ExpiryDate,
       acquisitionPeriodStart: data.acquisitionPeriodStart,
       acquisitionPeriodEnd: data.acquisitionPeriodEnd,
     };

--- a/src/modules/employees/import/__tests__/import.constants.test.ts
+++ b/src/modules/employees/import/__tests__/import.constants.test.ts
@@ -307,8 +307,6 @@ describe("IMPORT_COLUMNS", () => {
     "lastHealthExamDate",
     "admissionExamDate",
     "terminationExamDate",
-    "probation1ExpiryDate",
-    "probation2ExpiryDate",
     "acquisitionPeriodStart",
     "acquisitionPeriodEnd",
   ];

--- a/src/modules/employees/import/__tests__/import.parser.test.ts
+++ b/src/modules/employees/import/__tests__/import.parser.test.ts
@@ -332,8 +332,6 @@ describe("ImportParser.parseRow", () => {
       lastHealthExamDate: undefined,
       admissionExamDate: undefined,
       terminationExamDate: undefined,
-      probation1ExpiryDate: undefined,
-      probation2ExpiryDate: undefined,
     });
     const result = parser.parseRow(rawRow, 8);
 

--- a/src/modules/employees/import/__tests__/import.service.test.ts
+++ b/src/modules/employees/import/__tests__/import.service.test.ts
@@ -408,4 +408,86 @@ describe("ImportService.importFromFile", () => {
 
     expect(recentEmployees.length).toBeGreaterThanOrEqual(2);
   });
+
+  test("computes probation dates from hireDate for each imported employee", async () => {
+    // Use a fresh org so the employee count starts at 0 (shared org accumulates
+    // employees across tests and may be close to the tier limit).
+    const probResult = await createTestUserWithOrganization({
+      emailVerified: true,
+      skipTrialCreation: true,
+    });
+    const probOrgId = probResult.organizationId;
+    const probUserId = probResult.user.id;
+
+    await createTestSector({
+      organizationId: probOrgId,
+      userId: probUserId,
+      name: "Import Setor",
+    });
+    await createTestJobPosition({
+      organizationId: probOrgId,
+      userId: probUserId,
+      name: "Import Cargo",
+    });
+    await createTestJobClassification({
+      organizationId: probOrgId,
+      userId: probUserId,
+      name: "Import CBO",
+    });
+    await setupSubscription(probOrgId);
+
+    const probTemplate = await TemplateService.generate(probOrgId);
+
+    const rows = [
+      validRow({
+        name: "Empl A Probation",
+        hireDate: "06/04/2025",
+        cpf: generateCpf(),
+        sectorId: "Import Setor",
+        jobPositionId: "Import Cargo",
+        jobClassificationId: "Import CBO",
+      }),
+      validRow({
+        name: "Empl B Probation",
+        hireDate: "03/03/2025",
+        cpf: generateCpf(),
+        sectorId: "Import Setor",
+        jobPositionId: "Import Cargo",
+        jobClassificationId: "Import CBO",
+      }),
+    ];
+    const buffer = await buildWorkbookWithRows(probTemplate, rows);
+
+    const result = await ImportService.importFromFile({
+      buffer,
+      organizationId: probOrgId,
+      userId: probUserId,
+    });
+
+    expect(result.imported).toBe(2);
+    expect(result.failed).toBe(0);
+
+    const inserted = await db
+      .select({
+        name: schema.employees.name,
+        hireDate: schema.employees.hireDate,
+        p1: schema.employees.probation1ExpiryDate,
+        p2: schema.employees.probation2ExpiryDate,
+      })
+      .from(schema.employees)
+      .where(
+        and(
+          eq(schema.employees.organizationId, probOrgId),
+          isNull(schema.employees.deletedAt)
+        )
+      );
+
+    const a = inserted.find((e) => e.name === "Empl A Probation");
+    const b = inserted.find((e) => e.name === "Empl B Probation");
+
+    expect(a?.p1).toBe("2025-05-20");
+    expect(a?.p2).toBe("2025-07-04");
+    expect(b?.p1).toBe("2025-04-16");
+    expect(b?.p2).toBe("2025-05-31");
+  });
 });

--- a/src/modules/employees/import/__tests__/template.service.test.ts
+++ b/src/modules/employees/import/__tests__/template.service.test.ts
@@ -387,4 +387,35 @@ describe("TemplateService.generate", () => {
       expect(details.missing).toContain("CBOs");
     }
   });
+
+  test("generated template does not contain probation columns", async () => {
+    const { organizationId, userId } = await createTestUserWithOrganization();
+
+    await createTestSector({ organizationId, userId, name: "Setor Prob" });
+    await createTestJobPosition({
+      organizationId,
+      userId,
+      name: "Cargo Prob",
+    });
+    await createTestJobClassification({
+      organizationId,
+      userId,
+      name: "CBO Prob",
+    });
+
+    const buffer = await TemplateService.generate(organizationId);
+    const wb = await loadWorkbook(buffer);
+    const ws = getWorksheet(wb, SHEET_NAME_EMPLOYEES);
+
+    const headerRow = ws.getRow(1);
+    const headerValues: string[] = [];
+    headerRow.eachCell((cell) => {
+      if (typeof cell.value === "string") {
+        headerValues.push(cell.value);
+      }
+    });
+
+    expect(headerValues).not.toContain("Vencimento experiência 1");
+    expect(headerValues).not.toContain("Vencimento experiência 2");
+  });
 });

--- a/src/modules/employees/import/import.constants.ts
+++ b/src/modules/employees/import/import.constants.ts
@@ -587,20 +587,6 @@ export const IMPORT_COLUMNS: ImportColumn[] = [
     required: false,
     section: "health",
   },
-  {
-    key: "probation1ExpiryDate",
-    header: "Vencimento experiência 1",
-    width: 24,
-    required: false,
-    section: "health",
-  },
-  {
-    key: "probation2ExpiryDate",
-    header: "Vencimento experiência 2",
-    width: 24,
-    required: false,
-    section: "health",
-  },
 ];
 
 // ── Field key → PT-BR header map ────────────────────────────────────────────

--- a/src/modules/employees/import/import.parser.ts
+++ b/src/modules/employees/import/import.parser.ts
@@ -68,8 +68,6 @@ const DATE_FIELDS = [
   "lastHealthExamDate",
   "admissionExamDate",
   "terminationExamDate",
-  "probation1ExpiryDate",
-  "probation2ExpiryDate",
   "acquisitionPeriodStart",
   "acquisitionPeriodEnd",
 ] as const;

--- a/src/modules/employees/import/import.service.ts
+++ b/src/modules/employees/import/import.service.ts
@@ -4,6 +4,7 @@ import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { AuditService } from "@/modules/audit/audit.service";
 import type { CreateEmployee } from "@/modules/employees/employee.model";
+import { computeProbationDates } from "@/modules/employees/probation";
 import { LimitsService } from "@/modules/payments/limits/limits.service";
 import {
   FIELD_KEY_TO_HEADER,
@@ -178,6 +179,7 @@ export abstract class ImportService {
           healthInsurance: row.data.healthInsurance?.toString(),
           latitude: row.data.latitude?.toString(),
           longitude: row.data.longitude?.toString(),
+          ...computeProbationDates(row.data.hireDate),
           status: "ACTIVE" as const,
           createdBy: userId,
         });

--- a/src/modules/employees/probation.ts
+++ b/src/modules/employees/probation.ts
@@ -1,0 +1,15 @@
+export function addDays(isoDate: string, days: number): string {
+  const d = new Date(`${isoDate}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function computeProbationDates(hireDate: string): {
+  probation1ExpiryDate: string;
+  probation2ExpiryDate: string;
+} {
+  return {
+    probation1ExpiryDate: addDays(hireDate, 44),
+    probation2ExpiryDate: addDays(hireDate, 89),
+  };
+}

--- a/src/test/helpers/employee.ts
+++ b/src/test/helpers/employee.ts
@@ -92,8 +92,6 @@ type EmployeeOverrides = {
   lastHealthExamDate?: string;
   admissionExamDate?: string;
   terminationExamDate?: string;
-  probation1ExpiryDate?: string;
-  probation2ExpiryDate?: string;
   acquisitionPeriodStart?: string | null;
   acquisitionPeriodEnd?: string | null;
 };
@@ -310,10 +308,6 @@ function generateHealthDates(
     overrides.admissionExamDate ??
     maybe(profile, () => generatePastDateFrom(hireDate, 7));
 
-  const probation1ExpiryDate =
-    overrides.probation1ExpiryDate ??
-    maybe(profile, () => generatePastDateFrom(hireDate, 45));
-
   return {
     lastHealthExamDate:
       overrides.lastHealthExamDate ??
@@ -323,12 +317,6 @@ function generateHealthDates(
       }),
     admissionExamDate,
     terminationExamDate: overrides.terminationExamDate,
-    probation1ExpiryDate,
-    probation2ExpiryDate:
-      overrides.probation2ExpiryDate ??
-      (probation1ExpiryDate
-        ? maybe(profile, () => generatePastDateFrom(hireDate, 90))
-        : undefined),
   };
 }
 


### PR DESCRIPTION
## Contexto

Auditando produção identificamos inconsistência nas datas de vencimento do período de experiência (`probation1ExpiryDate` / `probation2ExpiryDate`):

- Uns cadastros com `hireDate + 45/+90` (fórmula antiga do frontend, exclusão do dia da admissão — art. 132 caput CC)
- Outros com `hireDate + 44/+89` (contagem inclusiva leiga — dia da admissão = dia 1)
- Muitos `NULL` em registros antigos

O cliente padronizou a regra em **contagem inclusiva** (`+44/+89`). Este PR consolida o cálculo no backend como única fonte de verdade, remove os campos da API de entrada e da planilha de import, e alinha o frontend (PR sibling).

## O que muda

- **Novo helper puro** `computeProbationDates(hireDate)` em `src/modules/employees/probation.ts` aplicando `hireDate + 44/+89 dias` (parse em UTC). Cobertura unit completa (month/year boundaries, ano bissexto, casos do cliente).
- **`EmployeeService.create`** passa a spread `...computeProbationDates(data.hireDate)` no insert. Valores enviados no payload são silenciosamente ignorados (Zod strip).
- **`EmployeeService.update`** recalcula **apenas quando `hireDate` é alterado**. Updates que não tocam `hireDate` preservam valores existentes. Condição extraída para local `hireDateChanged`.
- **Zod schemas de create/update** perdem `probation1ExpiryDate` e `probation2ExpiryDate`. Response (`employeeDataSchema`) mantém os campos.
- **Import (.xlsx)**: removidas as 2 colunas de `IMPORT_COLUMNS`, removidas do `DATE_FIELDS` do parser. `ImportService.importFromFile` aplica `computeProbationDates` por linha durante o batch insert. Planilhas antigas reutilizadas: colunas extras são silenciosamente ignoradas.
- **Factory de teste (`src/test/helpers/employee.ts`)** limpa: removidos overrides de probation que passaram a ser silenciosamente ignorados pelo service.
- **Docs**: `src/modules/employees/CLAUDE.md` documenta a nova regra em Business Rules e em Import (Bulk).

## Decisões registradas

- **Source of truth no backend, não validação de entrada**: sem consumidores externos da API hoje, validar o que o frontend manda só acopla desnecessariamente. Backend calcula, frontend exibe.
- **Update só recalcula quando `hireDate` muda**: comportamento menos surpreendente (não autocuura). Registros antigos inconsistentes vão ser corrigidos pelo backfill único abaixo.
- **Frontend mantém auto-calc client-side para preview**, mas os DatePickers viram permanentemente `disabled` (PR sibling).

## Rollout

1. Merge este PR → deploy backend.
2. Merge do PR sibling do frontend (`feat(funcionarios): ...` em `synnerdata-web-n`) → deploy frontend.
3. Smoke test em prod: cadastrar 1 funcionário teste via form, conferir probation no response, apagar.
4. **Backfill SQL em pgAdmin** (execução manual, não commitado) para corrigir registros existentes:

\`\`\`sql
-- Passo 1: preview (somente leitura)
SELECT id, name, hire_date,
       probation1_expiry_date AS p1_current, hire_date + 44 AS p1_expected,
       probation2_expiry_date AS p2_current, hire_date + 89 AS p2_expected
FROM employees
WHERE deleted_at IS NULL AND status != 'TERMINATED'
  AND (probation1_expiry_date IS DISTINCT FROM hire_date + 44
    OR probation2_expiry_date IS DISTINCT FROM hire_date + 89)
ORDER BY created_at;

-- Passo 2: update em transação
BEGIN;
UPDATE employees
SET probation1_expiry_date = hire_date + 44,
    probation2_expiry_date = hire_date + 89,
    updated_at = NOW()
WHERE deleted_at IS NULL AND status != 'TERMINATED'
  AND (probation1_expiry_date IS DISTINCT FROM hire_date + 44
    OR probation2_expiry_date IS DISTINCT FROM hire_date + 89)
RETURNING id, hire_date, probation1_expiry_date, probation2_expiry_date;
-- Inspecionar RETURNING, exportar CSV, depois:
COMMIT;

-- Passo 3: sanity check (esperado: 0)
SELECT COUNT(*) FROM employees
WHERE deleted_at IS NULL AND status != 'TERMINATED'
  AND (probation1_expiry_date IS DISTINCT FROM hire_date + 44
    OR probation2_expiry_date IS DISTINCT FROM hire_date + 89);
\`\`\`

Filtro `status != 'TERMINATED'` alinha com o padrão de unicidade de CPF — histórico de demitidos não é tocado.

## Test plan

- [x] 189 testes passam em \`src/modules/employees/__tests__/\` + \`src/modules/employees/import/__tests__/\`
- [x] \`npx tsc --noEmit\` limpo
- [x] \`npx ultracite check\` limpo (558 arquivos)
- [x] Cobertura: unit helper (9), create (3 cenários: happy path, payload ignorado, DB persistence), update (3 cenários: recalc on change, preserved on no-change, payload ignorado), import (1 integration + 1 regressão no template)
- [ ] Pós-merge: smoke test manual em prod (cadastrar/editar funcionário teste)
- [ ] Pós-merge: rodar SQL de backfill em pgAdmin prod (passos 1-3 acima)
- [ ] Validar Rosangela/Laisse no frontend após backfill

## Documentação relacionada

Spec em \`docs/superpowers/specs/2026-04-17-probation-auto-calculation-design.md\` e plano de implementação em \`docs/superpowers/plans/2026-04-17-probation-auto-calculation.md\` (ambos local — \`/docs\` é gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)