### PR TITLE
fix(vacations): correct period off-by-one + enforce daysEntitled <= 30

### DIFF
--- a/src/modules/employees/__tests__/last-acquisition-period.test.ts
+++ b/src/modules/employees/__tests__/last-acquisition-period.test.ts
@@ -1,9 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
-import {
-  computePeriodsFromHireDate,
-  computePeriodsFromLastAcquisition,
-} from "@/modules/occurrences/vacations/period-calculation";
+import { computePeriodsFromHireDate } from "@/modules/occurrences/vacations/period-calculation";
 import { VacationService } from "@/modules/occurrences/vacations/vacation.service";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestEmployee } from "@/test/helpers/employee";
@@ -72,9 +69,11 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // Vacation was created against hireDate "2025-01-01" with no prior vacations
-    // → computePeriodsFromHireDate computes the current period based on today.
-    const expected = computePeriodsFromHireDate("2025-01-01");
+    // The service computes periods using hireDate + vacation's startDate as reference.
+    const expected = computePeriodsFromHireDate(
+      "2025-01-01",
+      new Date("2027-02-01T00:00:00Z") // vacation startDate
+    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
       start: expected.acquisitionPeriodStart,
       end: expected.acquisitionPeriodEnd,
@@ -120,9 +119,11 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    const firstPeriods = computePeriodsFromHireDate("2024-01-01");
-    const secondPeriods = computePeriodsFromLastAcquisition(
-      firstPeriods.acquisitionPeriodEnd
+    // The service computes each vacation's periods independently using its own startDate.
+    // getLastAcquisitionPeriod returns the one with the latest acquisitionPeriodEnd.
+    const secondPeriods = computePeriodsFromHireDate(
+      "2024-01-01",
+      new Date("2027-04-01T00:00:00Z") // second vacation startDate
     );
     expect(body.data.lastAcquisitionPeriod).toEqual({
       start: secondPeriods.acquisitionPeriodStart,
@@ -171,8 +172,11 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    const firstPeriods = computePeriodsFromHireDate("2024-01-01");
     // Second vacation was deleted, so the last remaining period is from the first vacation.
+    const firstPeriods = computePeriodsFromHireDate(
+      "2024-01-01",
+      new Date("2027-05-01T00:00:00Z") // first vacation startDate
+    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
       start: firstPeriods.acquisitionPeriodStart,
       end: firstPeriods.acquisitionPeriodEnd,
@@ -210,7 +214,10 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    const periods = computePeriodsFromHireDate("2024-01-01");
+    const periods = computePeriodsFromHireDate(
+      "2024-01-01",
+      new Date("2027-07-01T00:00:00Z") // vacation startDate
+    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
       start: periods.acquisitionPeriodStart,
       end: periods.acquisitionPeriodEnd,
@@ -280,8 +287,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       })
     );
 
-    // Create vacation — service sees manual seed via getLastAcquisitionPeriod,
-    // then computes next period from it.
+    // Create vacation — the service now computes periods using hireDate + vacation's
+    // startDate as reference, ignoring the manual seed.
     await createTestVacation({
       organizationId,
       userId: user.id,
@@ -300,9 +307,12 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // Manual seed: 2024-01-01 to 2024-12-31
-    // Vacation creation sees this via getLastAcquisitionPeriod, computes next period
-    const vacationPeriods = computePeriodsFromLastAcquisition("2024-12-31");
+    // The vacation's periods are computed from hireDate + vacation's startDate,
+    // not from the manual seed. The vacation's period takes priority over the manual seed.
+    const vacationPeriods = computePeriodsFromHireDate(
+      "2024-01-01",
+      new Date("2027-08-01T00:00:00Z") // vacation startDate
+    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
       start: vacationPeriods.acquisitionPeriodStart,
       end: vacationPeriods.acquisitionPeriodEnd,

--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -10,7 +10,9 @@ Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias.
 - `daysUsed` deve ser >= 0 e <= `daysEntitled`
 - Periodos aquisitivo e concessivo: campos inline na tabela `vacations` (nao entidade separada)
   - `acquisitionPeriodStart` / `acquisitionPeriodEnd` / `concessivePeriodStart` / `concessivePeriodEnd`
-  - **Calculados pelo backend** via `computePeriodsFromLastAcquisition` (quando o funcionario ja tem ferias anteriores ou seed manual no employee) ou `computePeriodsFromHireDate` (primeira ferias). Helper em `src/modules/occurrences/vacations/period-calculation.ts`.
+  - **Calculados pelo backend** via `computePeriodsFromHireDate(hireDate, vacation.startDate)`. O aquisitivo retornado eh aquele cujo concessivo contem a `startDate` — ou seja, o ciclo pendente para gozo, nao o ciclo que esta acumulando. Helper em `src/modules/occurrences/vacations/period-calculation.ts`.
+  - **Nao considera historico** de ferias anteriores nem seed manual no employee — tudo eh derivado de `hireDate` + `startDate`. Suporte a ferias fracionadas (multiplos registros no mesmo aquisitivo) sera implementado em issue separada (#227).
+  - **Erro `VacationNoRightsError` (422)** quando `startDate` eh anterior ao primeiro aniversario da admissao (funcionario sem direito adquirido).
   - Regra CLT: aquisitivo = 12 meses; concessivo = 12 meses apos o fim do aquisitivo.
   - **Read-only na API**: removidos dos schemas Zod de create/update. Enviados no payload sao silenciosamente stripados. Frontend exibe em DatePickers desabilitados.
   - Snapshot historico do momento da criacao — updates preservam os valores (nao recalculam).
@@ -42,7 +44,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `startDate`, `endDate` (datas das ferias)
 - `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **computado pelo backend**, read-only na API, presente na response)
 - `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **computado pelo backend**, read-only na API, presente na response)
-- `daysEntitled` (inteiro, obrigatorio, sem default)
+- `daysEntitled` (inteiro, 1 a 30 conforme CLT art. 130, obrigatorio, sem default)
 - `daysUsed` (inteiro)
 - `notes` (opcional)
 
@@ -54,6 +56,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `VacationInvalidDateRangeError` (422)
 - `VacationInvalidDaysError` (422) -- daysEntitled != intervalo de datas, ou daysUsed > daysEntitled
 - `VacationDateBeforeHireError` (422) -- qualquer data anterior a hireDate do funcionario
+- `VacationNoRightsError` (422) -- `startDate` anterior ao primeiro aniversario da admissao
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)
 - `EmployeeTerminatedError` (422) -- shared, from `src/lib/errors/employee-status-errors.ts`
 

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -645,4 +645,68 @@ describe("POST /v1/vacations", () => {
       .limit(1);
     expect(updatedEmployee.status).toBe("VACATION_SCHEDULED");
   });
+
+  test("rejects with 422 when daysEntitled > 30 (CLT art. 130 limit)", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-08-14",
+          daysEntitled: 45,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+  });
+
+  test("accepts daysEntitled = 30 (upper boundary)", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-30",
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+  });
 });

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -484,7 +484,7 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // hireDate=2024-06-10, today~2026-04-19: completed=1 (2025-06-10<=today, 2026-06-10>today)
+    // startDate=2026-07-01 as reference: completed=2 (2025-06-10 and 2026-06-10 anniversaries), index=1
     // acquisitionPeriodStart = addMonths("2024-06-10", 12) = "2025-06-10"
     // acquisitionPeriodEnd = addDays(addMonths("2024-06-10", 24), -1) = "2026-06-09"
     // concessivePeriodStart = "2026-06-10", concessivePeriodEnd = "2027-06-09"

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -494,7 +494,7 @@ describe("POST /v1/vacations", () => {
     expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
   });
 
-  test("computes next periods from last acquisition when employee has prior period seed", async () => {
+  test("ignores employee manual seed and computes periods from hireDate + startDate", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -525,15 +525,12 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // lastAcquisitionPeriod.end = "2026-04-18" (manual seed from employee fields)
-    // computePeriodsFromLastAcquisition("2026-04-18"):
-    //   acquisitionPeriodStart = addDays("2026-04-18", 1) = "2026-04-19"
-    //   acquisitionPeriodEnd = addDays(addMonths("2026-04-19", 12), -1) = "2027-04-18"
-    //   concessivePeriodStart = "2027-04-19", concessivePeriodEnd = "2028-04-18"
-    expect(body.data.acquisitionPeriodStart).toBe("2026-04-19");
-    expect(body.data.acquisitionPeriodEnd).toBe("2027-04-18");
-    expect(body.data.concessivePeriodStart).toBe("2027-04-19");
-    expect(body.data.concessivePeriodEnd).toBe("2028-04-18");
+    // Manual seed on employee is now ignored; periods always computed
+    // from hireDate + vacation.startDate.
+    expect(body.data.acquisitionPeriodStart).toBe("2025-06-10");
+    expect(body.data.acquisitionPeriodEnd).toBe("2026-06-09");
+    expect(body.data.concessivePeriodStart).toBe("2026-06-10");
+    expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
   });
 
   test("ignores period fields in payload and computes from backend", async () => {
@@ -571,9 +568,46 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // Zod strips the 4 garbage values; backend uses lastAcquisitionPeriod.end = "2026-04-18"
-    expect(body.data.acquisitionPeriodStart).toBe("2026-04-19");
-    expect(body.data.concessivePeriodEnd).toBe("2028-04-18");
+    // Zod strips the 4 garbage values; backend computes from hireDate + startDate.
+    expect(body.data.acquisitionPeriodStart).toBe("2025-06-10");
+    expect(body.data.acquisitionPeriodEnd).toBe("2026-06-09");
+    expect(body.data.concessivePeriodStart).toBe("2026-06-10");
+    expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
+  });
+
+  test("rejects with 422 when vacation startDate is before the first anniversary", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2025-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    // startDate is before hireDate + 12 months (no acquired rights yet)
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-03-01",
+          endDate: "2026-03-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VACATION_NO_RIGHTS");
   });
 
   test("should set employee status to VACATION_SCHEDULED after creating vacation", async () => {

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -617,6 +617,7 @@ describe("POST /v1/vacations", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
+      hireDate: "2020-01-01",
     });
 
     const startDate = "2027-06-01";

--- a/src/modules/occurrences/vacations/__tests__/delete-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/delete-vacation.test.ts
@@ -252,6 +252,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
+      hireDate: "2020-01-01",
     });
 
     const vacation = await createTestVacation({

--- a/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/modules/occurrences/vacations/period-calculation";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const VACATION_NO_RIGHTS_PATTERN = /direito a férias/;
 
 describe("addDays", () => {
   test("adds days across month boundary", () => {
@@ -61,9 +62,35 @@ describe("computePeriodsFromLastAcquisition", () => {
 });
 
 describe("computePeriodsFromHireDate", () => {
-  test("today is the hire date exactly → 1st period is [hireDate, hireDate+1y-1d]", () => {
-    const today = new Date("2026-06-10T00:00:00Z");
-    expect(computePeriodsFromHireDate("2026-06-10", today)).toEqual({
+  test("throws VacationNoRightsError when referenceDate is before first anniversary", () => {
+    expect(() =>
+      computePeriodsFromHireDate("2025-01-01", new Date("2025-06-01T00:00:00Z"))
+    ).toThrow(VACATION_NO_RIGHTS_PATTERN);
+  });
+
+  test("throws when referenceDate equals hireDate exactly (employee just hired)", () => {
+    expect(() =>
+      computePeriodsFromHireDate("2026-06-10", new Date("2026-06-10T00:00:00Z"))
+    ).toThrow(VACATION_NO_RIGHTS_PATTERN);
+  });
+
+  test("Google AI example: hire 2024-01-01 + referenceDate 2025-07-01 → 1st cycle", () => {
+    expect(
+      computePeriodsFromHireDate("2024-01-01", new Date("2025-07-01T00:00:00Z"))
+    ).toEqual({
+      acquisitionPeriodStart: "2024-01-01",
+      acquisitionPeriodEnd: "2024-12-31",
+      concessivePeriodStart: "2025-01-01",
+      concessivePeriodEnd: "2025-12-31",
+    });
+  });
+
+  test("employee on exact anniversary → 1st completed cycle is the pending one", () => {
+    // hire 2026-06-10, referenceDate 2027-06-10 (exactly 1 year later)
+    // completed = 1 (anniversary was reached), pending cycle index = 0 → 1st cycle
+    expect(
+      computePeriodsFromHireDate("2026-06-10", new Date("2027-06-10T00:00:00Z"))
+    ).toEqual({
       acquisitionPeriodStart: "2026-06-10",
       acquisitionPeriodEnd: "2027-06-09",
       concessivePeriodStart: "2027-06-10",
@@ -71,9 +98,12 @@ describe("computePeriodsFromHireDate", () => {
     });
   });
 
-  test("employee on anniversary day exactly → 1 year counts as 1 completed period, so 2nd period", () => {
-    const today = new Date("2027-06-10T00:00:00Z");
-    expect(computePeriodsFromHireDate("2026-06-10", today)).toEqual({
+  test("employee with 2 completed anniversaries → 2nd cycle (aquisitivo year 2, concessivo year 3)", () => {
+    // hire 2026-06-10, referenceDate 2028-07-01
+    // completed = 2, pending cycle index = 1 → 2nd aquisitivo, 2nd concessivo
+    expect(
+      computePeriodsFromHireDate("2026-06-10", new Date("2028-07-01T00:00:00Z"))
+    ).toEqual({
       acquisitionPeriodStart: "2027-06-10",
       acquisitionPeriodEnd: "2028-06-09",
       concessivePeriodStart: "2028-06-10",
@@ -81,23 +111,23 @@ describe("computePeriodsFromHireDate", () => {
     });
   });
 
-  test("employee with 1 completed year and 1 day extra → still 2nd period", () => {
-    const today = new Date("2027-06-11T00:00:00Z");
-    expect(computePeriodsFromHireDate("2026-06-10", today)).toEqual({
-      acquisitionPeriodStart: "2027-06-10",
-      acquisitionPeriodEnd: "2028-06-09",
-      concessivePeriodStart: "2028-06-10",
-      concessivePeriodEnd: "2029-06-09",
+  test("Raquel homologação case: hire 2020-12-08 + referenceDate 2026-04-01 → 5th cycle", () => {
+    // completed = 5 (anniversaries 2021, 2022, 2023, 2024, 2025 all <= 2026-04-01)
+    // pending cycle index = 4 → 5th aquisitivo
+    expect(
+      computePeriodsFromHireDate("2020-12-08", new Date("2026-04-01T00:00:00Z"))
+    ).toEqual({
+      acquisitionPeriodStart: "2024-12-08",
+      acquisitionPeriodEnd: "2025-12-07",
+      concessivePeriodStart: "2025-12-08",
+      concessivePeriodEnd: "2026-12-07",
     });
   });
 
-  test("employee with 2 completed years", () => {
-    const today = new Date("2028-06-11T00:00:00Z");
-    expect(computePeriodsFromHireDate("2026-06-10", today)).toEqual({
-      acquisitionPeriodStart: "2028-06-10",
-      acquisitionPeriodEnd: "2029-06-09",
-      concessivePeriodStart: "2029-06-10",
-      concessivePeriodEnd: "2030-06-09",
-    });
+  test("defaults referenceDate to today when omitted", () => {
+    // Smoke test that the default param still works; exact values depend on today's date.
+    const result = computePeriodsFromHireDate("2020-01-01");
+    expect(result.acquisitionPeriodStart).toMatch(ISO_DATE_PATTERN);
+    expect(result.acquisitionPeriodEnd).toMatch(ISO_DATE_PATTERN);
   });
 });

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -401,6 +401,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
+      hireDate: "2020-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -435,6 +436,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
+      hireDate: "2020-01-01",
     });
 
     const vacation = await createTestVacation({

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -372,8 +372,8 @@ describe("PUT /v1/vacations/:id", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2025-02-01",
-      endDate: "2025-02-15",
+      startDate: "2026-02-01",
+      endDate: "2026-02-15",
       daysUsed: 0,
     });
 

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -620,4 +620,45 @@ describe("PUT /v1/vacations/:id", () => {
     expect(body.data.concessivePeriodStart).toBe(created.concessivePeriodStart);
     expect(body.data.concessivePeriodEnd).toBe(created.concessivePeriodEnd);
   });
+
+  test("rejects update with 422 when daysEntitled > 30", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const createResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    const { data: created } = await createResponse.json();
+
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${created.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ daysEntitled: 45 }),
+      })
+    );
+
+    expect(updateResponse.status).toBe(422);
+  });
 });

--- a/src/modules/occurrences/vacations/__tests__/vacation-jobs.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/vacation-jobs.test.ts
@@ -24,6 +24,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
+        hireDate: "2020-01-01",
       });
 
       const today = new Date();
@@ -74,6 +75,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
+        hireDate: "2020-01-01",
       });
 
       const future = new Date();
@@ -118,6 +120,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
+        hireDate: "2020-01-01",
       });
 
       const today = new Date();
@@ -168,6 +171,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
+        hireDate: "2020-01-01",
       });
 
       const today = new Date();

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -85,3 +85,15 @@ export class VacationOverlapError extends VacationError {
     );
   }
 }
+
+export class VacationNoRightsError extends VacationError {
+  status = 422;
+
+  constructor(hireDate: string, referenceDate: string) {
+    super(
+      "Funcionário ainda não tem direito a férias (menos de 12 meses desde a admissão)",
+      "VACATION_NO_RIGHTS",
+      { hireDate, referenceDate }
+    );
+  }
+}

--- a/src/modules/occurrences/vacations/period-calculation.ts
+++ b/src/modules/occurrences/vacations/period-calculation.ts
@@ -1,3 +1,5 @@
+import { VacationNoRightsError } from "./errors";
+
 export function addDays(isoDate: string, days: number): string {
   const d = new Date(`${isoDate}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() + days);
@@ -37,23 +39,33 @@ export function computePeriodsFromLastAcquisition(
 
 export function computePeriodsFromHireDate(
   hireDate: string,
-  today: Date = new Date()
+  referenceDate: Date = new Date()
 ): VacationPeriods {
   let completed = 0;
-  const test = new Date(`${hireDate}T00:00:00Z`);
-  while (test <= today) {
-    test.setUTCFullYear(test.getUTCFullYear() + 1);
-    if (test <= today) {
+  const anniversary = new Date(`${hireDate}T00:00:00Z`);
+  while (anniversary <= referenceDate) {
+    anniversary.setUTCFullYear(anniversary.getUTCFullYear() + 1);
+    if (anniversary <= referenceDate) {
       completed += 1;
     }
   }
-  const acquisitionPeriodStart = addMonths(hireDate, completed * 12);
+
+  if (completed < 1) {
+    throw new VacationNoRightsError(
+      hireDate,
+      referenceDate.toISOString().slice(0, 10)
+    );
+  }
+
+  const index = completed - 1;
+  const acquisitionPeriodStart = addMonths(hireDate, index * 12);
   const acquisitionPeriodEnd = addDays(
-    addMonths(hireDate, (completed + 1) * 12),
+    addMonths(hireDate, (index + 1) * 12),
     -1
   );
   const concessivePeriodStart = addDays(acquisitionPeriodEnd, 1);
   const concessivePeriodEnd = addDays(addMonths(concessivePeriodStart, 12), -1);
+
   return {
     acquisitionPeriodStart,
     acquisitionPeriodEnd,

--- a/src/modules/occurrences/vacations/vacation.model.ts
+++ b/src/modules/occurrences/vacations/vacation.model.ts
@@ -21,8 +21,9 @@ const vacationFieldsSchema = z.object({
   daysEntitled: z
     .number()
     .int("Dias deve ser um número inteiro")
-    .positive("Dias deve ser positivo")
-    .describe("Dias"),
+    .min(1, "Dias deve ser pelo menos 1")
+    .max(30, "Dias não pode exceder 30 (CLT art. 130)")
+    .describe("Dias (1 a 30 conforme CLT art. 130)"),
   daysUsed: z
     .number()
     .int("Dias utilizados deve ser um número inteiro")

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -239,6 +239,9 @@ export abstract class VacationService {
     await ensureEmployeeNotTerminated(data.employeeId, organizationId);
 
     VacationService.validateDates(data.startDate, data.endDate);
+    // validateDatesNotBeforeHire must run before computePeriodsFromHireDate so
+    // `startDate < hireDate` throws VacationDateBeforeHireError (specific)
+    // instead of VacationNoRightsError (generic, fired when completed = 0).
     VacationService.validateDatesNotBeforeHire(employee.hireDate, {
       startDate: data.startDate,
       endDate: data.endDate,

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -3,11 +3,7 @@ import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { ensureEmployeeNotTerminated } from "@/lib/helpers/employee-status";
 import { calculateDaysBetween } from "@/lib/schemas/date-helpers";
-import { EmployeeService } from "@/modules/employees/employee.service";
-import {
-  computePeriodsFromHireDate,
-  computePeriodsFromLastAcquisition,
-} from "@/modules/occurrences/vacations/period-calculation";
+import { computePeriodsFromHireDate } from "@/modules/occurrences/vacations/period-calculation";
 import {
   VacationAlreadyDeletedError,
   VacationDateBeforeHireError,
@@ -242,34 +238,17 @@ export abstract class VacationService {
 
     await ensureEmployeeNotTerminated(data.employeeId, organizationId);
 
-    const [employeeRaw] = await db
-      .select()
-      .from(schema.employees)
-      .where(
-        and(
-          eq(schema.employees.id, data.employeeId),
-          eq(schema.employees.organizationId, organizationId),
-          isNull(schema.employees.deletedAt)
-        )
-      )
-      .limit(1);
-    if (!employeeRaw) {
-      throw new VacationInvalidEmployeeError(data.employeeId);
-    }
-
-    const lastPeriod = await EmployeeService.getLastAcquisitionPeriod(
-      data.employeeId,
-      employeeRaw
-    );
-    const periods = lastPeriod
-      ? computePeriodsFromLastAcquisition(lastPeriod.end)
-      : computePeriodsFromHireDate(employee.hireDate);
-
     VacationService.validateDates(data.startDate, data.endDate);
     VacationService.validateDatesNotBeforeHire(employee.hireDate, {
       startDate: data.startDate,
       endDate: data.endDate,
     });
+
+    const periods = computePeriodsFromHireDate(
+      employee.hireDate,
+      new Date(`${data.startDate}T00:00:00Z`)
+    );
+
     VacationService.validateDays(
       data.startDate,
       data.endDate,


### PR DESCRIPTION
## Resumo

Corrige bug de off-by-one em `computePeriodsFromHireDate` e adiciona validação `daysEntitled <= 30` (CLT art. 130).

Closes #230.

### Bug 1 — Off-by-one nos períodos

Desde o PR #226, toda férias criada via `VacationService.create` armazenava o ciclo aquisitivo **acumulando** (ano N+1) em vez do ciclo com concessivo **aberto** (ano N, o que tem direitos pendentes). Confirmado em homologação com os registros da Raquel Maria (hire `2020-12-08`, férias `2026-04-01` gravada com aquisitivo ano 6 quando deveria ser ano 5).

**Fix:** usa `index = completed - 1` (ciclo pendente) em vez de `completed` (ciclo acumulando); lança `VacationNoRightsError` (422) quando `completed < 1` (antes do 1º aniversário).

### Bug 2 — Falta de validação CLT

CLT art. 130 limita férias a 30 dias por aquisitivo. Backend aceitava 45, 35, etc.

**Fix:** Zod schema em `vacationFieldsSchema.daysEntitled` agora tem `.min(1).max(30)`. Aplica-se a create + update (via `.partial()`).

### Simplificação: `VacationService.create` sempre calcula do hireDate

Removida a branching antiga baseada em `EmployeeService.getLastAcquisitionPeriod`. Agora `create` sempre calcula os períodos via `computePeriodsFromHireDate(employee.hireDate, vacation.startDate)`. Isso é:
- **Determinístico** — `{hireDate, startDate}` ↔ aquisitivo.
- **Self-healing** — se o DB tem registros errados, o próximo create produz valores corretos mesmo assim.
- **Alinhado ao cliente** — "concessivo é sempre baseado na data de contratação".

Suporte a férias fracionadas (#227) reintroduzirá history-awareness como um concern ortogonal.

### Ordem das validações

Documentada em comentário inline (commit `1726616`): `validateDatesNotBeforeHire` deve rodar **antes** de `computePeriodsFromHireDate`, senão um payload com `startDate < hireDate` emite `VacationNoRightsError` (genérico) em vez do `VacationDateBeforeHireError` (específico).

## Commits

- `4904e64` feat(vacations): add VacationNoRightsError (422)
- `353f56f` fix(vacations): correct off-by-one in computePeriodsFromHireDate
- `841f2da` fix(vacations): always compute periods from hireDate + startDate in create
- `1726616` docs(vacations): document validation ordering invariant in create
- `a2ec0f6` test(vacations): update create expectations for corrected period computation
- `b41c4e6` test(vacations): pin hireDate in flaky tests and refresh stale comment
- `e03d265` test(employees): align last-acquisition-period tests with corrected periods
- `dc8a59d` feat(vacations): enforce daysEntitled <= 30 (CLT art. 130)
- `24f263f` test(vacations): pin hireDate in delete/peripheral tests to remove flake
- `1c98726` docs(vacations): document corrected period rule and daysEntitled limit

## Test plan

- [x] `NODE_ENV=test bun test --env-file .env.test src/modules/occurrences/vacations/__tests__/ src/modules/employees/__tests__/` → **165 pass, 0 fail**
- [x] `npx tsc --noEmit` → clean
- [x] `npx ultracite check` → 560 files, no fixes applied
- [ ] CI (full suite) passa
- [ ] Cliente valida em homologação:
  - Criar férias produz aquisitivo/concessivo corretos (ciclo pendente, não o acumulando)
  - `daysEntitled = 45` → 422
  - `startDate` antes do 1º aniversário → 422 com `VACATION_NO_RIGHTS`
- [ ] Registros existentes em homologação corrigidos via backfill SQL (abaixo)

## Rollout

1. Merge desta PR em `preview` → deploy em homologação
2. Cliente re-testa em homologação (criação, validações, etc.)
3. Executar SQL de backfill em homologação (transação; preview + UPDATE + COMMIT). Spot-check dos 3 registros da Raquel — todos devem mostrar aquisitivo `2024-12-08 a 2025-12-07`
4. Cliente valida fluxo completo em homologação
5. Merge `preview` → `main` → deploy em produção
6. Executar SQL de backfill em produção
7. Cliente valida produção

## Backfill SQL (executar manualmente via pgAdmin, homologação → produção)

Três etapas: preview, preview de registros pulados, UPDATE em transação, sanity check.

<details>
<summary>1. Preview em homologação (read-only)</summary>

```sql
SELECT
  v.id,
  e.name,
  e.hire_date,
  v.start_date,
  v.days_entitled,
  v.acquisition_period_start AS old_aq_start,
  v.acquisition_period_end AS old_aq_end,
  v.concessive_period_start AS old_co_start,
  v.concessive_period_end AS old_co_end,
  DATE_PART('year', AGE(v.start_date, e.hire_date))::int AS completed_years,
  (e.hire_date + (DATE_PART('year', AGE(v.start_date, e.hire_date))::int - 1) * INTERVAL '1 year')::date AS new_aq_start,
  (e.hire_date + DATE_PART('year', AGE(v.start_date, e.hire_date))::int * INTERVAL '1 year' - INTERVAL '1 day')::date AS new_aq_end,
  (e.hire_date + DATE_PART('year', AGE(v.start_date, e.hire_date))::int * INTERVAL '1 year')::date AS new_co_start,
  (e.hire_date + (DATE_PART('year', AGE(v.start_date, e.hire_date))::int + 1) * INTERVAL '1 year' - INTERVAL '1 day')::date AS new_co_end
FROM vacations v
JOIN employees e ON e.id = v.employee_id
WHERE v.deleted_at IS NULL
  AND v.status != 'canceled'
  AND v.start_date >= e.hire_date
  AND DATE_PART('year', AGE(v.start_date, e.hire_date))::int >= 1
ORDER BY v.created_at DESC;
```

Inspecionar output. Linhas com `old_aq_start != new_aq_start` são os registros afetados. Exportar CSV para auditoria.
</details>

<details>
<summary>2. Preview de registros pulados (start_date < hire_date ou sem direito adquirido)</summary>

```sql
SELECT
  v.id, e.name, e.hire_date, v.start_date, v.days_entitled,
  CASE
    WHEN v.start_date < e.hire_date THEN 'start_before_hire'
    WHEN DATE_PART('year', AGE(v.start_date, e.hire_date))::int < 1 THEN 'no_rights_yet'
    ELSE 'other'
  END AS skip_reason
FROM vacations v
JOIN employees e ON e.id = v.employee_id
WHERE v.deleted_at IS NULL
  AND v.status != 'canceled'
  AND (v.start_date < e.hire_date OR DATE_PART('year', AGE(v.start_date, e.hire_date))::int < 1)
ORDER BY v.created_at DESC;
```

Registros inválidos (Andre/Joao etc.) — decidir caso a caso com o cliente. Não são corrigidos pelo backfill.
</details>

<details>
<summary>3. UPDATE em transação</summary>

```sql
BEGIN;

UPDATE vacations v
SET
  acquisition_period_start = (e.hire_date + (DATE_PART('year', AGE(v.start_date, e.hire_date))::int - 1) * INTERVAL '1 year')::date,
  acquisition_period_end = (e.hire_date + DATE_PART('year', AGE(v.start_date, e.hire_date))::int * INTERVAL '1 year' - INTERVAL '1 day')::date,
  concessive_period_start = (e.hire_date + DATE_PART('year', AGE(v.start_date, e.hire_date))::int * INTERVAL '1 year')::date,
  concessive_period_end = (e.hire_date + (DATE_PART('year', AGE(v.start_date, e.hire_date))::int + 1) * INTERVAL '1 year' - INTERVAL '1 day')::date,
  updated_at = NOW()
FROM employees e
WHERE v.employee_id = e.id
  AND v.deleted_at IS NULL
  AND v.status != 'canceled'
  AND v.start_date >= e.hire_date
  AND DATE_PART('year', AGE(v.start_date, e.hire_date))::int >= 1
RETURNING v.id, e.name, v.start_date, v.acquisition_period_start, v.acquisition_period_end, v.concessive_period_start, v.concessive_period_end;
```

Inspecionar count + amostra. Se OK: `COMMIT;` | senão: `ROLLBACK;`
</details>

<details>
<summary>4. Sanity check pós-COMMIT</summary>

```sql
SELECT COUNT(*) AS records_still_off
FROM vacations v
JOIN employees e ON e.id = v.employee_id
WHERE v.deleted_at IS NULL
  AND v.status != 'canceled'
  AND v.start_date >= e.hire_date
  AND DATE_PART('year', AGE(v.start_date, e.hire_date))::int >= 1
  AND (
    v.acquisition_period_start IS DISTINCT FROM (e.hire_date + (DATE_PART('year', AGE(v.start_date, e.hire_date))::int - 1) * INTERVAL '1 year')::date
    OR v.acquisition_period_end IS DISTINCT FROM (e.hire_date + DATE_PART('year', AGE(v.start_date, e.hire_date))::int * INTERVAL '1 year' - INTERVAL '1 day')::date
    OR v.concessive_period_start IS DISTINCT FROM (e.hire_date + DATE_PART('year', AGE(v.start_date, e.hire_date))::int * INTERVAL '1 year')::date
    OR v.concessive_period_end IS DISTINCT FROM (e.hire_date + (DATE_PART('year', AGE(v.start_date, e.hire_date))::int + 1) * INTERVAL '1 year' - INTERVAL '1 day')::date
  );
```

Esperado: `0`.
</details>

## Out of scope

- Fracionamento de férias (#227) — requer agrupar registros por aquisitivo e controlar saldo. Depende desta PR.
- Abono pecuniário (#229) — adiciona `daysSold`. Independente.
- Registros com `start_date < hire_date` (Andre/Joao) — sinalizados mas não corrigidos. Cliente decide caso a caso.
- Registros com `daysEntitled > 30` já em DB — não corrigidos pelo backfill. Cliente fará recadastro após fracionamento.