### PR TITLE
fix(vacations): reject daysEntitled sum > 30 per aquisitivo (CLT art. 130)

### DIFF
--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -7,6 +7,7 @@ Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias.
 - `startDate` deve ser <= `endDate`
 - Nenhuma data das ferias pode ser anterior a data de admissao do funcionario (`hireDate`): `startDate`, `endDate`. (Os periodos aquisitivo/concessivo sao computados a partir do `hireDate`, portanto sempre posteriores por construcao.)
 - `daysEntitled` deve corresponder exatamente ao intervalo de datas (`endDate - startDate + 1`), validado via `calculateDaysBetween` no service
+- **Soma de `daysEntitled` por aquisitivo nao pode exceder 30 dias** (CLT art. 130). Validado no service via `ensureAquisitivoLimit` considerando todos os registros nao-cancelados e nao-deletados do mesmo employee no mesmo `acquisition_period_start`. Aplicado em create (usando periodos computados) e update (usando o snapshot armazenado, excluindo o proprio registro). Registros com `status = canceled` ou `deletedAt != null` nao contam.
 - `daysUsed` deve ser >= 0 e <= `daysEntitled`
 - Periodos aquisitivo e concessivo: campos inline na tabela `vacations` (nao entidade separada)
   - `acquisitionPeriodStart` / `acquisitionPeriodEnd` / `concessivePeriodStart` / `concessivePeriodEnd`
@@ -56,6 +57,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `VacationInvalidDateRangeError` (422)
 - `VacationInvalidDaysError` (422) -- daysEntitled != intervalo de datas, ou daysUsed > daysEntitled
 - `VacationDateBeforeHireError` (422) -- qualquer data anterior a hireDate do funcionario
+- `VacationAquisitivoExceededError` (422) -- soma de `daysEntitled` no aquisitivo excederia 30 dias. Details: `{ acquisitionPeriodStart, acquisitionPeriodEnd, currentTotal, requestedDays, daysRemaining, maxAllowed: 30 }`.
 - `VacationNoRightsError` (422) -- `startDate` anterior ao primeiro aniversario da admissao
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)
 - `EmployeeTerminatedError` (422) -- shared, from `src/lib/errors/employee-status-errors.ts`

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -710,4 +710,311 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
   });
+
+  test("accepts 2nd vacation in same aquisitivo when sum <= 30", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const first = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-20", // 20 days
+          daysEntitled: 20,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(first.status).toBe(200);
+
+    const second = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-08-01",
+          endDate: "2026-08-10", // 10 days, totals 30 in aquisitivo
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(second.status).toBe(200);
+  });
+
+  test("rejects 2nd vacation in same aquisitivo when sum > 30 (CLT art. 130)", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-20", // 20 days
+          daysEntitled: 20,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    const second = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-08-01",
+          endDate: "2026-08-15", // 15 days, would total 35
+          daysEntitled: 15,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(second.status).toBe(422);
+    const body = await second.json();
+    expect(body.error.code).toBe("VACATION_AQUISITIVO_EXCEEDED");
+    expect(body.error.details.daysRemaining).toBe(10);
+    expect(body.error.details.currentTotal).toBe(20);
+    expect(body.error.details.requestedDays).toBe(15);
+  });
+
+  test("boundary: accepts 2nd vacation when sum equals exactly 30", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-29", // 29 days
+          daysEntitled: 29,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    const second = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-08-05",
+          endDate: "2026-08-05", // 1 day, totals 30 exactly
+          daysEntitled: 1,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(second.status).toBe(200);
+  });
+
+  test("limit is scoped per aquisitivo — consecutive aquisitivos are independent", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    // 1st aquisitivo: 2024-06-10 / 2025-06-09 (startDate 2026-05-01 → completed=1, index=0)
+    const firstAq = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-05-01",
+          endDate: "2026-05-30", // 30 days
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(firstAq.status).toBe(200);
+
+    // 2nd aquisitivo: 2025-06-10 / 2026-06-09 (startDate 2027-02-01 → completed=2, index=1)
+    const secondAq = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2027-02-01",
+          endDate: "2027-03-02", // 30 days in a different aquisitivo
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(secondAq.status).toBe(200);
+  });
+
+  test("canceled vacations do not count toward the aquisitivo sum", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const firstResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-30",
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(firstResponse.status).toBe(200);
+    const { data: first } = await firstResponse.json();
+
+    const cancelResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${first.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "canceled" }),
+      })
+    );
+    expect(cancelResponse.status).toBe(200);
+
+    const second = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-09-01",
+          endDate: "2026-09-30",
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(second.status).toBe(200);
+  });
+
+  test("deleted vacations do not count toward the aquisitivo sum", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const firstResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-30",
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(firstResponse.status).toBe(200);
+    const { data: first } = await firstResponse.json();
+
+    const deleteResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${first.id}`, {
+        method: "DELETE",
+        headers,
+      })
+    );
+    expect(deleteResponse.status).toBe(200);
+
+    const second = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-09-01",
+          endDate: "2026-09-30",
+          daysEntitled: 30,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    expect(second.status).toBe(200);
+  });
 });

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -661,4 +661,222 @@ describe("PUT /v1/vacations/:id", () => {
 
     expect(updateResponse.status).toBe(422);
   });
+
+  test("rejects update of daysEntitled when new total exceeds 30 in aquisitivo", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    // First vacation: 20 days
+    await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-20",
+          daysEntitled: 20,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    // Second vacation: 5 days (total 25)
+    const secondResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-08-01",
+          endDate: "2026-08-05",
+          daysEntitled: 5,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    const { data: second } = await secondResponse.json();
+
+    // Update second to 15 days → would total 35 in aquisitivo
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${second.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          startDate: "2026-08-01",
+          endDate: "2026-08-15",
+          daysEntitled: 15,
+        }),
+      })
+    );
+
+    expect(updateResponse.status).toBe(422);
+    const body = await updateResponse.json();
+    expect(body.error.code).toBe("VACATION_AQUISITIVO_EXCEEDED");
+    expect(body.error.details.currentTotal).toBe(20);
+    expect(body.error.details.requestedDays).toBe(15);
+    expect(body.error.details.daysRemaining).toBe(10);
+  });
+
+  test("accepts update of daysEntitled when own record is excluded from sum", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    // Only vacation in aquisitivo: 20 days
+    const createResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-20",
+          daysEntitled: 20,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    const { data: created } = await createResponse.json();
+
+    // Update to 25 days — self-excluded so sum = 25 (not 45)
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${created.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          startDate: "2026-07-01",
+          endDate: "2026-07-25",
+          daysEntitled: 25,
+        }),
+      })
+    );
+    expect(updateResponse.status).toBe(200);
+  });
+
+  test("accepts update of daysEntitled within aquisitivo limit (sum still <= 30)", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    // 10 + 10 in same aquisitivo
+    await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    const secondResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-08-01",
+          endDate: "2026-08-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    const { data: second } = await secondResponse.json();
+
+    // Update second to 15 days → total 25, under limit
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${second.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          startDate: "2026-08-01",
+          endDate: "2026-08-15",
+          daysEntitled: 15,
+        }),
+      })
+    );
+    expect(updateResponse.status).toBe(200);
+  });
+
+  test("update without daysEntitled change does not trigger the aquisitivo check", async () => {
+    // Regression guard: legacy records already over-limit must still be editable
+    // for non-day fields (status, notes) without being blocked by the new check.
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const createResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-07-01",
+          endDate: "2026-07-15",
+          daysEntitled: 15,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+    const { data: created } = await createResponse.json();
+
+    // Update only notes — aquisitivo check must be skipped
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${created.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "Observação atualizada" }),
+      })
+    );
+    expect(updateResponse.status).toBe(200);
+  });
 });

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -97,3 +97,21 @@ export class VacationNoRightsError extends VacationError {
     );
   }
 }
+
+export class VacationAquisitivoExceededError extends VacationError {
+  status = 422;
+
+  constructor(args: {
+    acquisitionPeriodStart: string;
+    acquisitionPeriodEnd: string;
+    currentTotal: number;
+    requestedDays: number;
+    daysRemaining: number;
+  }) {
+    super(
+      `Soma de dias no aquisitivo (${args.acquisitionPeriodStart} a ${args.acquisitionPeriodEnd}) excede o limite de 30 (CLT art. 130). Saldo disponível: ${args.daysRemaining} dias.`,
+      "VACATION_AQUISITIVO_EXCEEDED",
+      { ...args, maxAllowed: 30 }
+    );
+  }
+}

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -6,6 +6,7 @@ import { calculateDaysBetween } from "@/lib/schemas/date-helpers";
 import { computePeriodsFromHireDate } from "@/modules/occurrences/vacations/period-calculation";
 import {
   VacationAlreadyDeletedError,
+  VacationAquisitivoExceededError,
   VacationDateBeforeHireError,
   VacationInvalidDateRangeError,
   VacationInvalidDaysError,
@@ -19,6 +20,8 @@ import type {
   UpdateVacationInput,
   VacationData,
 } from "./vacation.model";
+
+const MAX_VACATION_DAYS_PER_AQUISITIVO = 30;
 
 const SELECT_FIELDS = {
   id: schema.vacations.id,
@@ -42,6 +45,59 @@ const SELECT_FIELDS = {
 } as const;
 
 export abstract class VacationService {
+  private static async ensureAquisitivoLimit(args: {
+    employeeId: string;
+    organizationId: string;
+    acquisitionPeriodStart: string | null;
+    acquisitionPeriodEnd: string | null;
+    requestedDays: number;
+    excludeId?: string;
+  }): Promise<void> {
+    // Legacy records may have null aquisitivo snapshots. The sum is
+    // unanchored — skip the check. Per-record Zod .max(30) still
+    // protects against obviously-invalid payloads.
+    if (
+      args.acquisitionPeriodStart === null ||
+      args.acquisitionPeriodEnd === null
+    ) {
+      return;
+    }
+
+    const conditions = [
+      eq(schema.vacations.organizationId, args.organizationId),
+      eq(schema.vacations.employeeId, args.employeeId),
+      eq(schema.vacations.acquisitionPeriodStart, args.acquisitionPeriodStart),
+      sql`${schema.vacations.status} != 'canceled'`,
+      isNull(schema.vacations.deletedAt),
+    ];
+    if (args.excludeId) {
+      conditions.push(sql`${schema.vacations.id} != ${args.excludeId}`);
+    }
+
+    const [row] = await db
+      .select({
+        total: sql<number>`COALESCE(SUM(${schema.vacations.daysEntitled}), 0)::int`,
+      })
+      .from(schema.vacations)
+      .where(and(...conditions));
+
+    const currentTotal = row?.total ?? 0;
+    const projectedTotal = currentTotal + args.requestedDays;
+
+    if (projectedTotal > MAX_VACATION_DAYS_PER_AQUISITIVO) {
+      throw new VacationAquisitivoExceededError({
+        acquisitionPeriodStart: args.acquisitionPeriodStart,
+        acquisitionPeriodEnd: args.acquisitionPeriodEnd,
+        currentTotal,
+        requestedDays: args.requestedDays,
+        daysRemaining: Math.max(
+          0,
+          MAX_VACATION_DAYS_PER_AQUISITIVO - currentTotal
+        ),
+      });
+    }
+  }
+
   private static async findById(
     id: string,
     organizationId: string
@@ -258,6 +314,14 @@ export abstract class VacationService {
       data.daysEntitled,
       data.daysUsed
     );
+
+    await VacationService.ensureAquisitivoLimit({
+      employeeId: data.employeeId,
+      organizationId,
+      acquisitionPeriodStart: periods.acquisitionPeriodStart,
+      acquisitionPeriodEnd: periods.acquisitionPeriodEnd,
+      requestedDays: data.daysEntitled,
+    });
 
     await VacationService.ensureNoOverlap({
       organizationId,

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -500,6 +500,17 @@ export abstract class VacationService {
       );
     }
 
+    if (data.daysEntitled !== undefined) {
+      await VacationService.ensureAquisitivoLimit({
+        employeeId: existing.employee.id,
+        organizationId,
+        acquisitionPeriodStart: existing.acquisitionPeriodStart,
+        acquisitionPeriodEnd: existing.acquisitionPeriodEnd,
+        requestedDays: merged.daysEntitled,
+        excludeId: id,
+      });
+    }
+
     if (data.startDate !== undefined || data.endDate !== undefined) {
       await VacationService.ensureNoOverlap({
         organizationId,

--- a/src/test/helpers/vacation.ts
+++ b/src/test/helpers/vacation.ts
@@ -30,7 +30,7 @@ export async function createTestVacation(
     overrides.endDate ??
     (() => {
       const d = new Date(startDate);
-      d.setDate(d.getDate() + faker.number.int({ min: 5, max: 30 }));
+      d.setDate(d.getDate() + faker.number.int({ min: 5, max: 29 }));
       return d.toISOString().split("T")[0];
     })();
 


### PR DESCRIPTION
## Resumo

Closes #232.

### O bug

A PR #231 adicionou `.max(30)` no Zod schema, mas o limite é aplicado **por registro**. A CLT art. 130 exige `≤ 30 dias por aquisitivo`. Antes deste fix era possível criar vários registros no mesmo aquisitivo (ex.: 20 + 15 dias) e somar mais de 30 sem o backend reclamar — exatamente o caso da Raquel Maria em homologação (35 + 45 + 7 = 87 dias em um único aquisitivo).

### O fix

- Novo erro `VacationAquisitivoExceededError` (422) com `currentTotal`, `requestedDays`, `daysRemaining`, `maxAllowed: 30` + janela do aquisitivo no `details`.
- Novo helper privado `VacationService.ensureAquisitivoLimit` que soma `daysEntitled` dos registros ativos (não-cancelados, não-deletados) no mesmo aquisitivo do employee e rejeita se ultrapassar 30.
- Chamado em `create` (usando os períodos recém-computados) e em `validateUpdate` (usando o snapshot existente, excluindo o próprio registro via `excludeId`).
- Update só dispara check quando `daysEntitled` está no payload — updates de apenas `notes`/`status` não são bloqueados mesmo em registros legados já acima do limite.
- Zod `.max(30)` por registro **permanece** como fail-fast antes do DB.
- Short-circuit defensivo quando `acquisitionPeriodStart`/`End` for `null` (registros legados pré-#226) — `VacationData` tem esses campos como `string | null`.

### Constante

Extraído `MAX_VACATION_DAYS_PER_AQUISITIVO = 30` no topo de `vacation.service.ts` para evitar magic number no helper.

### Out of scope

- Limite de 3 parcelas por aquisitivo (#227).
- Regra "pelo menos 1 parcela ≥ 14 dias" (#227).
- UX de saldo no frontend (#227).
- Recadastro manual dos registros já inconsistentes em homologação (cliente faz após #227).

## Commits

- `ca2fad0` feat(vacations): add VacationAquisitivoExceededError (422)
- `9075887` feat(vacations): validate daysEntitled sum per aquisitivo on create (CLT art. 130)
- `33a516d` feat(vacations): validate daysEntitled sum per aquisitivo on update (CLT art. 130)
- `51e8236` docs(vacations): document per-aquisitivo daysEntitled sum limit

## Test plan

- [x] `NODE_ENV=test bun test --env-file .env.test src/modules/occurrences/vacations/__tests__/ src/modules/employees/__tests__/` → **175 pass, 0 fail** (165 baseline + 10 novos)
- [x] `npx tsc --noEmit` → clean
- [x] `npx ultracite check` → 560 files, no fixes applied
- [ ] CI (full suite)
- [ ] Cliente valida em homologação:
  - Criar 2 férias somando > 30 no mesmo aquisitivo → 422 com `VACATION_AQUISITIVO_EXCEEDED`
  - Criar 2 férias somando = 30 → ambas aceitas (boundary)
  - Cancelar uma e criar outra no mesmo aquisitivo → aceita (canceladas não contam)
  - Deletar uma e criar outra → aceita (deletadas não contam)
  - Aquisitivos consecutivos independentes (30 + 30 em anos diferentes) → ambos aceitos
  - Update de `daysEntitled` que estouraria o aquisitivo → 422 com `daysRemaining` nos details
  - Update do próprio registro dentro do limite (ex.: 20 → 25 em aquisitivo único) → 200 (self-excluded)
  - Update apenas de `notes` em registro legado já over-limit → 200 (check pulado)

## Rollout

1. Merge em `preview` → deploy homologação
2. Cliente valida os cenários acima em homologação
3. Merge `preview` → `main` → deploy produção

**Não requer backfill SQL** — o fix apenas impede dados novos inválidos. Registros legados excedendo 30 dias (identificados no backfill do #231) ficam como estão até o cliente fazer o recadastro manual ou até o #227 trazer fracionamento completo com UX de saldo.

## Testes adicionados

**create-vacation.test.ts** (+6):
- accepts 2nd vacation in same aquisitivo when sum <= 30
- rejects 2nd vacation in same aquisitivo when sum > 30 (CLT art. 130) — valida código do erro e `daysRemaining`/`currentTotal`/`requestedDays` no details
- boundary: accepts 2nd vacation when sum equals exactly 30
- limit is scoped per aquisitivo — consecutive aquisitivos are independent
- canceled vacations do not count toward the aquisitivo sum
- deleted vacations do not count toward the aquisitivo sum

**update-vacation.test.ts** (+4):
- rejects update of daysEntitled when new total exceeds 30 in aquisitivo
- accepts update of daysEntitled when own record is excluded from sum
- accepts update of daysEntitled within aquisitivo limit (sum still <= 30)
- update without daysEntitled change does not trigger the aquisitivo check