### PR TITLE
fix(env): harden validation (RU-1) + Compozy workspace + audit baseline

### DIFF
--- a/.compozy/config.toml
+++ b/.compozy/config.toml
@@ -1,0 +1,45 @@
+# Compozy workspace configuration — Synnerdata API
+#
+# Defaults aplicados aos comandos do Compozy neste projeto.
+# Flags explícitas na CLI sempre sobrescrevem estes valores.
+#
+# Referências:
+# - CLAUDE.md raiz: "não faça commit sem ser solicitado" → auto_commit = false
+# - docs/improvements/api-infrastructure-checklist.md (seção 7.5.1) — Fase 3 Opção B
+
+[defaults]
+# Claude Code é o runtime ACP primário neste workspace
+ide = "claude"
+# Opus 4.7 (1M context) para ações complexas do roadmap
+model = "opus"
+# NÃO auto-commitar: controle manual de commits é exigência do projeto
+auto_commit = false
+# Análise profunda para refactors de infraestrutura
+reasoning_effort = "xhigh"
+
+[start]
+# Não reexecutar tasks já marcadas como concluídas em execuções anteriores
+include_completed = false
+
+[tasks]
+# Tipos válidos para task files deste projeto
+types = ["backend", "refactor", "test", "infra", "docs", "chore", "bugfix", "security"]
+
+[fix_reviews]
+# Processar até 2 issues em paralelo por round
+concurrent = 2
+# Batch de 3 issues antes de commit/checkpoint
+batch_size = 3
+
+[fetch_reviews]
+# Provider default caso futuramente adotemos ferramenta externa de review
+provider = "coderabbit"
+# Ignorar nitpicks para focar em problemas reais
+nitpicks = false
+
+[exec]
+# Execuções ad-hoc silenciosas por padrão
+verbose = false
+tui = false
+# Não persistir sessões por padrão (opt-in com --persist quando necessário)
+persist = false

--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,13 @@ yarn-error.log*
 package-lock.json
 **/*.bun
 
-# docs
-/docs
+# docs — por padrão ignorado; exceções explícitas para pastas versionáveis.
+# Usa `/docs/*` (não `/docs`) para que padrões `!` funcionem em filhos específicos.
+/docs/*
+!/docs/improvements/
+!/docs/improvements/**
+!/docs/reports/
+!/docs/reports/**
 
 # worktrees
 .worktrees/

--- a/docs/improvements/api-infrastructure-checklist.md
+++ b/docs/improvements/api-infrastructure-checklist.md
@@ -1,0 +1,1385 @@
+# Checklist de Infraestrutura de API
+
+> **⚠️ Documento vivo.** Este arquivo deve ser **atualizado continuamente** conforme a iniciativa avança:
+> - Decisão nova ou mudada → atualizar a seção correspondente **e** registrar no Changelog (última seção)
+> - Item auditado → atualizar Status (✅/⚠️/❌/N/A) + Observações nas seções 4 e 5
+> - Fase concluída → atualizar quadro 7.0 e registrar no Changelog
+> - Débito novo descoberto → adicionar em 7.7
+>
+> Quem retomar este trabalho (você, outro agente, ou o futuro-você daqui a 3 meses) deve conseguir reconstruir **de onde viemos, onde estamos e para onde vamos** apenas lendo este arquivo.
+
+Documento com a matriz de práticas de infraestrutura que sustentam uma API em termos de **segurança, confiabilidade, maturidade e performance**. A parte conceitual é **agnóstica** (reusável em qualquer projeto); a seção de aplicação está preenchida com o contexto do **synnerdata-api-b**.
+
+Organização:
+1. **Princípios de priorização** — regras para decidir o que entra em cada estágio.
+2. **Fluxo de trabalho** — 4 fases para sair da teoria e chegar a código melhor.
+3. **Eixos de contexto** — dimensões que alteram a prioridade de cada item.
+4. **Núcleo universal** — vale para qualquer API; estratificado em MVP / Early-stage / Scale.
+5. **Context-dependent** — ativa quando a API tem certo contexto; estratificado em MVP / Early-stage / Scale.
+6. **OWASP API Top 10 (2023)** — mapeamento de referência.
+7. **Aplicação ao projeto (synnerdata-api-b)** — status da iniciativa, contexto aplicado, compliance, decisões registradas, plano da Fase 1, débitos já identificados.
+8. **Changelog** — registro temporal das decisões e entregas.
+9. **Referências** — fontes usadas.
+
+---
+
+## 1. Princípios de priorização
+
+### YAGNI vs segurança — a regra prática
+
+> **YAGNI aplica-se à complexidade da solução, não à proteção contra abuso.**
+
+- **"Não implementar X"** → quase sempre YAGNI legítimo.
+  *Exemplos:* não implementar paginação com cursor, cache distribuído, idempotency keys universais.
+- **"Não limitar X"** → quase sempre dívida de segurança disfarçada.
+  *Exemplos:* não limitar body size, `limit` máximo na listagem, tempo de request.
+
+**Caso prático:** paginação client-side (backend devolve tudo, front pagina visualmente) é corte de complexidade válido em early-stage. Mas sem `limit.max(100)` no schema, qualquer cliente pode chamar `GET /items?limit=999999` e derrubar o servidor. Uma linha de código evita DoS.
+
+### Segurança tem gradações
+
+| Camada | O que é | Estágio |
+|---|---|---|
+| **Contra incidente catastrófico** | Vazamento entre clientes, brute-force, DoS trivial, HTTPS | MVP obrigatório |
+| **Redução de superfície de ataque** | Security headers completos, secrets manager, response filtering sistemático | Early-stage |
+| **Defesa em profundidade** | Anti-automation, SSRF prevention, cursor complexity analysis | Scale |
+
+Um projeto com segurança "MVP" **não está inseguro** — está apropriadamente protegido para seu estágio. Segurança máxima no dia 1 é paranoia que viola YAGNI.
+
+### Critério de corte por estágio
+
+| Estágio | Critério | Pergunta guia |
+|---|---|---|
+| **MVP** | Ausência causa incidente grave **OU** implementação custa < 30min com alto payoff | "Se eu lançar sem isso, em quanto tempo vira problema?" |
+| **Early-stage** | Dói em semanas/meses de uso real, mas não bloqueia launch | "Adicionar antes do primeiro incidente ou antes da primeira auditoria" |
+| **Scale** | Só faz sentido com volume/clientes/integração específicos | "Esperar sinal real antes de investir" |
+
+---
+
+## 2. Fluxo de trabalho
+
+Metodologia para sair da teoria (checklist agnóstico) e chegar a código melhor (implementação priorizada) sem fase morta ou trabalho dobrado.
+
+### Fase 0 — Contexto aplicado (sem código)
+
+Fechar os 6 eixos de contexto no **projeto específico**. Decidir quais itens `context-dependent` viram relevantes e em qual estágio. Registrar decisões arquiteturais e compliance aplicável.
+
+**Entrega:** seções 7.1, 7.2 e 7.3 preenchidas.
+
+### Fase 1 — Audit item a item (sem código)
+
+Varrer o código (bootstrap, lib, módulos relevantes) e para **cada item da checklist** marcar:
+
+- ✅ implementado corretamente
+- ⚠️ existe mas com débito (precisa refactor)
+- ❌ não existe (implementação nova)
+- N/A no contexto
+
+**Entrega:** colunas `Status` e `Observações` preenchidas nas seções 4 e 5.
+
+### Fase 2 — Roadmap priorizado (sem código)
+
+Consolidar os achados em 3 buckets de execução:
+
+- 🔴 **Urgente** — MVP faltante + débitos críticos (risco real hoje em prod)
+- 🟡 **Curto prazo (30-90 dias)** — hardening + preparação compliance integrada
+- 🟢 **Médio prazo / sob demanda** — itens scale + certificações quando surgir exigência
+
+**Entrega:** seção 7.5 preenchida.
+
+### Fase 3 — Execução item a item
+
+Atacar o roadmap em ordem 🔴 → 🟡 → 🟢. Para cada item, independente de ser refactor ou implementação nova:
+
+1. Abrir branch dedicada (`feat/` ou `fix/` ou `refactor/`) derivando de `preview`
+2. Implementar com testes (seguir padrões do projeto)
+3. PR → preview → main
+4. Voltar ao checklist e atualizar status
+
+**Princípio-chave:** não separar "revisar existente" de "implementar faltante" em macro-fases. A prioridade real é por **risco**, não por "já existe ou não". Itens relacionados devem ser atacados juntos para evitar tocar os mesmos arquivos duas vezes.
+
+---
+
+## 3. Eixos de contexto
+
+Dimensões que alteram a prioridade/aplicabilidade de cada item. Referência para decidir o que entra em "context-dependent" no contexto específico do projeto.
+
+| # | Eixo | Valores típicos |
+|---|---|---|
+| 1 | **Tipo de cliente** | browser / mobile / server-to-server / IoT |
+| 2 | **Tenancy** | single-tenant / multi-tenant |
+| 3 | **Domínio / regulação** | B2B / B2C / financeiro / saúde / governo / genérico |
+| 4 | **Arquitetura interna** | monolito / microserviços / serverless / filas assíncronas |
+| 5 | **Escala / padrão de carga** | baixo volume / alto volume / read-heavy / write-heavy |
+| 6 | **Exposição** | pública na internet / privada (VPC/VPN) / atrás de BFF / consumida por terceiros |
+
+---
+
+## 4. Núcleo universal
+
+Vale para **qualquer API** em produção, independente de contexto. Faltar qualquer item de MVP é risco real.
+
+**Legenda de Status (a preencher na fase de audit):** ✅ implementado · ⚠️ parcial · ❌ não implementado
+
+### 4.1 MVP universal
+
+Em ordem decrescente de prioridade.
+
+| # | Item | Por quê | Status | Observações |
+|---|---|---|---|---|
+| 1 | HTTPS/TLS em produção | Não-negociável em qualquer API pública | ✅ | Coolify + Let's Encrypt automático (README §Deploy) |
+| 2 | Authentication forte (se dados não-públicos) | Lib madura (hash argon2/bcrypt, sessão/JWT com expiração) | ✅ | Better Auth com: email/password + `requireEmailVerification: true` + complexity hook (upper/lower/digit/special) + `minPasswordLength: 8` / `maxPasswordLength: 128` (anti-DoS hash) + `revokeSessionsOnPasswordReset: true` + 2FA OTP criptografado (5 tentativas, 6 dígitos, 5min) + 10 backup codes criptografados + cookie cache 5min + `useSecureCookies` em prod. 🏆🏆 synnerdata >> avocado-hp |
+| 3 | Input validation em toda boundary externa | Schema lib (Zod, Joi, AJV) — primeira linha de defesa | ✅ | Zod v4 + `z.config(z.locales.pt())` em `lib/zod-config.ts` (erros em pt-BR automáticos) + `lib/validation/documents.ts` com CPF/CNPJ check digits reais. 🏆 synnerdata > avocado-hp |
+| 4 | Error handling consistente (envelope previsível) | Clientes precisam de formato único; evita vazamento de stack trace | ✅ | `errorPlugin` com `AppError` hierarchy + Sentry integration em 5xx/unhandled + formatação recursiva de `cause` (Drizzle wrap) + `cause` exposto em dev, escondido em prod. 🏆 synnerdata > avocado-hp |
+| 5 | Env validation + fail-fast no boot | Config quebrada não deve subir silenciosamente | ⚠️ | Parse Zod na startup ✅. Débitos: `BETTER_AUTH_SECRET` sem `.min(32)`; `SMTP_USER/PASSWORD` `.optional()` sem refine condicional em prod; `PII_ENCRYPTION_KEY.length(64)` não valida hex; `SMTP_FROM` deveria ser `z.email()`; `NODE_ENV` não validado (usa `process.env.NODE_ENV` direto); `CORS_ORIGIN` formato comma-separated implícito |
+| 6 | Secrets fora do código | `.env` não commitado; não hardcoded | ✅ | Tudo via `env.ts`; `.env` não commitado |
+| 7 | Body size limit explícito | Defaults dos runtimes costumam ser generosos demais — DoS trivial | ✅ | `maxRequestBodySize: 1024 * 1024 * 10` (10MB) em `src/index.ts:62`. 🏆 synnerdata > avocado-hp |
+| 8 | Request timeout | Handler bloqueado pendura o servidor indefinidamente | ❌ | **Não configurado.** Nem no `index.ts` (Elysia `serve.idleTimeout`) nem por plugin |
+| 9 | Rate limit global | Primeira barreira contra abuso/scan automatizado | ✅ | `elysia-rate-limit` — 100 req/min por IP, 60s window, headers expostos. `src/index.ts:93-105` |
+| 10 | Rate limit agressivo em endpoints de auth | Brute-force em login é atacado por bots automaticamente | ✅ | Better Auth tem rate limit interno **mais rigoroso que o global**: `/sign-in/*` 5req/min, `/sign-up/*` 3req/min, `/two-factor/*` 3req/min, `/forgot-password/*` 3req por 5min, `/send-verification-email` 3req por 5min, `/get-session` unlimited. Skip no rate limit global está **correto**. ⚠️ Ressalva: `storage: "memory"` — não escala horizontalmente. Com 1 instância no Coolify hoje = ok; revisar em escala |
+| 11 | Max page size em qualquer endpoint de listagem | DoS via query pesada, independente de paginação sofisticada | ? | Validar nos controllers dos módulos (Bloco 4) e em `lib/schemas/` (Bloco 2) |
+| 12 | Health check (liveness) | Qualquer orquestrador/load balancer precisa | ✅ | `/health/live` (liveness) + `/health` (deep: DB com latência, version, uptime). `lib/health/index.ts` |
+| 13 | Graceful shutdown (SIGTERM) | Requests em voo não podem ser cortadas ao deploy | ✅ | SIGTERM + SIGINT, flag `isShuttingDown`, logs estruturados em cada etapa, `Bun.sleep()` no grace period, `pool.end()` no fim. `lib/shutdown/shutdown.ts` |
+| 14 | Logs estruturados (JSON) | Logs text-based não permitem agregação/queries | ✅ | Pino JSON em prod, pino-pretty em dev, silent em test. Nível por ambiente (info/debug/silent). `lib/logger/CLAUDE.md` documenta arquitetura. 🏆 synnerdata > avocado-hp (tem CLAUDE.md dedicado) |
+| 15 | Correlation ID / Request ID | Header de request + log — correlacionar suporte a logs | ✅ | `req-<uuid>` gerado no `derive`, injetado via `AsyncLocalStorage`, Pino mixin inclui `requestId` em todo log automaticamente. `X-Request-ID` injetado no header tanto em sucesso (`onAfterHandle`) quanto em erro (`onError` do logger). 🏆 synnerdata > avocado-hp (avocado-hp não injetava header em erro) |
+| 16 | requestId no body do erro | Primeiro ticket de suporte vai pedir — custo trivial | ❌ | **Confirmado ausente.** `errorPlugin` loga `requestId` via mixin (em log), mas o envelope de resposta NÃO retorna `requestId`. Cliente só vê no header `X-Request-ID` — suporte precisa pedir manualmente |
+| 17 | Error tracking (Sentry ou equivalente) | Logs você não lê; error tracker alerta 5xx | ✅ | GlitchTip via `@sentry/bun`. `beforeSend` **remove `authorization` e `cookie`** do request (proteção contra vazamento de credencial). `tracesSampleRate` 0.2 prod / 1.0 dev. Environment "production"/"preview". `captureException` chamado em 5xx AppError e unhandled. 🏆 synnerdata > avocado-hp (avocado-hp não tinha) |
+| 18 | Dependency audit em CI | Supply chain é vetor principal; `npm/bun audit` + Dependabot/Renovate | ⚠️ | **Trivy** scan imagem Docker (semanal + PR main/preview) ✅. **Dependabot** completo (npm + docker + github-actions) com target `preview`, groups e security patches ✅. **Mas `bun pm audit` NÃO está em nenhum workflow nem no package.json** — README está errado ao afirmar isso. Trivy cobre CVE de lib Docker, mas deps JS específicas são auditadas só via Dependabot (reativo, não bloqueia PR). Adicionar `bun pm audit --audit-level=high` no lint.yml. 🏆 Dependabot config é excelente |
+| 19 | Lockfile versionado + reproducible builds | Sem lockfile, cada build pode trazer deps diferentes | ✅ | `bun.lock` versionado. Dockerfile usa `--frozen-lockfile --production --ignore-scripts`. `.dockerignore` exclui node_modules/dist/.git/.env*/.claude. Multi-stage build reproduzível |
+
+### 4.2 Early-stage universal
+
+Adicionar antes do primeiro incidente ou antes da primeira auditoria.
+
+| # | Item | Por quê | Status | Observações |
+|---|---|---|---|---|
+| 1 | Health check deep (DB, deps críticas) | Liveness ≠ saúde real — DB fora ainda responde liveness | ✅ | `/health` executa `SELECT 1` com latência e retorna unhealthy se falhar. Só checa DB (sem Pagar.me/SMTP, correto para evitar cascata) |
+| 2 | Métricas básicas (latência/throughput/erro rate) | Logs resolvem triagem; métricas antecipam degradação | ❌ | Sem Prometheus/OTel aparente no bootstrap. GlitchTip cobre error tracking, não métricas |
+| 3 | OpenAPI / contrato documentado | Documentação viva + client gen + validação externa | ✅ | `@elysiajs/openapi` + `mapJsonSchema` Zod v4 customizado + `extractErrorMessages` (bônus: `x-error-messages` nos schemas). 🏆 synnerdata > avocado-hp. `paths: {}` em prod (reduz info disclosure) |
+| 4 | Versionamento na URL (`/v1`) | Prepara para breaking changes sem quebrar clientes | ⚠️ | **Inconsistência.** Bootstrap registra controllers sem prefix global (`src/index.ts:137-143`). `adminController` usa `/v1/admin` (visto em `modules/CLAUDE.md`), mas outros (employees, organizations, occurrences, payments, audit, public) precisam ser auditados no Bloco 4 para confirmar padrão |
+| 5 | Response filtering sistemático | Response schemas tipados em todos os endpoints evitam vazamento acidental | ? | Padrão documentado em `docs/code-standards/`; auditar adesão no Bloco 4 |
+| 6 | Paginação padronizada | Schema reutilizável `limit`/`offset`/`sort`/`search` | ? | Auditar `lib/schemas/` e controllers no Bloco 2/4 |
+| 7 | Secrets manager (Vault/AWS SM/Doppler) | `.env` basta no MVP; em prod com múltiplos ambientes vira fraqueza | ❌ | Coolify gerencia `.env` via UI. Aceitável no MVP com 1 cliente; revisar quando escalar |
+| 8 | Testes de integração na CI | Testes unitários não pegam regressão de integração | ⚠️ | `test.yml` com Postgres + MailHog como services, affected tests em PR + full suite diário. **Mas `SKIP_INTEGRATION_TESTS: "true"` setado no CI** — integration tests aparentemente pulados (validar semântica do flag). **Playwright E2E NÃO está em nenhum workflow** — só há script `test:e2e` no package.json sem CI. 🏆 Affected tests via `scripts/affected-tests.sh` é plus sobre avocado-hp |
+| 9 | Política de deprecation (`Deprecation`/`Sunset` headers) | Antes do primeiro breaking change em endpoint público | ❌ | Sem headers ou política escrita. API Key em prod consumida por cliente (Power BI) reforça necessidade |
+| 10 | Backup automatizado do DB | Testar restore, não só backup | ⚠️ | Postgres gerenciado pelo Coolify. **Não há verificação do código** sobre política de backup/restore. Validar via UI do Coolify: frequência, retention, teste periódico de restore. Documentar em runbook |
+
+### 4.3 Scale universal
+
+Quando volume/clientes/SLA justificarem investimento.
+
+| # | Item | Por quê | Status | Observações |
+|---|---|---|---|---|
+| 1 | Observabilidade madura (retenção, alertas, dashboards) | Métricas cruas sem alerta/dashboard não acionam ninguém | | |
+| 2 | SLO/error budget formal | Ao assinar SLA com cliente | | |
+| 3 | Load testing periódico | Sem isso, primeiro spike de tráfego derruba a API | | |
+| 4 | DR/disaster recovery policy ativa | Backup ≠ DR; testar restore regularmente | | |
+| 5 | Runbooks / playbooks de incidente | Oncall precisa saber o que fazer às 3h da manhã | | |
+| 6 | Chaos engineering (opcional/extremo) | Só quando maturidade já é alta | | |
+
+---
+
+## 5. Context-dependent
+
+Aplicável conforme contexto do projeto. Cada item lista o **eixo + valor** que o ativa, e o **estágio** dentro desse contexto.
+
+### 5.1 MVP conforme contexto
+
+Quando o contexto está presente, esses itens viram MVP (não podem esperar).
+
+| # | Item | Contexto ativador | Por quê é MVP nesse contexto | Status | Observações |
+|---|---|---|---|---|---|
+| 1 | CORS configurado com origin específica | Cliente = browser | Front não funciona sem isso; `*` é inseguro | ✅ | `parseOrigins(env.CORS_ORIGIN)` suporta múltiplas origins, `credentials: true`, `allowedHeaders` + `exposeHeaders` específicos, `maxAge: 86400`. 🏆 synnerdata > avocado-hp |
+| 2 | CSRF protection | Cookie-based auth em browser | XSRF trivial sem proteção | ✅ | Better Auth via `trustedOrigins: parseOrigins(env.CORS_ORIGIN)` — CSRF check por origin. Cookies `useSecureCookies` em prod (HTTPS only) |
+| 3 | BOLA — authz por objeto/tenant | Tenancy = multi-tenant | Vazamento entre clientes é catastrófico desde o 1º cliente (OWASP API1) | ⚠️ | Macro `auth` injeta `session.activeOrganizationId` (fonte de isolamento). API key tem `organizationId` na metadata (extraído em `resolveApiKeyOrgContext`). **Mas**: cada service precisa filtrar por `organizationId` manualmente — auditar no Bloco 4 para confirmar disciplina. Risco #1 do OWASP |
+| 4 | RBAC / authorização funcional (BFLA) | Domínio com papéis distintos | Usuário comum não pode executar ação de admin (OWASP API5) | ✅ | `lib/permissions.ts` define system roles (super_admin/admin/user) + org roles (owner/manager/supervisor/viewer) + api-key roles via `createAccessControl`. 26 resources × actions no org level. Macro `auth: { permissions: {...} }` valida via `auth.api.hasPermission()`. 🏆 synnerdata > avocado-hp (avocado-hp tinha menos resources) |
+| 5 | Audit log de ações sensíveis | Regulação (financeiro/saúde/gov/LGPD) | Obrigação legal; imutabilidade do registro | ⚠️ | `AuditService.log()` em `modules/audit/audit.service.ts` tem silent catch interno (design intencional, OK). 🏆 Audit disparado em hooks Better Auth (user create, login, org CRUD, member changes, invitation accept). **Débitos reais**: (1) `auditPlugin` em `lib/audit/` (lugar errado — débito #5); (2) Exige contexto manual no plugin (débito #23); (3) Tipos frouxos (débito #24); (4) **API keys NÃO auditam create/revoke/delete** — crítico para compliance (novo débito #54); (5) **Imutabilidade**: `modules/audit/audit.service.ts` só tem `insert` + `select`, sem update/delete — ✅ imutável. Falta **retention policy** (débito #55) |
+| 6 | Idempotency keys | Integração com pagamento/fiscal externa síncrona | Duplicação = dinheiro/multa | ✅ | **Webhook Pagar.me tem idempotência completa** (`webhook.service.ts:80-96`): check `pagarmeEventId` → se `processedAt` existe, skip. Grava evento antes de processar, atualiza `processedAt` após sucesso. Se erro, salva error mas mantém unprocessed (permite retry). `handleSubscriptionUpdated` também usa timestamp ordering para prevent out-of-order updates. 🏆 synnerdata > avocado-hp |
+| 7 | Criptografia em repouso (DB, backups) | PII / financeiro / saúde / regulado | Obrigação legal (LGPD/HIPAA/PCI) | ✅ | **Implementação excelente** em `lib/crypto/pii.ts`: AES-256-GCM authenticated encryption, **scrypt KDF** com salt per-encrypt (não chave fixa), formato `salt:iv:tag:encrypted`. Helpers `PII.mask.{cpf,email,phone,pis,rg}` para display seguro. `isEncrypted()` para detectar formato. 🏆 **synnerdata >> avocado-hp** (avocado-hp não tinha nada disso). Validar no Bloco 4 quais campos são efetivamente cifrados no DB |
+| 8 | WAF ou bot protection | Exposição = pública B2C ou financeira | Tráfego malicioso/scraping em massa | ❌ | Sem WAF/CDN na frente. Decisão registrada em 7.3 #1 — adotar Cloudflare Free Tier no **final do early-stage** |
+| 9 | mTLS entre serviços | Arquitetura = microserviços em rede não-confiável | Confiança mútua entre nós | N/A | Monolito — não aplicável |
+
+### 5.2 Early-stage conforme contexto
+
+| # | Item | Contexto ativador | Por quê | Status | Observações |
+|---|---|---|---|---|---|
+| 1 | Security headers browser (CSP, X-Frame, Referrer-Policy) | Cliente = browser e API exposta sem CDN aplicando | Redução de superfície a XSS/clickjacking | ⚠️ | **Parcial.** ✅ X-Frame-Options: DENY, Referrer-Policy, X-XSS-Protection, Permissions-Policy configurados via `.headers()` em `src/index.ts:65-74`. ❌ **CSP ausente** — mas valor limitado em API JSON pura (protege HTML renderizado). 🏆 synnerdata > avocado-hp (avocado-hp não tinha nenhum) |
+| 2 | HSTS, X-Content-Type-Options | Qualquer API HTTPS | Baixo custo; bloqueia ataques de downgrade/MIME sniffing | ✅ | `X-Content-Type-Options: nosniff` sempre; `Strict-Transport-Security: max-age=31536000; includeSubDomains` em produção. `src/index.ts:66,72`. 🏆 synnerdata > avocado-hp |
+| 3 | Compression (gzip/brotli) | Payloads grandes sem CDN comprimindo na frente | Reduz bandwidth e latência percebida | ❌ | Sem middleware de compression. Cloudflare Free Tier (decisão 7.3 #1) vai resolver |
+| 4 | HTTP/2 no edge | Cliente com múltiplas conexões concorrentes | Multiplexing reduz overhead de TCP | ? | Depende do proxy do Coolify (Caddy/Traefik). Validar no Bloco 6 |
+| 5 | Jobs assíncronos (fila) | Side-effects que não podem bloquear request (email, relatório, integração) | Request não pode depender de SMTP/API externa lenta | ⚠️ | `cronPlugin` em `lib/cron-plugin.ts` registra **7 cron jobs** via `@elysiajs/cron` **no mesmo processo**: `expire-trials`, `notify-expiring-trials`, `process-scheduled-cancellations`, `suspend-expired-grace-periods`, `process-scheduled-plan-changes`, `activate-scheduled-vacations`, `complete-expired-vacations`. Emails/webhooks síncronos no request path (a confirmar Bloco 4/5). Sem fila externa (Redis/BullMQ) — aceitável MVP; revisar quando volume exigir. Dynamic import suspeito para `VacationJobsService` (possível dep circular) |
+| 6 | Retention policy para logs/audit | Regulado (LGPD/HIPAA/PCI) ou B2B com compliance | Retenção exigida por lei ou contrato | ? | Auditar `modules/audit/` no Bloco 4 e política do Coolify/Postgres no Bloco 6 |
+| 7 | Data minimization em responses | Multi-tenant + dados sensíveis | Reduz superfície de vazamento (OWASP API3) | ? | Depende de response schemas nos módulos — auditar no Bloco 4 |
+| 8 | API gateway / BFF | Múltiplos consumidores (web + mobile + parceiros) | Agregação, caching, rate limit uniforme | N/A | Apenas web + API key — não justifica hoje |
+| 9 | Content negotiation (Accept/Content-Type) rigorosa | API pública com múltiplos formatos | Contrato claro | ? | Elysia + Zod trata Content-Type; validar no Bloco 2 |
+
+### 5.3 Scale conforme contexto
+
+| # | Item | Contexto ativador | Sinal para investir | Status | Observações |
+|---|---|---|---|---|---|
+| 1 | Tracing distribuído (OTel) | Arquitetura = microserviços ou filas assíncronas | 2º serviço/fila introduzido — monolito puro não precisa | | |
+| 2 | Circuit breaker / retry-backoff | Dependências externas síncronas | 1ª dependência externa crítica no request path | | |
+| 3 | Cache layer (Redis/Memcached) | Read-heavy, queries caras repetidas | Queries dominando CPU ou pool de conexões | | |
+| 4 | ETag / conditional GET (`If-None-Match`) | Payloads grandes estáveis re-baixados | Bandwidth/latência de GETs repetidos medível | | |
+| 5 | CDN edge caching | Leitura pública estável (catálogos, docs) | Tráfego geograficamente distribuído ou alto volume |  | |
+| 6 | Paginação por cursor | Tabelas grandes e voláteis | Listagem offset ficando lenta ou inconsistente | | |
+| 7 | Anti-automation em fluxos sensíveis | Fluxos com side-effect/custo sendo abusados | 1º sinal de abuso (convite em massa, reset em massa) | | |
+| 8 | SSRF prevention (allowlist de host) | API faz fetch de URL fornecida pelo cliente | Introdução de webhook ou integração por URL | | |
+| 9 | Service mesh | Arquitetura = microserviços em prod | Múltiplos serviços com comunicação interna complexa | | |
+| 10 | Feature flags / canary deploy | Velocidade de deploy alta (múltiplas/dia) | Risco de deploy completo grande demais | | |
+| 11 | APM avançado (Datadog/New Relic) | Quando Sentry + logs + métricas não bastarem | Diagnóstico ficando limitado pelos dados existentes | | |
+| 12 | Idempotency keys em POSTs críticos | Criação de recursos com efeito não-reversível ou caro | Após 1º incidente de duplicação | | |
+
+---
+
+## 6. OWASP API Security Top 10 (2023)
+
+Referência oficial para risk-ranking de APIs. Usar como "não esquecer" na fase de audit.
+
+| # | Risco | Cobertura típica no núcleo universal | Reforço por contexto |
+|---|---|---|---|
+| API1 | Broken Object Level Authorization (BOLA) | — | Multi-tenant → MVP |
+| API2 | Broken Authentication | Auth forte (MVP universal) | — |
+| API3 | Broken Object Property Level Authorization | Input validation + Response filtering (universal) | Multi-tenant → reforçar em MVP |
+| API4 | Unrestricted Resource Consumption | Body/timeout/rate limit/max page (MVP universal) | — |
+| API5 | Broken Function Level Authorization (BFLA) | — | Papéis/roles → MVP |
+| API6 | Unrestricted Access to Sensitive Business Flows | — | B2C ou fluxos com custo → Scale |
+| API7 | SSRF | — | API faz fetch de URL do cliente → Scale |
+| API8 | Security Misconfiguration | Security headers (Early universal), dep audit (MVP universal) | — |
+| API9 | Improper Inventory Management | OpenAPI + versionamento (Early universal) | — |
+| API10 | Unsafe Consumption of APIs | — | API consome terceiros síncronos → Scale |
+
+---
+
+## 7. Aplicação ao projeto (synnerdata-api-b)
+
+Seção específica do projeto. Começa pelo **status atual** da iniciativa (7.0) — sempre que uma fase avançar, **atualizar aqui e no Changelog**.
+
+### 7.0 Status da iniciativa
+
+| Fase | Status | Data | Entregas |
+|---|---|---|---|
+| **0. Contexto aplicado** | ✅ Concluída | 2026-04-21 | Seções 7.1–7.3, 7.6, 7.7 preenchidas + convenção semântica + 10 débitos pré-audit |
+| **1. Audit item a item** | ✅ Concluída | 2026-04-21 | Status nas seções 4 e 5 preenchidos (~65 itens); 95 débitos totais em 7.7; relatório em [`docs/reports/2026-04-21-api-infrastructure-audit.md`](../reports/2026-04-21-api-infrastructure-audit.md) |
+| **2. Roadmap priorizado** | ✅ Concluída | 2026-04-21 | Seção 7.5 com 69 ações organizadas em 3 buckets (🔴 10 urgentes / 🟡 38 curto prazo / 🟢 21 sob demanda) com IDs, dependências, tipo e esforço |
+| **3. Execução** | 🔄 Iniciando | 2026-04-21 | Opção B (Híbrido) adotada; RU-1 como primeira ação; Compozy setup em paralelo para ativar a partir de RU-6 |
+
+**➡️ Próxima ação:** iniciar **Grupo 1 do bucket 🔴 — RU-1 (hardening de `env.ts`)** via branch `fix/urgent-foundation-hardening`, em paralelo com setup do Compozy (`compozy setup` + `.compozy/config.toml` + habilitar `cy-idea-factory`).
+
+### 7.1 Contexto do projeto
+
+Produto: **Synnerdata** — SaaS B2B de gestão de Departamento Pessoal brasileiro. Atualmente no **MVP com 1 cliente ativo em produção** consumindo a API via front web próprio e via API keys (para integração Power BI do cliente).
+
+| Eixo | Valor no projeto | Implicação |
+|---|---|---|
+| 1. Tipo de cliente | Browser (front web responsivo) + server-to-server (API keys → Power BI do cliente) | CORS é obrigatório, CSRF via Better Auth; headers browser-specific (CSP/X-Frame) têm valor menor em rotas consumidas por API key |
+| 2. Tenancy | Multi-tenant (1 organização = 1 empresa cliente), plugin organizations do Better Auth | **BOLA é risco #1** — isolamento por `organizationId` obrigatório e com testes |
+| 3. Domínio / regulação | B2B SaaS de DP brasileiro — PII sensível (CPF, salário), **dados de saúde sensíveis** (atestados médicos — Art. 11 LGPD), processos trabalhistas. Pagamentos via Pagar.me (sem armazenar cartão) | LGPD obrigatória com rigor extra para dados de saúde; PCI N/A (delegado); audit trail imutável é requisito |
+| 4. Arquitetura interna | Monolito Elysia + PostgreSQL; jobs agendados via `cron-plugin` no mesmo processo; sem filas externas | Tracing distribuído é YAGNI; correlation ID simples basta |
+| 5. Escala / carga | **MVP — 1 cliente, volume baixo**, centenas de funcionários por org, sem projeção para milhares. Uso read+write equilibrado | Cache/cursor/paginação sofisticada são YAGNI; foco em correção e hardening |
+| 6. Exposição | Pública (SaaS na internet), DNS DuckDNS, TLS Let's Encrypt via Coolify, **sem WAF/CDN na frente hoje** (cai direto no Coolify) | Sem edge cobrindo, a app assume responsabilidade por security headers, rate limit, compression, DDoS mitigation básica |
+
+### 7.2 Compliance aplicável
+
+Mapa de conformidade para o contexto do synnerdata. Define o que **entra como requisito do MVP/early-stage** e o que é sob demanda.
+
+| Framework | Aplica? | Nível de esforço no contexto atual |
+|---|---|---|
+| **LGPD** | ✅ Obrigatório | Dados pessoais de funcionários brasileiros. **Dados de saúde** (atestados médicos) são sensíveis pelo Art. 11 — exigem base legal específica, criptografia reforçada, retention justificada. **LGPD é tratada como requisito integrado ao MVP/early-stage, não fase separada** |
+| **PCI DSS** | ❌ Não se aplica | Pagar.me tokeniza o cartão — API recebe `card_id`, nunca PAN/CVV. Requisito único: garantir em audit que **nenhum log/persistência toca dados de cartão cru** |
+| **SOC 2 (Type I/II)** | ⚠️ Opcional / sob demanda | Certificação, não lei. Só investir quando cliente enterprise exigir. Hoje sem sinal |
+| **ISO 27001** | ⚠️ Opcional / sob demanda | Similar a SOC 2 — pressão de venda corporativa/governo. Sem sinal hoje |
+| **eSocial (transmissão)** | ❌ N/A hoje → 🟢 Scale futuro | Hoje a API **só armazena dados localmente para consulta interna do cliente**. Evolução para transmissão direta ao eSocial é roadmap **Scale**, sem pedido atual do cliente |
+| **NRs trabalhistas (NR-1, NR-6, NR-7)** | Indireto | Não regulam a API, mas EPI/atestados/PCMSO podem ser exigidos em fiscalização trabalhista do cliente → **retention policy de audit, EPIs e atestados é obrigação contratual**, não só boa prática |
+
+**Resumo operacional:** no horizonte MVP/early-stage, o foco é **LGPD bem feita com rigor extra para dados de saúde**. SOC 2 e ISO 27001 entram sob demanda de cliente. eSocial é scale. PCI é verificação de audit (não permitir vazamento acidental de cartão).
+
+### 7.3 Decisões arquiteturais registradas
+
+Decisões tomadas nesta rodada de planejamento que devem guiar a execução.
+
+| # | Decisão | Estágio | Observações |
+|---|---|---|---|
+| 1 | **Cloudflare Free Tier na frente da API** — cobre WAF básico, DDoS, HSTS, TLS 1.3, HTTP/2+3, compression, bot fight mode, rate limit básico | 🟡 Early-stage — **etapa final** | DNS hoje no registro.br é do cliente. Requer alinhamento com o cliente para apontar DNS → Cloudflare → Coolify. TLS Let's Encrypt do Coolify permanece atrás |
+| 2 | **Sem WAF/CDN no MVP** | 🔴 MVP | Decisão consciente: volume baixo + 1 cliente B2B não justifica edge agora. A app assume responsabilidades que CDN cobriria (security headers, rate limit, compression) até a decisão #1 ser executada |
+| 3 | **eSocial direto = Scale** | 🟢 Scale | Requer estudo de viabilidade (layout, certificado, protocolos). Sem pedido do cliente atual |
+| 4 | **Sem front mobile nativo** | N/A | Web responsivo atende o uso atual e planejado |
+| 5 | **LGPD integrada, não fase separada** | 🔴 MVP / 🟡 Early-stage | Criptografia de PII, audit trail, retention, response filtering entram como requisito do próprio MVP/early-stage |
+| 6 | **API Keys já em prod** (cliente usa para Power BI) | Ativo | Auth via API key precisa de: rate limit próprio, scopes documentados, rotação, audit de uso, cuidado extra com BOLA |
+| 7 | **GlitchTip (error tracking)** já instalado via `SENTRY_DSN` | ✅ Atende MVP | Confirmar em audit que cobre erros 5xx + contexto de usuário/org |
+
+### 7.4 Audit item a item
+
+**A preencher na Fase 1.** Varrer código e marcar Status (✅/⚠️/❌/N/A) + Observações nas seções 4 e 5 acima. Aqui ficará o resumo consolidado após o audit.
+
+#### 7.4.1 Plano de execução da Fase 1
+
+Ordem sugerida de inspeção — do bootstrap para fora, seguindo o fluxo da request. A cada arquivo, marcar Status + Observações nos itens relevantes das seções 4 e 5.
+
+**Bootstrap e configuração (fundamento)**
+
+1. `src/index.ts` — ordem de plugins globais, CORS, rate limit, body size, listen, security headers, OpenAPI
+2. `src/env.ts` — validação Zod completa, fail-fast, todos os secrets declarados
+
+**Infraestrutura (lib/ + plugins em lib/)**
+
+3. `src/lib/errors/` + `src/lib/responses/` — hierarquia `AppError`, envelope consistente, inclusão de `requestId` no erro
+4. `src/lib/logger/` — Pino estruturado, correlation ID via AsyncLocalStorage, silent em test
+5. `src/lib/ratelimit/` — config global + presença de rate limit dedicado em `/api/auth`
+6. `src/lib/shutdown/` — SIGTERM/SIGINT, grace period, `pool.end()`
+7. `src/lib/health/` — liveness + deep check (DB)
+8. `src/lib/cors.ts` — origin restrito, credentials, methods
+9. `src/lib/sentry.ts` — integração GlitchTip, captura de 5xx, contexto de usuário/org
+10. `src/lib/request-context/` + `request-context.ts` — investigar duplicação (débito #4)
+11. `src/lib/audit/` — classificar: plugin ou morto (débito #5)
+12. `src/lib/crypto/` — uso do `PII_ENCRYPTION_KEY`, algoritmo, quais campos criptografados
+13. `src/lib/validation/` + `src/lib/schemas/` + `src/lib/zod-config.ts` — reuso, consistência
+14. `src/lib/utils/` (retry, timeout) — presença de helpers úteis para deps externas
+
+**Auth (coração do projeto)**
+
+15. `src/lib/auth.ts` (24KB) — config Better Auth, senders injetados, permissions, hooks, audit
+16. `src/lib/auth-plugin.ts` — macros `auth` e `orgAuth`, validação de `activeOrganizationId`, check de BOLA
+17. `src/lib/permissions.ts` — statements de permissions, consistência com orgAuth
+18. `src/lib/password-complexity.ts` — regras de senha
+
+**Módulos críticos para infra (sem entrar em domínio)**
+
+19. `src/modules/payments/webhook/` — validação de assinatura (`PAGARME_WEBHOOK_USERNAME/PASSWORD`), **idempotency**, timeout, logging sem dados de cartão
+20. `src/modules/public/` — rate limit por rota, validação Zod, captcha/honeypot em fluxos com side-effect
+21. `src/modules/admin/api-keys/` — BOLA por `organizationId`, rate limit por key, rotação, scopes, audit de uso
+22. `src/modules/audit/` — confirmar que é domínio (service imutável, retention)
+
+**Emails**
+
+23. `src/emails/` + `src/lib/email.tsx` — confirmar escopo do refactor já decidido (débito #8)
+
+**CI/CD e deploy (do README)**
+
+24. `.github/workflows/` — lint, test, build, security (Trivy), dependabot
+25. `Dockerfile` / `scripts/entrypoint.sh` — migrations automáticas, non-root, multi-stage
+
+#### Entregáveis da Fase 1
+
+1. **Status + Observações preenchidos nas tabelas das seções 4 e 5** (todos os itens que o projeto assumiu como relevantes para o contexto)
+2. **Relatório narrativo** em `docs/reports/YYYY-MM-DD-api-infrastructure-audit.md` com:
+   - Resumo executivo (X itens ✅, Y ⚠️, Z ❌)
+   - Achados surpreendentes (positivos e negativos)
+   - Riscos imediatos identificados em prod (se houver — cliente em produção)
+   - Recomendação inicial de priorização
+3. **Seção 7.7 expandida** se surgirem débitos novos durante a varredura
+4. **Changelog** atualizado com a conclusão da Fase 1
+
+#### 7.4.2 Metodologia de avaliação (como julgar "está bom / precisa melhorar")
+
+**Princípio central:** não copiar nenhuma referência. Avaliar cada item pela **melhor solução para o contexto synnerdata**, usando múltiplas fontes e juízo técnico independente.
+
+**4 fontes a consultar para cada item auditado**, ponderadas na ordem:
+
+| # | Fonte | Como usar | Ferramenta |
+|---|---|---|---|
+| 1 | **Código atual do synnerdata** | O que existe, como está implementado, qual o débito real | `Read`, `Grep`, `Glob` |
+| 2 | **Docs oficiais do Elysia** | Padrão recomendado pelo framework, APIs atualizadas, breaking changes, deprecations | `context7` (mcp tool) — `resolve-library-id` + `query-docs` |
+| 3 | **Best practices na web** | OWASP, artigos recentes (2026), comunidade, análises de segurança | `WebSearch` + `WebFetch` |
+| 4 | **Avocado-hp como inspiração** | Referência **de organização e padrão**, não de decisão técnica. Benchmark pareado, não dogma | `Read` em `~/Documentos/avocado-hp/avocado-hp/apps/server/src/` |
+
+**Critério de julgamento:** para cada item, responder *"qual a melhor solução para este projeto, neste contexto?"* — **nunca** *"está igual ao avocado-hp?"*.
+
+**Dimensões de avaliação** (cada item passa por 4 lentes):
+
+| # | Dimensão | Pergunta-guia | Fonte principal |
+|---|---|---|---|
+| 1 | **Presença/completude** | O item existe e está configurado? | Código atual |
+| 2 | **Organização semântica** | Está no lugar correto da estrutura de pastas (seção 7.6)? | Código atual + 7.6 |
+| 3 | **Qualidade da implementação** | A implementação é sólida (tipagem, responsabilidade única, testabilidade, legibilidade)? Sinais: `any` excessivo, arquivos > 20KB com múltiplos concerns, funções longas, duplicação, dynamic imports suspeitos, lógica inline que deveria ser extraída | Leitura atenta do código |
+| 4 | **Aderência a best practices** | Segue docs oficiais (Elysia, Better Auth, Zod) + OWASP + padrões de 2026? | Docs via `context7` + web research |
+
+**Quando consultar `context7` e `WebSearch` (obrigatório em débitos significativos):**
+
+Cada débito 🟡 ou 🔴 relevante deve ser validado contra ao menos uma fonte externa antes de ser registrado como ação final. Em particular:
+
+- **Antes de sugerir implementação custom**: consultar docs do framework via `context7` (ex: `/better-auth/better-auth`, `/elysiajs/documentation`) para verificar se já existe feature built-in. Ver princípio "Better Auth primeiro" em 7.7
+- **Antes de sugerir refactor de segurança**: buscar best practice atualizada via `WebSearch` (ex: HMAC webhook signature, security headers para JSON API, rate limit storage)
+- **Para cada débito de qualidade capturado**: anotar na coluna "Ação" se houve validação externa ou se é julgamento do audit
+
+Exemplo aplicado nesta auditoria:
+- Débito #32 (rate limit `storage: "memory"`) → context7 `/better-auth/better-auth` → confirmou solução built-in (`storage: "database"`) — 1 linha de mudança
+- Débito #56 (Basic Auth em webhook) → WebSearch → confirmou HMAC-SHA256 como padrão 2026 (Stripe, GitHub, Shopify, Okta) → anotar que Pagar.me v5 precisa ser verificado especificamente
+- Débito 5.2 #1 (CSP ausente) → WebSearch → confirmou "for API-only servers, CSP is less critical" → manter como 🟢 baixa prioridade em vez de MVP
+
+**Possíveis veredictos por item:**
+
+| Veredicto | Significado | Ação |
+|---|---|---|
+| ✅ `synnerdata está correto` | Alinhado em TODAS as 4 dimensões | Status ✅ nas tabelas 4/5 |
+| ✅ `funcional mas qualidade melhorável` | Dimensão 1 ✅ mas 2/3/4 com ressalva | Status ✅ + débito em 7.7 descrevendo o aspecto de qualidade |
+| ⚠️ `synnerdata < ideal` | Existe mas com gap em 1+ dimensão | Status ⚠️ + observação + débito em 7.7 |
+| ⚠️ `synnerdata = avocado-hp, ambos subótimos` | Mesmo débito que vimos no outro projeto — solução vem das fontes 2/4 | Documentar solução correta; Status ⚠️ |
+| 🏆 `synnerdata > avocado-hp` | Implementação daqui supera a de lá | Celebrar; ✅; **anotar para trazer de volta ao avocado-hp** |
+| ❌ `não existe` | Item ausente | Status ❌ + prioridade (MVP/Early/Scale) |
+| ⚠️ `existe mas em lugar errado` | Implementado mas viola 7.6 | Status ⚠️ + débito em 7.7 |
+
+**Pontos de partida sabidos (não começar do zero):**
+
+- synnerdata **já tem** coisas que avocado-hp não tinha: `PII_ENCRYPTION_KEY` + `src/lib/crypto/`, `INTERNAL_API_KEY` para jobs, Trivy scan, Dependabot, `retry.ts`/`timeout.ts`, GlitchTip integrado, Uptime Kuma, `api-keys` em prod, infra de testes mais rica (builders/factories/fixtures)
+- avocado-hp tinha débitos que **provavelmente existem aqui também**: body size limit, request timeout, rate limit em `/api/auth`, security headers — mas **investigar de forma independente**, não assumir
+- avocado-hp **organiza melhor** `lib/` vs `plugins/` e emails — aí sim adotar a ideia
+
+**Princípio "Better Auth primeiro" (crítico):**
+
+Better Auth é peça essencial do projeto e resolve **muitos gaps de auth/identity nativamente**. Antes de propor qualquer implementação custom em auth, session, CSRF, rate limit de auth, 2FA, password, API keys, organizações, invitations:
+
+1. **Verificar primeiro** se Better Auth já oferece a feature (ver tabela em 7.7 "Features já usadas" e "Features ainda não usadas")
+2. **Consultar docs via `context7`** (`mcp__context7__resolve-library-id` + `query-docs`) antes de propor código custom
+3. **Preferir configuração da lib** a código próprio — menos código para manter, menos bugs, lib é auditada pela comunidade
+4. **Só implementar custom** quando Better Auth comprovadamente não cobrir E o gap for real no contexto do projeto
+
+Exemplo já aplicado: rate limit em `/api/auth` parecia débito MVP; auditoria revelou que Better Auth tem `customRules` muito mais granulares que uma implementação custom genérica faria. Débito **resolvido sem código novo**.
+
+#### 7.4.3 Regras da Fase 1
+
+- **Somente leitura** — não alterar código; apenas registrar estado atual
+- **Não corrigir nada ainda** — tentação de "já que está aqui, conserto" atrapalha o mapeamento; corrige na Fase 3
+- **Se encontrar algo que parece crítico em prod** (ex: webhook sem idempotency, rota sem auth), destacar no relatório como 🔴 **urgente** para a Fase 2, mas seguir o audit até o fim
+- **Investigação independente** — para cada item, consultar as 4 fontes da seção 7.4.2 antes de emitir veredicto. Não é cópia, é investigação
+- **Registrar incertezas** — se algo não for claro entre "correto" e "débito", marcar com `?` nas Observações e listar o que precisa confirmar
+
+#### Pontos de atenção já mapeados para a Fase 1
+
+Descobertas da leitura superficial dos módulos — não detalhes de negócio, só áreas onde a infra toca pontos sensíveis e precisam inspeção cuidadosa:
+
+- **`modules/auth/` não tem controller/service próprios** — auth é **100% plugin-based via Better Auth**. Toda lógica vive em `lib/auth.ts` (24KB), `lib/auth-plugin.ts` e `lib/permissions.ts`. Esses três arquivos são o **coração da infra de auth** e são candidatos diretos a migrar para `src/plugins/`
+- **`modules/payments/webhook/`** — endpoint recebe eventos do Pagar.me. Inspecionar na Fase 1: validação de assinatura (`PAGARME_WEBHOOK_USERNAME`/`PASSWORD`), **idempotency** contra reprocessamento de evento, rate limit próprio, timeout adequado, logging do payload cru (sem PII/cartão) para replay
+- **`modules/public/`** — rotas **sem autenticação**, superfície de ataque direta. Inspecionar: rate limit por rota (mais agressivo que global), validação Zod rigorosa, nenhum vazamento de dados sensíveis, captcha/honeypot em fluxos com side-effect (ex: contact form)
+- **`modules/admin/api-keys/`** — auth method alternativo já em produção (cliente consome via Power BI). Inspecionar: isolamento por `organizationId` (BOLA), rate limit próprio por key, rotação, scopes documentados, audit de uso, revogação
+
+### 7.5 Roadmap priorizado
+
+**Consolidado na Fase 2 (2026-04-21)** a partir do audit da Fase 1 e do relatório em `docs/reports/2026-04-21-api-infrastructure-audit.md`.
+
+**Convenções:**
+- **ID** = identificador da ação no roadmap (RU-N, CP-N, MP-N). Usar em branches e PRs: `fix/ru-2-requestid-no-erro`
+- **Débitos cobertos** = referência aos débitos de 7.7 resolvidos pela ação
+- **Tipo:** `config` (mudança em arquivo de config) · `new` (implementação nova) · `refactor` (move/split/rename) · `docs` (documentação/runbook) · `plan` (plano dedicado em `docs/plans/`)
+- **Esforço:** `S` < 1h · `M` 1-4h · `L` > 4h · `XL` plano próprio com múltiplos PRs
+- **Depende de:** IDs que precisam estar concluídos antes
+
+#### 🔴 Bucket Urgente (0-30 dias, cliente ativo em produção)
+
+Priorizar **fundação primeiro** (env.ts → errorPlugin → timeout), depois **compliance** (audit de API keys), depois **validação** (BOLA + integration tests).
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **RU-1** | Hardening de `src/env.ts` — adicionar `BETTER_AUTH_SECRET.min(32)`, `PII_ENCRYPTION_KEY.regex(hex)`, `SMTP_FROM.email()`, `NODE_ENV` enum, `SMTP_USER/PASSWORD` refine condicional em prod, documentar formato de `CORS_ORIGIN` | #14, #15, #16, #17, #18, #19 | config | S | — |
+| **RU-2** | Incluir `requestId` no body do erro — no `errorPlugin` (`lib/errors/error-plugin.ts`), adicionar `error.requestId` em todas as respostas | #16 MVP | config | S | RU-1 |
+| **RU-3** | Request timeout global — configurar `serve.idleTimeout` (ou equivalente Bun) em `src/index.ts`; extrair como constante `REQUEST_TIMEOUT_MS` | #20, MVP #8 | config | S | — |
+| **RU-4** | `bun pm audit` no CI — adicionar step em `.github/workflows/lint.yml` com `--audit-level=high`; atualizar README | #76, MVP #18 | config | S | — |
+| **RU-5** | Validar/corrigir `SKIP_INTEGRATION_TESTS` em `test.yml` — confirmar semântica, remover se estiver pulando testes importantes, documentar caso legítimo | #77 | config | S | — |
+| **RU-6** | Audit de operações em API keys — adicionar `AuditService.log()` em `ApiKeyService.create/revoke/delete` com `resource: "api_key"`, capturing prefix (nunca a key completa) | #54 | new | M | — |
+| **RU-7** | Fix auditPlugin — injetar `user`/`session.activeOrganizationId` do contexto do macro `auth` (remover `context` manual); remover `\| string` dos tipos de action/resource | #23, #24 | refactor | M | — |
+| **RU-8** | Mover auditPlugin para `src/plugins/audit/` e remover `lib/audit/` — classificar como plugin + atualizar imports | #5, #30 | refactor | M | RU-7 |
+| **RU-9** | Auditoria de BOLA em todos os services de domínio + testes cruzados entre orgs — varrer `src/modules/**/*.service.ts` confirmando filtro `organizationId` em todas as queries; adicionar testes de isolamento em pelo menos 3 módulos representativos | BOLA 5.1 #3, OWASP API1 | new | L | — |
+| **RU-10** | Runbook de backup Coolify — criar `docs/runbooks/database-backup.md` documentando: frequência de backup no Coolify, retention, processo de restore, teste periódico | #92 | docs | S | — |
+
+**Total bucket 🔴: 10 ações · ~7 S/M + 1 L. Entregável em ~2-3 semanas trabalhando 50% do tempo nelas.**
+
+#### 🟡 Bucket Curto Prazo (30-90 dias, hardening + preparação compliance + organização)
+
+Organizado em **5 PRs dedicados** (refactors grandes) + ações pontuais.
+
+##### Refactors estruturais (PRs dedicados, `plan` em `docs/plans/`)
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **CP-1** | **PR #1 — Criar `src/plugins/` e migrar plugins Elysia de `lib/`** — `logger/`, `health/`, `cors.ts`, `ratelimit/` (investigar estrutura vazia), `shutdown/`, `auth-plugin.ts` (quebrado em sub-arquivos), `cron-plugin.ts`, `sentry.ts`, `request-context/` (consolidar com `request-context.ts`) | #1, #4, #27 (+ #49 parcial) | plan | XL | RU-8 |
+| **CP-2** | **PR #2 — Consolidar emails em `src/lib/emails/`** — mapa em débitos #8/#9; padronizar params `to`, abstrair `dispatchEmail({...})`, mover hardcoded contact email p/ env | #8, #9, #68, #69, #70, #71, #72, #73 | plan | XL | — |
+| **CP-3** | **PR #3 — `src/routes/v1/` + versionamento padronizado** — extrair catálogo de controllers de `src/index.ts` para `src/routes/v1/index.ts`; alinhar prefix `/api/v1/` em todos os controllers | #10, #13, #42 | plan | L | — |
+| **CP-4** | **PR #4 — Quebrar `lib/auth.ts` (24KB) e `lib/auth-plugin.ts` (369 linhas)** — `auth/config.ts`, `auth/audit-helpers.ts`, `auth/validators.ts`, `auth/hooks.ts`; `auth/plugin.ts` + `auth/openapi-enhance.ts` | #38, #39, #49, #51 | plan | L | CP-1 |
+| **CP-5** | **PR #5 — Limpar `lib/errors/`** — mover `employee-status-errors.ts`, `subscription-errors.ts` para `modules/<domínio>/errors.ts`; mover `lib/helpers/employee-status.ts` para `modules/employees/`; consolidar schemas de erro com factory `errorSchema(code)` (padrão avocado-hp) | #2, #21, #45 | refactor | L | — |
+
+##### Segurança e webhooks
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **CP-6** | Validar suporte a HMAC no Pagar.me v5 e migrar webhook (se suportado); se não suportado, adicionar IP allowlist como defesa adicional | #56, #57 | new | M | — |
+| **CP-7** | Adicionar gitleaks ou trufflehog no `security.yml` para scan de histórico git | #84 | config | S | — |
+| **CP-8** | Gerar SBOM via `trivy sbom` como artifact no `security.yml` | #85 | config | S | — |
+| **CP-9** | Trivy filesystem scan (`trivy fs .`) no `security.yml` além do image scan | #82 | config | S | — |
+| **CP-10** | Pin SHA do `oven/bun:1-alpine` no Dockerfile + atualização via Dependabot | #87 | config | S | — |
+| **CP-11** | HEALTHCHECK deep no Dockerfile (trocar `/health/live` por `/health` com `--retries=10`) | #88 | config | S | — |
+| **CP-12** | `wait-for-db` no `scripts/entrypoint.sh` antes de rodar migrations | #89 | new | S | — |
+| **CP-13** | Escopar secrets no `test.yml` por step (não no job todo) | #95 | config | S | — |
+
+##### Cloudflare Free Tier (decisão 7.3 #1 — etapa final do early-stage)
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **CP-14** | Alinhar com cliente para migrar DNS registro.br → Cloudflare → Coolify (cliente é owner do DNS); documentar processo e rollback | Decisão 7.3 #1 | docs | S | — |
+| **CP-15** | Configurar Cloudflare Free Tier: WAF básico, Bot Fight Mode, HSTS, compression, HTTP/2+3, rate limit básico. Manter Let's Encrypt do Coolify atrás | Decisão 7.3 #1, #3 (compression), #4 (HTTP/2) | config | M | CP-14 |
+| **CP-16** | Revisar headers HTTP da app após Cloudflare — evitar duplicação (app + CDN ambos setando HSTS etc.) | Débito potencial após CP-15 | config | S | CP-15 |
+
+##### Observabilidade e CI
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **CP-17** | Métricas básicas — OTel Metrics ou Prometheus client: latência por rota, throughput, erro rate, pool de conexões DB | Early #2 | new | M | — |
+| **CP-18** | Política de deprecation com headers `Deprecation` / `Sunset` — documentar em `docs/api-versioning.md` + helper em `lib/responses/` para injetar headers | Early #9 | new | M | CP-3 |
+| **CP-19** | Playwright E2E em workflow CI — novo workflow ou step em `test.yml` (pelo menos no schedule diário) | #78 | config | M | — |
+| **CP-20** | Coverage reporting — ativar `--coverage` no `test.yml` e subir pro Codecov/coveralls | #86 | config | S | — |
+| **CP-21** | Cache de `bun install` em todos workflows | #80 | config | S | — |
+| **CP-22** | `--frozen-lockfile` no `bun install` do `lint.yml` | #81 | config | S | — |
+| **CP-23** | Build workflow smoke test — rodar bundle com timeout para validar startup | #79 | config | S | — |
+
+##### Env.ts e auth hardening adicional
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **CP-24** | Log explícito em `UnauthorizedError` do macro auth com IP + path (não logar a chave/token) | #36 | new | S | — |
+| **CP-25** | `permissions.ts` — helper `inheritRole(base, overrides)` para reduzir duplicação entre owner/manager/supervisor/viewer | #50 | refactor | M | — |
+| **CP-26** | Mover `extractErrorMessages` de `src/index.ts` para `lib/openapi/error-messages.ts` (ou `src/plugins/openapi/` após CP-1) | #11 | refactor | S | CP-1 |
+| **CP-27** | Registrar listeners (`registerPaymentListeners`, `registerEmployeeListeners`) ANTES do `.listen()` no bootstrap | #12 | config | S | — |
+| **CP-28** | Mover `lib/audit/` totalmente — após RU-8 verificar se sobrou algo; remover pasta vazia | #5 resolução final | refactor | S | RU-8 |
+| **CP-29** | `formatErrorDetail` com limite de profundidade (max 5) para evitar stack overflow em `cause` cíclico | #44 | config | S | — |
+| **CP-30** | Investigar dynamic imports suspeitos — `cron-plugin.ts` + `lib/auth.ts` `afterCreateOrganization` (possível dep circular) | #28, #52 | refactor | M | — |
+
+##### Qualidade geral
+
+| ID | Ação | Débitos cobertos | Tipo | Esforço | Depende de |
+|---|---|---|---|---|---|
+| **CP-31** | Centralizar uso de `isProduction`/`isDev` via `@/env` (hoje há `process.env.NODE_ENV` direto em vários arquivos) | #26, #41 | refactor | S | — |
+| **CP-32** | `cron-plugin.ts` — refatorar 7 jobs duplicados via array declarativo ou helper `createCronJob({ name, pattern, handler })` | #46 | refactor | M | CP-1 |
+| **CP-33** | `auth.ts` helpers `auditXxx` duplicados — consolidar em `buildAuditEntry(...)` | #51 (parcial — resto em CP-4) | refactor | S | CP-4 |
+| **CP-34** | Branded type `EncryptedString` para `lib/crypto/pii.ts` diferenciando plaintext de ciphertext | #47 | refactor | S | — |
+| **CP-35** | `isBetterAuthNotFound` wrapper genérico em `api-key.service.ts` (reduz duplicação em 3 métodos) | #61 | refactor | S | — |
+| **CP-36** | Newsletter — não revelar existência de email (retornar mesma response em duplicado e novo) | #62 | refactor | S | — |
+| **CP-37** | Version fallback em `lib/health/index.ts` — trocar `"1.0.50"` hardcoded por `"unknown"` ou ler do `package.json` | #29 | config | S | — |
+| **CP-38** | Runbook de oncall em `docs/runbooks/` — DB down, webhook Pagar.me falhando, SMTP caído, Sentry recebendo 5xx em massa | #93 | docs | M | — |
+
+**Total bucket 🟡: 38 ações. Execução sugerida em paralelo por tema (PRs dedicados CP-1…CP-5 podem rodar em paralelo com ações pontuais).**
+
+#### 🟢 Bucket Médio Prazo / Sob Demanda (quando houver sinal real)
+
+Não investir antes do sinal. Cada item lista o **sinal que justifica investir**.
+
+| ID | Ação | Débitos / Itens cobertos | Sinal que justifica |
+|---|---|---|---|
+| **MP-1** | Paginação por cursor | Perf #6, listagens lentas | Listagem específica excedendo SLA ou inconsistente (audit logs, financial entries primeiros) |
+| **MP-2** | Cache layer (Redis) | Perf #6 | Queries repetidas dominando CPU ou pool DB |
+| **MP-3** | ETag / `If-None-Match` em GETs estáveis | Perf #5 | Bandwidth/latência mensurável em GETs repetidos |
+| **MP-4** | BullMQ + Redis para jobs assíncronos | Early 5.2 #5 | 1º SMTP lento bloqueando request OU job pesado que não pode bloquear HTTP |
+| **MP-5** | Rate limit Better Auth com `storage: "database"` | #32 | Ao escalar para múltiplas instâncias (LB horizontal) |
+| **MP-6** | Tracing distribuído (OTel) | Obs #8 | Introdução de 2º serviço/fila/microserviço |
+| **MP-7** | APM avançado (Datadog/New Relic) | Obs #9 | Quando Sentry + logs + métricas não bastarem |
+| **MP-8** | Idempotency keys em POSTs críticos | Ctx 5.1 #6 estendido | Após 1º incidente de duplicação em operação não-webhook |
+| **MP-9** | Anti-automation em fluxos sensíveis | Ctx 5.3 #7 | 1º sinal de abuso em convite/reset em massa |
+| **MP-10** | SSRF prevention | Ctx 5.3 #8 | Ao introduzir webhook/fetch de URL do cliente |
+| **MP-11** | Feature flags / canary deploy | Ctx 5.3 #10 | Velocidade de deploy alta (múltiplas/dia) |
+| **MP-12** | eSocial — transmissão direta | Decisão 7.3 #3 | Demanda do cliente + estudo de viabilidade |
+| **MP-13** | SOC 2 Type I/II certification | Compliance 7.2 | Cliente enterprise exigir |
+| **MP-14** | ISO 27001 | Compliance 7.2 | Cliente corporativo/governo exigir |
+| **MP-15** | Retention policy de audit logs (implementação de pruning) | #55 | LGPD formal + primeira auditoria |
+| **MP-16** | SLO / error budget formal | Scale obs | Ao assinar SLA com cliente |
+| **MP-17** | Load testing periódico | Scale obs | Projeção de aumento de carga ou primeiro spike em prod |
+| **MP-18** | DR (disaster recovery) testado | Scale obs | Quando SLA exigir ou após primeiro incidente de DB |
+| **MP-19** | Paginação de listagem de API keys | #59 | Volume de keys exceder ~50 por org ou listagem ficar lenta |
+| **MP-20** | CSP (Content-Security-Policy) | Ctx 5.2 #1 | Se API começar a servir HTML/assets ao browser (hoje API JSON pura, baixo valor) |
+| **MP-21** | Captcha/honeypot em endpoints públicos | Ctx 5.2 — #63 | Detectar abuso em contact/newsletter (Cloudflare Bot Fight Mode cobre parte após CP-15) |
+
+**Total bucket 🟢: 21 ações monitoradas. Nenhuma investida agora — aguardar sinal.**
+
+---
+
+### Resumo executivo do roadmap
+
+| Bucket | Ações | Esforço consolidado | Prazo alvo |
+|---|---|---|---|
+| 🔴 Urgente | 10 | ~7 S/M + 1 L = 2-3 semanas com foco parcial | até 30 dias |
+| 🟡 Curto prazo | 38 (5 plans dedicados + 33 pontuais) | 5 planos XL/L + ~30 S/M | 30-90 dias |
+| 🟢 Médio prazo | 21 | Sob demanda | indefinido (monitorar sinais) |
+
+**Princípios de execução:**
+- Atacar 🔴 **primeiro e até o fim** antes de iniciar 🟡
+- Dentro de 🟡, priorizar **PRs dedicados (CP-1 a CP-5)** que destravam outros trabalhos (ex: CP-1 destrava CP-4, CP-26, CP-28)
+- Itens de 🟢 só entram com sinal concreto — revisitar a cada trimestre ou após incidentes
+- Manter **este documento atualizado** conforme ações são concluídas (ver aviso no topo)
+
+### 7.5.1 Metodologia de execução — Fase 3
+
+Discussão ocorrida após conclusão da Fase 2. Registra propostas de metodologia, agrupamento de PRs, e avaliação de ferramentas (Compozy) para garantir que cada ação seja revisada cuidadosamente antes de tocar código.
+
+#### Template de plano de execução (proposta)
+
+Cada ação M/L/XL gera um arquivo em `docs/plans/YYYY-MM-DD-<id>-<slug>.md` com a estrutura:
+
+```markdown
+# Plano <ID> — <Nome da ação>
+
+## Meta
+- ID: <RU-N | CP-N>
+- Branch: `<tipo>/<id-slug>` (ex: `fix/ru-2-requestid-no-erro`)
+- PR alvo: `preview`
+- Esforço: S | M | L | XL
+- Débitos cobertos: #N, #N (ref 7.7)
+- Depende de: <IDs ou "nenhum">
+
+## Contexto e justificativa
+Por que essa ação agora, o que ela destrava, qual risco resolve.
+
+## Pesquisa de best practices (4 fontes — seção 7.4.2)
+- **Elysia docs** (via context7): resumo do que a doc oficial orienta
+- **Better Auth docs** (se relevante)
+- **Web/OWASP 2026**: síntese de best practices atuais
+- **Avocado-hp** (comparação pareada, se relevante)
+→ **Conclusão:** qual é o caminho certo validado
+
+## Implementação
+- Arquivos a modificar
+- Passos sequenciais com código-chave
+- Considerações especiais (impacto em outros módulos, gotchas)
+
+## Validação
+- [ ] `bun run lint:types` passa
+- [ ] `bun run lint:check` passa
+- [ ] Testes afetados: `NODE_ENV=test bun test --env-file .env.test <paths>`
+- [ ] Smoke test manual (se UI/runtime tocado)
+- [ ] OpenAPI ainda gera (se schemas tocados)
+- Evidência a capturar antes de marcar "done"
+
+## Rollback
+Se algo quebrar em prod, como reverter com segurança.
+
+## Definition of Done
+- [ ] Código implementado
+- [ ] Testes passam
+- [ ] PR aberto para `preview`
+- [ ] Débitos em 7.7 marcados como resolvidos (com data)
+- [ ] Changelog do checklist atualizado
+- [ ] Seção 7.0 atualizada se concluir bucket 🔴 inteiro
+```
+
+Ações **S** (config trivial, <1h) não precisam de plano formal — descrição no PR basta.
+
+#### Agrupamento sugerido de PRs (bucket 🔴)
+
+Proposta: 10 ações urgentes em **5 PRs temáticos** para reduzir overhead de review.
+
+| Grupo | Ações | Branch | Racional |
+|---|---|---|---|
+| **Grupo 1 — Fundação hardening** | RU-1, RU-2, RU-3 | `fix/urgent-foundation-hardening` | env.ts + errorPlugin + timeout; arquivos correlacionados |
+| **Grupo 2 — CI hardening** | RU-4, RU-5 | `fix/urgent-ci-hardening` | ambos em `.github/workflows/` |
+| **Grupo 3 — Audit refactor** | RU-6, RU-7, RU-8 | `refactor/urgent-audit-plugin` | audit de API keys + refactor do auditPlugin — alta correlação |
+| **Grupo 4 — BOLA validation** | RU-9 | `test/urgent-bola-validation` | auditoria + testes; L, escopo grande, isolado |
+| **Grupo 5 — Docs** | RU-10 | `docs/urgent-backup-runbook` | runbook isolado |
+
+Bucket 🟡 terá um plano por PR dedicado (CP-1 a CP-5) + agrupamentos por afinidade nas ações pontuais (decidir em subpasta da Fase 3).
+
+#### Política de worktrees
+
+Convenção do projeto (`CLAUDE.md` raiz): *"Use worktrees para trabalho que precisa de isolamento (implementação paralela, features independentes)"*.
+
+Aplicação a este roadmap:
+- **Grupos 1, 2, 3, 5 (🔴)** → branches normais de `preview` (trabalho sequencial, S/M)
+- **Grupo 4 — RU-9 (L, BOLA)** → worktree se rodar em paralelo com outro grupo
+- **CP-1, CP-2 (XL)** → worktree obrigatório (isolamento para não bloquear trabalho normal)
+
+#### Avaliação do Compozy como alternativa ao template caseiro
+
+[Compozy](https://github.com/compozy/compozy) é um CLI Go que orquestra pipeline completo de AI-assisted dev: PRD → TechSpec → Tasks → Execution → Review → Fix → Archive. Artifact-driven em `.compozy/tasks/<slug>/`.
+
+**Fit com o que precisamos** (comparação pareada):
+
+| Necessidade | Template caseiro | Compozy |
+|---|---|---|
+| Planos revisados cuidadosamente | Eu escrevo, você aprova | `/cy-create-prd` + `/cy-create-techspec` com ADRs |
+| Pesquisa 4 fontes (context7, web) | Eu faço manualmente | Skills cy-create-* têm research automático |
+| Validação antes de completar | Eu rodo testes | `/cy-final-verify` força evidence-based |
+| Revisão de código | Informal | `/cy-review-round` manual ou `fetch-reviews --provider coderabbit` |
+| Remediação de review | Manual | `compozy fix-reviews` sistemático |
+| Contexto entre PRs | Chat | `cy-workflow-memory` persistente |
+| Council de perspectivas (segurança, arquitetura) | Eu faço os papéis | Extension `cy-idea-factory`: 6 agentes (security-advocate, architect-advisor, pragmatic-engineer, product-mind, devils-advocate, the-thinker) |
+| Artifacts versionados | `docs/plans/` | `.compozy/tasks/<slug>/` |
+| Overhead inicial | Zero | Setup CLI + `compozy setup` |
+| Overhead por ação | Baixo | Baixo após setup, mas pipeline PRD→TechSpec→Tasks pesa para ações S |
+
+**Sinais no repositório** (avaliação):
+- `skills-lock.json` já tem 6 skills instaladas (`better-auth-*`, `zod-4`, `create-auth-skill`, `organization-best-practices`) — projeto **já usa sistema de skills**
+- Skills `cy-*` disponíveis no toolkit desta sessão — infraestrutura Compozy-compatível
+- Não há `.compozy/` ainda — CLI não foi setup
+
+**Compozy é overkill para ações S** (RU-1 = adicionar `.min(32)` no env.ts, 1 linha) — pipeline PRD→TechSpec→Tasks custa 10x o tempo de implementação.
+
+**Compozy é adequado ou melhor que template caseiro para ações M/L/XL** — rigor built-in com final-verify + council + review estruturado resolve exatamente o "revisados cuidadosamente" solicitado.
+
+#### Matriz de escolha por tipo de ação
+
+| Tipo | Ações no roadmap | Fluxo recomendado |
+|---|---|---|
+| **S** | RU-1, RU-2, RU-3, RU-4, RU-5, RU-10, CP pontuais (CP-7, CP-8, CP-9, CP-10, CP-11, CP-12, CP-13, CP-20, CP-21, CP-22, CP-23, CP-26, CP-27, CP-29, CP-31, CP-34, CP-35, CP-36, CP-37) | Branch simples a partir de `preview` → implementação + testes → PR → merge. Descrição do PR substitui plano formal |
+| **M** | RU-6, RU-7, RU-8, CP-6, CP-15, CP-17, CP-18, CP-19, CP-25, CP-30, CP-32, CP-38 | Compozy completo: `/cy-create-prd` → `/cy-create-techspec` → `/cy-create-tasks` → `compozy start` → `/cy-final-verify` |
+| **L** | RU-9, CP-3, CP-4, CP-5 | Compozy completo + `/cy-review-round` para cobertura extensa |
+| **XL** | CP-1, CP-2 | Compozy completo + council (security-advocate + architect-advisor + devils-advocate) debatendo decisões + `cy-workflow-memory` para estado entre sub-PRs |
+
+#### Opções de metodologia
+
+Três caminhos possíveis para a Fase 3. Escolher uma e registrar a decisão no final desta subseção.
+
+| Opção | Descrição | Prós | Contras |
+|---|---|---|---|
+| **A — Pilot Compozy em uma ação M** | Setup do Compozy, testar com RU-7 ou RU-8, avaliar resultado, então decidir se adota integralmente ou volta atrás | Baixo risco; decisão informada por experiência real; se não funcionar, perda é pequena | Atrasa execução do bucket 🔴; exige setup antes de ver valor |
+| **B — Híbrido imediato** | Ações **S** (RU-1 a RU-5, RU-10) via branches simples já; paralelamente setup Compozy; a partir da primeira M (RU-6) usar Compozy | Zero bloqueio no trabalho "rápido"; ganha rigor onde ele importa; melhor custo/benefício | Dois fluxos em paralelo inicialmente; exige disciplina para não misturar |
+| **C — Template caseiro** | Manter template proposto acima, ignorar Compozy | Zero setup adicional; fluxo familiar | Reinventa o que Compozy já faz melhor; mais trabalho manual meu em planos longos; sem final-verify built-in |
+
+#### Decisão
+
+> **Status:** ✅ Decidida.
+>
+> **Decisão tomada em:** 2026-04-21
+> **Opção escolhida:** **B — Híbrido imediato**
+> **Justificativa:** Permite iniciar imediatamente as ações urgentes de baixo esforço (RU-1 a RU-5, RU-10) via branches simples sem bloquear o trabalho com setup, enquanto o Compozy é instalado em paralelo. A partir da primeira ação M (RU-6), usa-se Compozy para ganhar rigor (PRD + TechSpec + final-verify + council) onde ele agrega valor real. Melhor custo/benefício entre as três opções: zero bloqueio para ações rápidas, máximo rigor para refactors que impactam arquitetura.
+
+**Consequências operacionais:**
+
+- **Imediato:** iniciar RU-1 (Grupo 1 — Fundação) via branch `fix/urgent-foundation-hardening`. Descrição do PR substitui plano formal (ações S)
+- **Compozy setup (concluído em 2026-04-21):** CLI instalado globalmente, 9 skills core disponíveis, `.compozy/config.toml` criado no projeto com defaults alinhados ao CLAUDE.md (`ide = "claude"`, `model = "opus"`, `auto_commit = false`, `reasoning_effort = "high"`). `.compozy/` versionado (não está no `.gitignore`)
+- **Extensão `cy-idea-factory` — diferida:** council de 6 agentes (security-advocate, architect-advisor, pragmatic-engineer, product-mind, devils-advocate, the-thinker) **não instalado agora**. Motivo: roadmap atual (bucket 🔴 + maior parte do 🟡) tem escopo claro vindo do audit; council de debate é overkill para "adicionar `.min(32)`" ou "mover auditPlugin". Instalar **apenas antes de CP-1 ou CP-2** (XL com decisões arquiteturais) ou antes de atacar qualquer item do bucket 🟢 (cache layer, eSocial, SOC 2 — decisões com múltiplos trade-offs sem design pronto). Comando quando chegar a hora: `compozy ext install --yes compozy/compozy --remote github --ref v0.1.12 --subdir extensions/cy-idea-factory && compozy ext enable cy-idea-factory && compozy setup`
+- **A partir de RU-6:** usar pipeline Compozy completo (`/cy-create-prd` → `/cy-create-techspec` → `/cy-create-tasks` → `compozy start` → `/cy-final-verify`). Artifacts em `.compozy/tasks/<slug>/` substituem `docs/plans/` para ações M/L/XL
+- **Ações S do bucket 🟡** seguem no fluxo simples (não criam artifact Compozy)
+
+### 7.5.2 Política de testes — Fase 3
+
+**Princípio central:** testar o que vai ser tocado, não tudo. Rodar só os testes que cobrem arquivos refatorados ou lógica afetada. Coverage é sinal, não meta — um arquivo com 100% de cobertura em testes tautológicos vale menos que 60% em testes de comportamento real.
+
+#### Categorias de política (por tipo de ação)
+
+Cada ação do roadmap tem uma das 4 categorias abaixo registrada no campo **Política de teste** do seu plano de execução.
+
+| Categoria | Quando aplica | Comando/disciplina |
+|---|---|---|
+| **(1) TDD clássico** | Comportamento observável muda ou é adicionado (contratos, segurança, compliance, autorização) | Red → Green → Refactor. Teste escrito ANTES da implementação, precisa falhar primeiro |
+| **(2) Não-regressão** | Refactor/move sem alteração de comportamento (mover plugin, consolidar arquivos, renomear) | Rodar testes que cobrem o código afetado ANTES (baseline verde) → refatorar → rodar MESMOS testes DEPOIS (tem que continuar verde) |
+| **(3) Teste mínimo focado** | Mudança pequena mas observável (1-2 linhas em schema, adição de header, comportamento alterado em edge case) | Adicionar 1-2 testes focados na mudança. Não tentar cobrir tudo — só a mudança |
+| **(4) N/A** | Config de CI, documentação, infra externa (Cloudflare), ou mudança de arquivo não-executável (runbook) | Validação pelo próprio pipeline/config ou manualmente |
+
+#### Escopo de execução
+
+**Não rodar suite completa** (227 arquivos de teste, > 10min). Para cada ação, identificar e rodar apenas:
+
+1. **Testes diretos** do arquivo/módulo tocado (`src/<area>/__tests__/*`)
+2. **Testes de consumidores** (arquivos que importam o que está sendo refatorado, via `grep` nos imports)
+3. **Testes novos** escritos pela categoria da ação
+
+Comando padrão (padrão do projeto, ver `package.json`):
+
+```bash
+NODE_ENV=test bun test --env-file .env.test <paths específicos>
+```
+
+O projeto já tem `scripts/affected-tests.sh` usado no CI — pode ser adaptado localmente se o escopo for ambíguo.
+
+#### Coverage como sinal de apoio
+
+Rodar `bun run test:coverage` **uma vez no início da Fase 3** como baseline. Usar:
+
+- **Para identificar risco**: arquivo que será refatorado com 0% cobertura → adicionar 1 teste crítico antes de tocar
+- **Para comparação**: após ação, cobertura do arquivo tocado deve ser ≥ linha de base
+- **Não usar como meta**: não perseguir 90% em arquivo que não precisa (ex: config, bootstrap)
+
+#### Regras de ouro
+
+1. **Testa comportamento, não implementação.** `app.handle(new Request(...))` > spy em função interna.
+2. **Não testa o framework.** Não escrever teste que "Elysia responde 200 em `.get()`" ou "Zod parseia schema válido".
+3. **Edge case de segurança = sempre testa.** BOLA, authorization, auditoria, encryption — mesmo se só "agregar teste mínimo" parece pouco, testar.
+4. **Movimentos (refactor) = rodar existentes.** Se testes existentes continuam passando após refactor, comportamento preservado.
+5. **Não adicionar teste que só dá trabalho.** Se teste só valida estrutura/config óbvia, pular.
+
+#### Tabela de políticas por ação do bucket 🔴
+
+Mapeamento específico para cada ação urgente (ajustar nas M/L/XL à medida que entram em plano formal Compozy).
+
+| ID | Categoria | Arquivos afetados | Testes a rodar (baseline) | Testes a escrever |
+|---|---|---|---|---|
+| **RU-1** | (3) Teste mínimo | `src/env.ts` | Nenhum específico (env parse é boot); após mudança, rodar suite de auth para confirmar que novas regras não quebraram | 1 arquivo `src/__tests__/env.test.ts` com: (a) rejeita `BETTER_AUTH_SECRET` < 32; (b) rejeita `PII_ENCRYPTION_KEY` não-hex; (c) rejeita `SMTP_FROM` não-email; (d) em prod exige `SMTP_USER`/`SMTP_PASSWORD` |
+| **RU-2** | (1) TDD | `src/lib/errors/error-plugin.ts` | `src/lib/errors/__tests__/*` | Novo teste em `error-plugin.test.ts`: `app.handle(Request)` que causa AppError → response contém `error.requestId` matching `req-<uuid>` |
+| **RU-3** | (4) N/A | `src/index.ts` (bootstrap) | — | Teste de timeout real é custoso (precisa esperar); validar manualmente via startup log / verificar config está presente |
+| **RU-4** | (4) N/A | `.github/workflows/lint.yml` | — | Validação pelo próprio CI ao rodar `bun pm audit` |
+| **RU-5** | (4) N/A | `.github/workflows/test.yml` | — | Investigação — sem teste a adicionar |
+| **RU-6** | (1) TDD | `src/modules/admin/api-keys/api-key.service.ts` | `src/modules/admin/api-keys/__tests__/*` | Novos testes em `create-api-key.test.ts`, `delete-api-key.test.ts`, `revoke-api-key.test.ts`: spy em `AuditService.log` confirma chamada com `resource: "api_key"`, `action` correta, `resourceId`, `userId` |
+| **RU-7** | (1) TDD + (2) Não-regressão | `src/lib/audit/audit-plugin.ts` (ou `src/plugins/audit/`) + consumidores | `src/modules/audit/__tests__/*` + grep em controllers que usam `audit()` | Novo teste: `audit()` chamado sem context injeta `user` e `organizationId` do session automaticamente (TDD) + testes existentes de consumidores continuam passando (não-regressão) |
+| **RU-8** | (2) Não-regressão | `src/lib/audit/` → `src/plugins/audit/` (move) | `src/modules/audit/__tests__/*` + testes de todos os controllers que chamam `audit()` | Nenhum — comportamento não muda |
+| **RU-9** | (1) TDD | Criar testes novos em pelo menos 3 módulos representativos (ex: `modules/employees/`, `modules/occurrences/vacations/`, `modules/admin/api-keys/`) | Suite atual dos módulos escolhidos | Novos testes BOLA: user da org A recebe 403/404 ao tentar (a) GET por ID, (b) LIST filtrado, (c) UPDATE, (d) DELETE de recurso pertencente à org B |
+| **RU-10** | (4) N/A | Runbook (doc) | — | — |
+
+#### Definition of Done com testes (atualização do template em 7.5.1)
+
+Adicionar ao template de plano:
+
+```markdown
+## Política de teste
+- **Categoria:** (1) TDD clássico | (2) Não-regressão | (3) Teste mínimo | (4) N/A
+- **Testes a escrever antes:** [lista com paths] ou "nenhum"
+- **Testes de baseline/regressão:** [lista com paths ou comando `bun test <paths>`]
+- **Justificativa se N/A:** [motivo]
+```
+
+Novos itens no **Definition of Done**:
+
+- [ ] Testes escritos antes da implementação (categoria 1) ou focados adicionados (categoria 3)
+- [ ] `bun test <paths afetados>` passa 100% após a mudança
+- [ ] Se refactor sem mudança de comportamento (categoria 2), testes de baseline continuam passando
+- [ ] Coverage do arquivo/módulo tocado igual ou maior que linha de base
+
+### 7.6 Organização semântica do projeto
+
+A organização de pastas é parte do produto. Cada adição deve caber naturalmente na estrutura existente; criar pasta nova só é aceitável quando representa um **conceito semântico novo**, não por conveniência.
+
+**Princípio guia:** antes de criar arquivo ou pasta, perguntar — *"onde um mantenedor futuro procuraria isso?"*. Se a resposta não for óbvia, o lugar está errado.
+
+#### Código (`src/`)
+
+Cada pasta em `src/` tem um **critério semântico próprio**. A regra é clara: o critério decide onde algo mora, e cada pasta carrega responsabilidade única.
+
+`src/modules/` é responsabilidade do **domínio/negócio** e não está no escopo deste documento (vive em `docs/code-standards/module-code-standards.md`).
+
+| Pasta | Responsabilidade | Critério |
+|---|---|---|
+| `src/lib/` | **Utilitários puros** — agnósticos ao framework HTTP | Função/classe/schema **testável sem subir uma app Elysia**. Sem `new Elysia()`, sem hooks, sem macros |
+| `src/plugins/` ⭐ novo | **Plugins Elysia** — infraestrutura cross-cutting com ciclo de vida HTTP | Tem `new Elysia({ name })`, hooks (`derive`, `onError`, `onAfterHandle`, `onAfterResponse`) ou macros (`auth`, `orgAuth`) |
+| `src/routes/` ⭐ sugerida | **Montadores de rotas** — composição de controllers por versão da API | `src/routes/v1/index.ts` compondo todos os controllers. Deixa `src/index.ts` enxuto (bootstrap + plugins globais, não catálogo de rotas) |
+| `src/db/` | **Acesso a dados** — conexão, migrations, schema, seeds | Infra do Drizzle: `index.ts` (conexão), `migrate.ts`, `schema/`, `migrations/`, `seeds/` |
+| `src/emails/` | **Templates e renderização de email** — React Email | `components/` (shared), `templates/<dominio>/` (por contexto), `render.ts`. **Senders** (que disparam o envio) são utilitários em `src/lib/` ou `src/plugins/` dependendo da complexidade |
+| `src/test/` | **Infraestrutura de testes** — helpers, fixtures, factories, builders, preload | Suporte aos testes dos módulos. Não testa nada por si — é ferramenta |
+| `src/env.ts` | **Validação de configuração** — Zod schema para env vars | Única fonte de config. Toda env var nova passa por aqui |
+| `src/index.ts` | **Bootstrap** — instanciar Elysia, registrar plugins globais, registrar `routes/v1`, listen | Enxuto: composição, não lógica. Se cresce demais, sinal de que algo deveria ter ido para `plugins/` ou `routes/` |
+
+**Regra prática:** antes de criar arquivo ou pasta, perguntar:
+- **É plugin Elysia?** (tem `new Elysia()`, hooks, macros) → `src/plugins/`
+- **É utilitário puro, testável sem subir app?** → `src/lib/`
+- **É domínio/negócio?** → `src/modules/`
+- **É composição de rotas de uma versão da API?** → `src/routes/v1/`
+- **É acesso a banco?** → `src/db/`
+- **É template de email?** → `src/emails/`
+- **É infraestrutura de teste?** → `src/test/`
+
+Se a resposta não for óbvia, o critério da pasta está ambíguo e precisa revisão.
+
+#### Convenção adotada para este projeto
+
+Hoje o `src/lib/` mistura utilitários puros e plugins Elysia; e existe duplicidade (ex: `src/emails/` + `src/lib/email.tsx`). A convenção acima passa a valer **a partir desta iniciativa** via:
+
+1. **Plugins novos (do MVP/early-stage) nascem em `src/plugins/`** desde já — mesmo que o legado ainda esteja em `lib/`. Paramos de piorar a mistura.
+2. **Legado migra oportunisticamente**: quando a Fase 3 tocar em algo que está no lugar errado, aproveita o PR e move.
+3. **Débitos grandes** (mover múltiplos plugins de uma vez, consolidar emails) podem virar PRs dedicados de refactor se o volume justificar — ver 7.7.
+
+#### Documentação (`docs/`)
+
+Subpastas já convencionadas que devem ser **reaproveitadas**, não duplicadas:
+
+| Pasta | Propósito | Uso nesta iniciativa |
+|---|---|---|
+| `docs/code-standards/` | Padrões e convenções de código | Atualizar se o audit revelar padrão novo a adotar |
+| `docs/improvements/` | **Planos estruturais de melhoria da API** (maturidade, infra, deployment) | ✅ Este checklist mora aqui |
+| `docs/plans/` | Planos de execução **feature-by-feature**, datados (`YYYY-MM-DD-<nome>.md`) | Plans gerados na Fase 3 para itens complexos do roadmap |
+| `docs/reports/` | Relatórios de estado em um ponto do tempo (audit, snapshot) | Relatório consolidado da Fase 1 (audit) |
+| `docs/refactoring/` | Notas sobre refactors estruturais | Se algum débito técnico gerar refactor relevante |
+| `docs/payments-decisions/` | ADRs específicos do módulo de pagamentos | — |
+
+#### Artefatos das próximas fases deste trabalho
+
+| Fase | Artefato | Onde mora |
+|---|---|---|
+| Fase 0 (concluída) | Este checklist + contexto aplicado | `docs/improvements/api-infrastructure-checklist.md` ✅ |
+| Fase 1 | Audit de estado — Status preenchido em cada item + relatório consolidado | Status nas seções 4 e 5 **deste arquivo**; relatório narrativo em `docs/reports/YYYY-MM-DD-api-infrastructure-audit.md` |
+| Fase 2 | Roadmap priorizado com 3 buckets (🔴/🟡/🟢) | Seção 7.5 **deste arquivo** |
+| Fase 3 | Execução por item. Itens simples = PR direto; itens complexos ganham plan próprio | PRs via branches `feat/` `fix/` `refactor/` a partir de `preview`. Plans em `docs/plans/YYYY-MM-DD-<slug>.md` |
+
+#### Padrões de código a respeitar ao executar
+
+- **Zod v4** para validação (nunca `t.*` do Elysia) — single source of truth para validação + OpenAPI
+- **Envelope** `{ success, data }` ou `{ success, error }` via helpers em `src/lib/responses/`
+- **AppError hierarchy** em `src/lib/errors/` e erros de domínio em `errors.ts` do módulo — nunca `status()` do Elysia
+- **IDs domínio-prefixados** (`<domain>-${crypto.randomUUID()}`)
+- **Soft delete** com `deletedAt`/`deletedBy` e filtro `isNull(...)` nas queries
+- **Timestamps + auditoria** (`createdAt`, `updatedAt`, `createdBy`, `updatedBy`) — populados do session
+- **Filtro obrigatório por `organizationId`** em qualquer query de entidade de domínio (defesa BOLA)
+- **JSON Merge Patch** (RFC 7396) em updates com campos nullable
+- **Sem re-exports / barrel files** (exceto `src/db/schema/index.ts`)
+
+### 7.7 Débitos de organização de código já identificados
+
+Pré-audit — itens de **organização semântica** detectados no `src/` atual. Entram no backlog de refactors da Fase 2 (🟡 Curto prazo, não urgentes — não bloqueiam MVP).
+
+#### Em `src/lib/` — mistura de responsabilidades
+
+| # | Débito | Ação sugerida |
+|---|---|---|
+| 1 | **Plugins Elysia e utilitários puros misturados** em `src/lib/` | Criar `src/plugins/` e migrar: `logger/`, `health/`, `ratelimit/`, `shutdown/`, `cors.ts`, `auth-plugin.ts`, `cron-plugin.ts`, `sentry.ts`, `request-context/` |
+| 2 | `src/lib/helpers/employee-status.ts` tem **lógica de domínio**, não utilitário | Mover para `src/modules/employees/` (helper específico do domínio não pertence a `lib/`) |
+| 3 | `src/lib/utils/` com genuínos utilitários (`retry.ts`, `timeout.ts`) | Manter. Após remoção de `helpers/` (débito #2), resolve a duplicação `helpers/` vs `utils/` |
+| 4 | `src/lib/request-context.ts` **e** `src/lib/request-context/` convivendo | Investigar migração incompleta; manter só a forma atual e remover a duplicata. Mover o resultado final para `src/plugins/` |
+| 5 | `src/lib/audit/` convivendo com `src/modules/audit/` já existente | **Módulo `audit/` já existe em `modules/`** (controller + service + model). Investigar o que `lib/audit/` contém: provavelmente é plugin Elysia que deve ir para `src/plugins/audit/`, ou código duplicado/morto a remover |
+| 6 | `src/lib/__tests__/` dentro de `lib/` | Padrão do projeto é `__tests__/` ao lado do código — revisar se cabe migrar para junto de cada artefato |
+| 7 | `src/lib/auth.ts` com 24KB | Arquivo grande pode esconder concerns misturados — revisar se cabe dividir em `auth.ts` (config) + `auth-permissions.ts` + `auth-hooks.ts` |
+
+#### Em `src/emails/` vs `src/lib/email.tsx` — duplicação de responsabilidade
+
+**Decisão registrada:** consolidar seguindo o padrão do avocado-hp — tudo em `src/lib/emails/{senders, templates, components}`. Justificativa: emails são utilitários puros (não são plugins Elysia), têm responsabilidade única por subpasta, e a estrutura já foi validada no projeto-referência.
+
+**Escopo mapeado no Bloco 5 da Fase 1 (2026-04-21) — validado via `grep`:**
+
+| # | Débito | Ação |
+|---|---|---|
+| 8 | **`src/emails/` e `src/lib/email.tsx` convivendo** — duas "fontes de email" no código | Consolidar em `src/lib/emails/`. Movimentação: `src/emails/components/` (5 arquivos) → `src/lib/emails/components/`; `src/emails/templates/{auth,contact,payments}/` (19 templates) → `src/lib/emails/templates/{auth,contact,payments}/`; `src/emails/render.ts` → `src/lib/emails/render.ts`; `src/emails/constants.ts` → `src/lib/emails/constants.ts`; `src/emails/__tests__/` → `src/lib/emails/__tests__/`. Remover `src/emails/` vazio |
+| 9 | **`src/lib/email.tsx` com 476 linhas** concentra transporter Nodemailer + 19 senders (7 auth + 9 payments + 1 admin + 1 contact) | Dividir em: `src/lib/emails/mailer.ts` (transporter + helper `sendEmail`, ~40 linhas); `src/lib/emails/senders/auth.tsx` (7 senders); `src/lib/emails/senders/payments.tsx` (9 senders); `src/lib/emails/senders/admin.tsx` (1 sender); `src/lib/emails/senders/contact.tsx` (1 sender). Remover `src/lib/email.tsx` |
+
+**Impacto real mapeado via `grep` (bom — muito menor do que estimado):**
+
+- **0 arquivos fora de `lib/`** importam templates de `@/emails/` diretamente — só o próprio `lib/email.tsx` consome os templates
+- **6 arquivos consumidores** importam de `@/lib/email` (precisam atualizar imports para novos senders):
+  - `modules/payments/plan-change/plan-change.service.ts`
+  - `modules/payments/checkout/checkout.service.ts`
+  - `modules/payments/admin-provision/admin-provision.service.ts`
+  - `modules/payments/hooks/listeners.ts`
+  - `modules/public/contact/contact.service.ts`
+  - `modules/payments/jobs/jobs.service.ts`
+- **1 arquivo crítico de auth**: `lib/auth.ts:23-31` importa 6 senders de `./email` (verification, reset, welcome, provision-activation, 2FA OTP, org-invitation). Quebrar aqui impede login/signup
+- **Templates têm imports relativos** para `../../components/email-*` — ao mover junto, paths relativos ficam iguais (0 mudanças necessárias nos templates)
+- **Total de arquivos tocados:** ~33 (26 moves + 5 novos senders + 1 mailer + 1 removal + 7-8 atualizações de import)
+
+**Cuidados obrigatórios na execução:**
+
+1. ✅ **`grep` de imports já executado** — confirmado que apenas 6 consumidores externos + `lib/auth.ts` precisam atualização
+2. **Better Auth usa 6 senders em `lib/auth.ts`** — testar verificação de email, reset, welcome, invitation, 2FA OTP após refactor
+3. **Templates `.tsx` têm JSX** — garantir que o tsconfig reconhece o novo caminho
+4. **Rodar `bun test` no subset de email + auth** antes de commit
+5. **Executar ciclo completo E2E**: signup → verification email → login → reset password (via MailHog em dev)
+
+**Por que virar plano dedicado na Fase 3** (não PR oportunista): apesar do escopo menor do que estimado, ~33 arquivos + integração com auth/payments críticos justifica plano em `docs/plans/YYYY-MM-DD-emails-consolidation.md` com checklist de validação.
+
+#### Em `src/` raiz — falta de `src/routes/`
+
+| # | Débito | Ação sugerida |
+|---|---|---|
+| 10 | Sem `src/routes/` — composição de controllers provavelmente espalhada entre `src/index.ts` e os próprios módulos | Investigar na Fase 1. Se `src/index.ts` registra controllers diretamente, extrair para `src/routes/v1/index.ts` — isolando bootstrap (plugins globais + listen) do catálogo de rotas |
+
+#### Débitos descobertos no Bloco 1 da Fase 1 (2026-04-21)
+
+| # | Débito | Origem | Ação sugerida |
+|---|---|---|---|
+| 11 | **`extractErrorMessages` (28 linhas de Zod v4 internals) dentro de `src/index.ts`** | Bootstrap está acoplado à lógica de extração de error messages para OpenAPI | Extrair para `src/lib/openapi/error-messages.ts` (ou em futuro `src/plugins/openapi/`) |
+| 12 | **Registro de listeners (`registerPaymentListeners`, `registerEmployeeListeners`) dentro do `.listen()` callback** | `src/index.ts:147-148` — se listen falhar, listeners não registram | Registrar antes do `.listen()` ou mover para plugins dedicados |
+| 13 | **Versionamento na URL inconsistente** | Bootstrap registra controllers sem prefix global `/api/v1`. `admin` usa `/v1/admin`, mas outros módulos precisam auditar | Padronizar: extrair para `src/routes/v1/index.ts` compondo todos os controllers com prefix único (alinhado com débito #10) |
+| 14 | ~~`env.ts` — `BETTER_AUTH_SECRET` sem `.min(32)`~~ | ✅ **Resolvido em RU-1 (2026-04-21)** — adicionado `.min(32)` ao schema |
+| 15 | ~~`env.ts` — `SMTP_USER`/`SMTP_PASSWORD` `.optional()` sem refine condicional em prod~~ | ✅ **Resolvido em RU-1 (2026-04-21)** — `superRefine` exige ambos quando `NODE_ENV=production` |
+| 16 | ~~`env.ts` — `PII_ENCRYPTION_KEY.length(64)` não valida hex~~ | ✅ **Resolvido em RU-1 (2026-04-21)** — `.regex(/^[0-9a-fA-F]{64}$/)` com mensagem explicativa |
+| 17 | ~~`env.ts` — `SMTP_FROM: z.string()`~~ | ✅ **Resolvido em RU-1 (2026-04-21)** — trocado por `z.email().default(...)` |
+| 18 | ~~`env.ts` — `NODE_ENV` não validado no schema~~ | ✅ **Resolvido em RU-1 (2026-04-21)** — `NODE_ENV: z.enum(["development","production","test"]).default("development")`; `isProduction` agora lê de `env.NODE_ENV` |
+| 19 | ~~`env.ts` — `CORS_ORIGIN` formato comma-separated implícito~~ | ✅ **Resolvido em RU-1 (2026-04-21)** — `.describe()` documenta formato comma-separated (parser delegado a `parseOrigins` em `lib/cors.ts`) |
+| 20 | **Falta request timeout global** | Elysia/Bun default é 255s (`idleTimeout`), mas sem controle explícito | Configurar `serve.idleTimeout` explícito em `src/index.ts` ou plugin dedicado |
+
+#### Débitos descobertos no Bloco 2 da Fase 1 (2026-04-21)
+
+| # | Débito | Severidade | Ação sugerida |
+|---|---|---|---|
+| 21 | **Erros de domínio em `src/lib/errors/`** (`employee-status-errors.ts`, `subscription-errors.ts`) | 🟡 organização | Mover para `src/modules/employees/errors.ts` e `src/modules/payments/subscription/errors.ts`. `lib/errors/` fica só com `base-error.ts`, `error-plugin.ts`, `http-errors.ts` |
+| 22 | ~~`auditPlugin` sem try/catch em `AuditService.log()`~~ | — | **Reavaliado — não é débito.** `AuditService.log()` (`modules/audit/audit.service.ts:9-29`) **já tem try/catch interno** com silent catch via logger. Design intencional documentado no CLAUDE.md do módulo audit: "Logging é assíncrono e silencioso — falhas não propagam erro". `auditPlugin` chama `AuditService.log()` via `await` mas é seguro porque o método nunca propaga erro |
+| 23 | **`auditPlugin` exige contexto manual** | 🟡 hardening | Hoje cada controller passa `context: { userId, organizationId }` ao chamar `audit()`. Propenso a esquecer. Melhor: injetar via macro auth (padrão avocado-hp) — deriva `user`/`session` e o plugin de audit pega automaticamente |
+| 24 | **`auditPlugin` — `action`/`resource` aceitam `string`** | 🟡 hardening | Tipo `AuditAction \| string` permite valores ad-hoc e perde type safety. Remover `\| string` força enum estrito |
+| 25 | **`errorPlugin` não trata `code === "PARSE"`** | 🟡 qualidade | Parse errors (JSON inválido) caem no "unhandled" com 500. Avocado-hp tratava como 400 `PARSE_ERROR`. Adicionar branch explícito |
+| 26 | **`errorPlugin` usa `process.env.NODE_ENV` direto** em vez de importar `isProduction` de `env.ts` | 🟢 leve | Inconsistência — `env.ts` já exporta `isProduction`. Padronizar |
+| 27 | **`lib/cron-plugin.ts` é plugin Elysia em `lib/`** | 🟡 organização | Confirma débito #1 geral — mover para `src/plugins/cron/` |
+| 28 | **`cron-plugin.ts` usa dynamic import para `VacationJobsService`** | 🟡 investigar | Padrão suspeito — pode indicar dependência circular entre `lib/cron-plugin.ts` e `modules/occurrences/vacations/`. Investigar causa e remover dynamic import se não houver motivo real |
+| 29 | **`lib/health/index.ts` — version fallback hardcoded `"1.0.50"`** | 🟢 leve | Se `npm_package_version` não vier, usa valor fixo que fica desatualizado. Trocar por `"unknown"` ou importar do `package.json` |
+| 30 | **Configuração do `auditPlugin` em `lib/audit/audit-plugin.ts` conflita com `modules/audit/`** | 🟡 organização | O plugin importa `AuditService` + tipos de `modules/audit/`. Inverter dependência: plugin Elysia em `src/plugins/audit/` pode importar do módulo, mas não existir dentro de `lib/` |
+
+#### Débitos descobertos no Bloco 3 da Fase 1 (2026-04-21) — Auth
+
+| # | Débito | Severidade | Ação sugerida |
+|---|---|---|---|
+| 31 | ~~8 de 9 hooks de audit no Better Auth sem `.catch()`~~ | — | **Reavaliado — não é débito.** Mesma razão do #22: `AuditService.log()` tem silent catch interno. Todos os hooks de `auth.ts` chamam `AuditService.log()` via helpers (`auditUserCreate`, `auditLogin`, etc.) — erros são logados sem propagar. O `.catch()` em `afterCreateOrganization` é redundante (defensivo mas não necessário). **Consistência de estilo** pode virar débito leve separado — ver #31-revisado abaixo |
+| 32 | **Rate limit do Better Auth em `storage: "memory"`** | 🟡 hardening | **Validado via context7/Better Auth docs**: solução 1-linha — trocar para `storage: "database"` + `modelName: "rateLimit"` (Better Auth cria tabela automaticamente) OU `storage: "secondary-storage"` com Redis. Feature built-in, **zero código custom**. Migrar quando escalar horizontalmente ou se rate limit for crítico para SOC2 |
+| 33 | **Macro `auth.resolve` chama `auth.api.getSession` em toda request autenticada** | 🟡 performance | Cookie cache de 5min já ajuda (`session.cookieCache`). Validar se está funcionando. Para API keys, `auth.api.verifyApiKey` é chamado todo request — validar cache |
+| 34 | **`auth-plugin.ts` define `NoActiveOrganizationError`, `AdminRequiredError`, `SuperAdminRequiredError` inline** | 🟢 organização | Mover para `lib/errors/auth-errors.ts` para consistência com hierarquia AppError |
+| 35 | **`validatePasswordComplexity` usa `APIError` do Better Auth, não `AppError` do projeto** | 🟢 organização | Better Auth prefere `APIError` dele nos hooks (correto). Mas manter `AppError` consistente fora desse contexto. Documentar a convenção |
+| 36 | **API key sem log explícito de falha de auth** (UnauthorizedError thrown silently) | 🟡 segurança | Brute-force / credential stuffing difícil de detectar sem log. Adicionar log explícito em `UnauthorizedError` no macro `auth` (auth-plugin.ts:224) com IP + path — NÃO logar a chave |
+| 37 | **Password complexity sem check contra common passwords** | 🟢 nice-to-have | Better Auth não tem plugin pronto para isso. `haveibeenpwned` API ou lista k-anonymity em `validatePasswordComplexity` — baixa prioridade |
+| 38 | **`lib/auth.ts` com 24KB** concentra: config Better Auth + 9 helpers de audit + `getAdminEmails` + `validateUniqueRole` + tipos + hooks de DB + plugins | 🟡 qualidade/organização | Arquivo grande com múltiplos concerns dificulta manutenção. Quebrar em: `lib/auth/config.ts` (instância Better Auth), `lib/auth/audit-helpers.ts` (helpers de audit), `lib/auth/validators.ts` (validateUniqueRole, getAdminEmails), `lib/auth/hooks.ts` (databaseHooks + organizationHooks). Manter `lib/auth.ts` como re-export |
+| 39 | **Inconsistência de estilo em hooks de audit** | 🟢 qualidade | `afterCreateOrganization` usa `.catch()` defensivo (redundante mas explícito); demais hooks usam `await` direto. Padronizar um estilo. Como `AuditService.log()` já tem silent catch, **remover os `.catch()` redundantes** é mais limpo |
+| 40 | **Uso de `as any` em `auth-plugin.ts`** 3x e em vários arquivos | 🟡 qualidade | `auth.api as any` para acessar `hasPermission` e `verifyApiKey` (typing limitation do Better Auth). Documentar com comentário do motivo (já feito) mas avaliar extension de tipo (ambient .d.ts) |
+| 41 | **Audit de qualidade geral**: vários arquivos usam `process.env.NODE_ENV` direto em vez de importar de `@/env` | 🟢 consistência | Centralizar via `env.ts` (ver débitos #14-19 sobre env.ts em si) |
+
+#### Débitos de qualidade — revisão retroativa dos Blocos 1-3 (2026-04-21)
+
+Dimensão "Qualidade da implementação" adicionada à metodologia após o Bloco 3. Esta tabela registra débitos de qualidade encontrados nos arquivos já auditados mas não destacados antes.
+
+**Bloco 1 (Bootstrap + env):**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 42 | **`src/index.ts` encadeia 16 `.use()`** linearmente sem agrupamento semântico | 🟢 legibilidade | Comentários de bloco separando: plugins globais de infra (errorPlugin, loggerPlugin, healthPlugin), middleware HTTP (cors, rateLimit), auth (betterAuth), docs (openapi), jobs (cronPlugin), controllers. Ou extrair para função `registerControllers(app)` quando houver `src/routes/v1/` |
+| 43 | **`src/index.ts:60-64`** — config `serve.maxRequestBodySize` hardcoded | 🟢 qualidade | Extrair constante nomeada (ex: `const MAX_BODY_SIZE_MB = 10`) ou puxar de env para configurabilidade |
+
+**Bloco 2 (lib/):**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 44 | **`lib/errors/error-plugin.ts::formatErrorDetail`** é recursivo sem limite de profundidade | 🟡 robustez | Se `error.cause` for cíclico ou muito profundo, causa stack overflow ou logs enormes. Adicionar contador de profundidade com max (ex: 5) |
+| 45 | **`lib/responses/response.types.ts`** tem 7 schemas de erro quase idênticos (unauthorized, forbidden, notFound, conflict, internal, badRequest, validation) | 🟢 qualidade/duplicação | Avocado-hp usa factory `errorSchema(code: string)` que elimina a duplicação. Migrar para factory pattern |
+| 46 | **`lib/cron-plugin.ts`** hardcoda 7 jobs com `.use(cron({...}))` encadeado, cada um repetindo mesma estrutura (`async run() { ... logger.info(...) }`) | 🟢 duplicação | Array declarativo de configs + loop `.use(cron(config))` ou helper `createCronJob({ name, pattern, handler })` que já inclui logger pattern |
+| 47 | **`lib/crypto/pii.ts`** — `encrypt` retorna `string` e `decrypt` espera `string` — tipo não diferencia plaintext de ciphertext | 🟢 type safety | Branded type `type EncryptedString = string & { __brand: 'encrypted' }` para forçar que apenas retorno de `encrypt` seja aceito em `decrypt`. Nice-to-have |
+| 48 | **`lib/errors/error-plugin.ts`** — função `formatValidationErrors` usa cast inseguro `err as ElysiaValidationError` | 🟢 type safety | Usar type guard ou schema Zod para parse defensivo |
+
+**Bloco 3 (Auth):**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 49 | **`lib/auth-plugin.ts` com 369 linhas** concentra: macro definition, resolvers, 7 funções helper de validação, OpenAPI enhancement (enhanceAuthProperties + addValidationsToComponents + addValidationsToPaths), exportação OpenAPI | 🟡 organização/qualidade | Dividir em: `lib/auth/plugin.ts` (só o Elysia macro), `lib/auth/validators.ts` (helpers de role/permission/subscription), `lib/auth/openapi-enhance.ts` (enhancements do OpenAPI do Better Auth). Pode ir junto com #38 no refactor de auth |
+| 50 | **`lib/permissions.ts`** — duplicação massiva entre `orgRoles` (owner/manager/supervisor/viewer) — owner e manager têm 20+ linhas quase idênticas | 🟡 duplicação | Helper `inheritRole(baseRole, overrides)` que recebe um role base e sobrescreve só as diferenças. Ex: `manager: inheritRole(owner, { organization: ["read", "update"], member: ["create", "read"], ... })`. Reduz ~80 linhas |
+| 51 | **`lib/auth.ts`** — 9 helpers `auditXxx` quase idênticos (auditUserCreate, auditLogin, auditOrganizationCreate, ..., auditInvitationAccept) | 🟡 duplicação | Generalizar em `buildAuditEntry(action, resource, resourceId, userId, organizationId?, changes?)` ou manter helpers mas extrair para `lib/auth/audit-helpers.ts` (alinhado com #38) |
+| 52 | **`lib/auth.ts` — `afterCreateOrganization`** usa dynamic import para `OrganizationService` (linha 651-653) | 🟡 investigar | Mesmo padrão suspeito do cron-plugin (#28). Investigar se há dep circular `auth.ts ↔ OrganizationService` e resolver se possível |
+| 53 | **`lib/auth-plugin.ts::resolveApiKeyOrgContext`** faz `auth.api.verifyApiKey` a cada request com API key | 🟡 performance | Sem cache — toda request com `x-api-key` verifica no DB (via Better Auth). Para cliente consumindo Power BI, isso pode ser muitos queries redundantes. Cache simples por TTL curto (30s) pode ajudar. Validar no Bloco 4 (api-keys) se há cache built-in |
+
+#### Débitos descobertos no Bloco 4 da Fase 1 (2026-04-21) — Módulos críticos
+
+**Webhook Pagar.me** (`modules/payments/webhook/`):
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 54 | **API keys não auditam operações admin** | 🔴 compliance | `api-key.service.ts` NÃO chama `AuditService.log()` em create/revoke/delete. Operações administrativas sensíveis (criar credencial, revogar, apagar) **sem audit trail**. Adicionar audit em todas 3 operações com `resource: "api_key"`, capturing createdBy/prefix (nunca a key). Risco LGPD + SOC2 |
+| 55 | **Sem retention policy definida para audit logs** | 🟡 compliance | CLAUDE.md do audit não define quanto tempo logs são mantidos. LGPD pede retention justificada. Definir política (ex: 5 anos para eventos de segurança, 2 anos para CRUD operacional) e implementar jobs de pruning |
+| 56 | **Webhook usa Basic Auth em vez de HMAC signature** | 🟡 segurança | **Validado via WebSearch**: HMAC-SHA256 é o padrão usado por Stripe, GitHub, CircleCI, Shopify, Okta em 2026. Basic Auth é inferior porque: (1) credential estática trafega a cada request; (2) não detecta tampering do body; (3) rotação requer coordenação. Implementação atual tem timing-safe compare correto (webhook.service.ts:139-172), mas o modelo é fraco. **Ação**: consultar docs oficiais do Pagar.me v5 (em docs.pagar.me) para confirmar se suporta HMAC — alguns provedores BR ainda ficaram em Basic Auth. Se sim, migrar; se não, manter + restringir por IP allowlist (defesa adicional) |
+| 57 | **`_rawBody` em `WebhookService.process`** passed mas não usado para verificação | 🟢 código morto ou bug | `webhook.service.ts:76` — underscore indica intenção abandonada. Ou remover parâmetro, ou usar para verificação HMAC (#56). Provavelmente relacionado a HMAC incompleto |
+| 58 | **Webhook silencia quando metadata ausente** | 🟡 robustez | `handleChargePaid`, `handleChargeFailed`, `handleSubscriptionCreated` retornam silently se `data.metadata?.organization_id` não existe. Webhook crítico deveria logar WARN com payload para investigação posterior. `handleSubscriptionCreated` faz isso ✅; os demais não |
+
+**API Keys** (`modules/admin/api-keys/`):
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 59 | **Listagem sem paginação** | 🟡 performance/DoS | `ApiKeyService.list()` retorna TODAS as keys (sem limit/offset). Com 1 cliente hoje OK, mas com N clientes e M keys cada, vira DoS via query pesada. Better Auth `listApiKeys` não tem paginação nativa — implementar via filter ou fetch + slice |
+| 60 | **Rate limit por key inconsistente entre service e plugin** | 🟢 documentação | `api-key.service.ts:34` diz `rateLimitMax: 100`; `lib/auth.ts:848` diz `maxRequests: 200`. CLAUDE.md do api-keys explica "200 para compensar dupla verificação". Documentar a intenção explicitamente ou unificar |
+| 61 | **`isBetterAuthNotFound` helper repetido em cada método** | 🟢 duplicação | `api-key.service.ts` tem 3 métodos (getById, revoke, delete) com try/catch quase idêntico só para mapear 404 do Better Auth. Extrair wrapper genérico: `handleBetterAuthNotFound(keyId, fn)` |
+
+**Public** (`modules/public/`):
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 62 | **Newsletter revela existência de email** | 🟡 privacidade/enumeration | CLAUDE.md: "Email duplicado ativo → ConflictError (409)". Isso permite enumerar emails inscritos (enumeration attack). Retornar **mesmo response** em ambos os casos (sucesso vs duplicado) — lado servidor faz a distinção silenciosamente |
+| 63 | **Public endpoints sem captcha/honeypot** | 🟡 anti-automation | `/v1/public/contact` e `/v1/public/newsletter/subscribe` são alvos para bots/spam. Rate limit global (100/min) pode não ser suficiente. Cloudflare Free Tier (decisão 7.3 #1) resolverá parte. Considerar também honeypot field no form |
+| 64 | **Contact form envia email síncrono** | 🟡 performance | `contact.service` provavelmente chama `sendContactEmail` via await no request. Se SMTP lento, request lento. Já coberto em débito 5.2 #5 (Jobs assíncronos) |
+
+**Audit** (`modules/audit/`):
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 65 | **Filtros de `getByOrganization` aceitam `string` direto** | 🟢 robustez | `audit.service.ts:41-55` faz `new Date(options.startDate)` sem validar. Input inválido pode retornar resultados inesperados. Validação já é feita no `auditQuerySchema` Zod antes — mas defesa em profundidade é ok |
+| 66 | **`audit.service.ts:35` — `select()` retorna **todas** as colunas de audit logs** | 🟢 performance | `db.select().from(auditLogs)` — sem projeção. Em compliance logs podem crescer muito. Considerar select explícito com só campos necessários, ou só pegar `changes` sob demanda (lazy) |
+| 67 | **Sem endpoint `/audit-logs/:id` individual** | 🟢 completude | Apenas list e por-resource. Se suporte precisar ver um único evento, não há endpoint. Nice-to-have |
+
+#### Débitos descobertos no Bloco 5 da Fase 1 (2026-04-21) — Emails
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 68 | **Inconsistência de nome de parâmetro em senders** (`to` vs `email`) | 🟡 qualidade/DX | `sendVerificationEmail({ email })`, `sendPasswordResetEmail({ email })` mas `sendWelcomeEmail({ to })`, `sendUpgradeConfirmationEmail({ to })`. Mesma coisa semanticamente, nomes diferentes. Padronizar para `to` (mais claro e alinhado com Nodemailer) em todos os senders durante o refactor (débito #9) |
+| 69 | **19 senders com padrão quase idêntico** `renderEmail + sendEmail` | 🟡 duplicação | Cada sender tem ~15 linhas fazendo a mesma coisa. Avaliar abstração: função genérica `dispatchEmail({ to, subject, component })` que faz render + send, e cada sender vira 3-4 linhas. Fazer durante o refactor (débito #9) |
+| 70 | **Email hardcoded `"contato@synnerdata.com.br"`** em `sendContactEmail` | 🟡 qualidade | Destinatário de email de contato deveria estar em env var (`CONTACT_EMAIL`). Hoje hardcoded dificulta mudança sem deploy |
+| 71 | **`sendAdminCancellationNoticeEmail` usa `env.SMTP_USER` como destinatário admin** | 🟡 qualidade | Admin notification vai para o usuário SMTP (se definido) — feature flag implícita. Deveria ter `ADMIN_NOTIFICATION_EMAIL` dedicado no env, independente de `SMTP_USER` |
+| 72 | **`roleLabels` em `src/emails/constants.ts`** duplica nomes de roles | 🟢 duplicação | roles (owner, manager, supervisor, viewer) também estão em `lib/permissions.ts`. Criar `lib/permissions/role-labels.ts` (ou similar) e importar dos dois lugares |
+| 73 | **Transporter condicional `env.SMTP_USER && env.SMTP_PASSWORD`** | 🟡 robustez | Em dev com MailHog (sem auth) funciona. Em prod, se alguém esquecer de setar as vars, o transporter inicializa sem auth → SMTP provavelmente rejeita → emails falham silenciosamente (já não propaga erro — ver débitos #74). Ligado a #15 (refine condicional em prod) |
+| 74 | **Falhas de email não são propagadas** | 🟡 observabilidade | `lib/auth.ts:53-69` tem `handleWelcomeEmail` com try/catch que só loga. `sendEmail` em si não tem catch — erro propaga. Inconsistência: alguns callers capturam silently, outros deixam subir. Documentar política ("email é best-effort em X contextos, crítico em Y"). Related: #5.2 #5 (jobs assíncronos) |
+| 75 | **Templates carregam React + React Email** — bundle size em produção | 🟢 performance | Com 19 templates + 5 components, o bundle tem React completo só para servir emails. Medir impacto após primeiro deploy de produção. Tree-shaking deve ajudar; não é prioridade |
+
+#### Débitos descobertos no Bloco 6 da Fase 1 (2026-04-21) — CI/CD e Deploy
+
+**CI workflows (.github/workflows/):**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 76 | **`bun pm audit` ausente** em todos os workflows e scripts do package.json | 🟡 supply chain | Adicionar `bun pm audit --audit-level=high` como step no lint.yml — bloqueia PR com CVE HIGH/CRITICAL. Atualizar README para refletir realidade (hoje afirma que existe) |
+| 77 | **`SKIP_INTEGRATION_TESTS: "true"`** em test.yml | 🟡 cobertura | Validar semântica: o flag pula integration tests no CI? Se sim, integration não roda e cobertura é falsa. Documentar intenção ou remover flag. CLAUDE.md não menciona |
+| 78 | **Playwright E2E não está em nenhum workflow** | 🟡 cobertura | `test:e2e` existe em `package.json` mas não é executado em CI. Adicionar workflow separado (ou step em test.yml) — ao menos no schedule diário. E2E é a camada que detecta regressões de UX/integração completas |
+| 79 | **Build workflow não faz smoke test** | 🟡 qualidade | `build.yml:27-28` só verifica `test -f ./dist/index.js`. Um bundle pode existir mas falhar no startup. Adicionar step: `timeout 10 bun run dist/index.js || [ $? -eq 124 ]` (expect timeout, não erro) |
+| 80 | **Sem cache de `bun install`** em todos workflows | 🟢 performance CI | Cada run baixa deps do zero. `setup-bun@v2` tem cache nativo — ativar com `cache: true` ou `actions/cache`. Reduz CI time |
+| 81 | **`lint.yml` roda `bun install` sem `--frozen-lockfile`** | 🟡 reprodutibilidade | Se alguém alterar lockfile em PR sem notar, CI instala mas não pega. Adicionar flag para consistência com Dockerfile |
+| 82 | **Trivy scaneia imagem, não filesystem** | 🟡 cobertura | `security.yml` só faz image scan. Fazer scan FS também com `trivy fs .` (secrets em histórico git, misconfigs em IaC, vulnerabilidades em deps não-Docker) |
+| 83 | **Trivy severity `CRITICAL,HIGH` ignora MEDIUM** | 🟢 cobertura | Pode deixar MEDIUM real passar. Considerar incluir `MEDIUM` quando volume for gerenciável |
+| 84 | **Sem scan de secrets em histórico git** (gitleaks/trufflehog) | 🟡 segurança | `secretlint` é local (pre-commit via husky). Se alguém commitou secret e depois removeu, continua no histórico. Adicionar `gitleaks` ou `trufflehog` ao security.yml |
+| 85 | **Sem SBOM (Software Bill of Materials)** | 🟡 compliance | SOC2 e supply chain em 2026 esperam SBOM. Trivy pode gerar via `trivy sbom`. Adicionar como artifact do build |
+| 86 | **Sem coverage reporting** | 🟢 qualidade | `bun test --coverage` existe (`test:coverage` no package.json) mas não roda no CI. Para code review, saber que 70% do código tem testes é informação crítica. Subir pro Codecov/coveralls |
+
+**Dockerfile:**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 87 | **Base image `oven/bun:1-alpine` sem pin de SHA** | 🟡 supply chain | Tag `1-alpine` muda. Em scan reprodutível, pinar como `oven/bun:1-alpine@sha256:<digest>` e atualizar via Dependabot. Trade-off: mais manual, mais seguro |
+| 88 | **HEALTHCHECK só chama `/health/live`** | 🟡 robustez | Liveness não detecta DB morto. Considerar trocar para `/health` (deep check) com `--retries=10` — se DB down, container marcado unhealthy, Coolify reinicia |
+
+**Entrypoint e runtime:**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 89 | **Migrations rodam a cada startup sem wait-for-db** | 🟡 robustez | Se Postgres não está pronto quando container sobe, `bun run src/db/migrate.ts` falha e container morre. Adicionar `wait-for-it.sh` ou loop simples: `until pg_isready -h $DB_HOST; do sleep 1; done` antes do migrate |
+| 90 | **Sem estratégia de migration em scale** | 🟢 escala | Múltiplas instâncias subindo simultaneamente podem ter race condition em migration. Drizzle é idempotente mas locks podem travar. Em escala: migration em job one-shot separado (Kubernetes Job ou script pré-deploy) |
+| 91 | **Sem rollback de migration** | 🟢 robustez | Se migration tem bug, deploy fica preso. Documentar processo de rollback (reset de `__drizzle_migrations` + checkout de commit anterior + redeploy) em runbook |
+
+**Deploy e observabilidade de produção:**
+
+| # | Débito | Severidade | Ação |
+|---|---|---|---|
+| 92 | **Backup policy do Postgres gerenciado pelo Coolify não está documentada no repo** | 🟡 compliance | LGPD/SOC2 esperam retention documentada. Validar na UI do Coolify: frequência de backup, retention, teste de restore periódico. Documentar em runbook (`docs/runbooks/database-backup.md`) |
+| 93 | **Sem runbook de oncall/incidente** | 🟢 maturidade | Onde procurar quando algo quebra 3h da manhã? Criar `docs/runbooks/` com: DB down, webhook Pagar.me falhando, SMTP caído, Sentry recebendo 5xx em massa |
+| 94 | **Version do projeto em `package.json:3` (`1.0.50`) é manual** | 🟢 qualidade DX | Sem semantic-release ou similar — dev precisa bumpar manualmente. Para lib/app com release frequente, considerar automation. Não crítico agora |
+| 95 | **Em `test.yml`, secrets Pagar.me/Auth expostos no `env` do job inteiro** | 🟡 segurança CI | Todos os steps enxergam `PAGARME_SECRET_KEY` etc. Deveria ser escopado só ao step de teste, ou usar `secrets` inherit em actions filhas. Baixo risco (GitHub já protege logs), mas princípio de menor privilégio |
+
+#### Features do Better Auth que já usamos (referência para não reinventar)
+
+Para cada necessidade, **primeiro verificar se o Better Auth já oferece**. Tabela do que já está ativo:
+
+| Necessidade | Feature Better Auth | Status |
+|---|---|---|
+| Rate limit em auth endpoints | `rateLimit.customRules` | ✅ Ativo (5 regras custom) |
+| CSRF protection | `trustedOrigins` | ✅ Ativo |
+| Cookies seguros | `advanced.useSecureCookies` | ✅ Ativo em prod |
+| IP real atrás de proxy | `advanced.ipAddress.ipAddressHeaders` | ✅ Ativo (x-forwarded-for, x-real-ip) |
+| Email verification obrigatória | `emailAndPassword.requireEmailVerification` | ✅ Ativo |
+| Revogação de session em reset | `emailAndPassword.revokeSessionsOnPasswordReset` | ✅ Ativo |
+| Session cache (perf) | `session.cookieCache` | ✅ Ativo (5min) |
+| Password complexity | `emailAndPassword.password.hash` hook | ✅ Ativo (upper+lower+digit+special) |
+| 2FA OTP + backup codes | `twoFactor` plugin | ✅ Ativo (encrypted OTP/backup) |
+| Admin roles | `admin` plugin | ✅ Ativo (super_admin/admin) |
+| Multi-tenancy (org) | `organization` plugin | ✅ Ativo (hooks + limits) |
+| API Keys com permissions | `apiKey` plugin | ✅ Ativo (rate limit próprio 200/min) |
+| i18n de mensagens | `better-auth-localization` | ✅ Ativo (pt-BR) |
+| Hash password | `better-auth/crypto` | ✅ Ativo |
+| OpenAPI de auth | `openAPI` plugin + enhance custom | ✅ Ativo |
+
+#### Features do Better Auth **ainda não usadas** (avaliar se viram relevantes)
+
+A consultar via `context7` e docs oficiais quando surgir gap específico — **não implementar custom antes de verificar**:
+
+| Feature | Quando considerar |
+|---|---|
+| `magic link` plugin (passwordless) | Se quisermos reduzir fricção de senha esquecida |
+| `email-otp` plugin | OTP por email como alternativa a password |
+| `passkey` / WebAuthn | Se compliance exigir auth mais forte que 2FA |
+| `jwt` plugin | Se consumidores externos preferirem JWT a cookies |
+| `bearer` plugin | Bearer token suporte |
+| `username` plugin | Login por username além de email |
+| `accountLinking` | Social providers (Google, GitHub) |
+| `oAuthProxy` | OAuth pass-through |
+| `phone-number` plugin | Login por telefone |
+| Rate limit `storage: "database"` | Ao escalar horizontalmente |
+| `ac`/`access` custom statements | Se quisermos resources fora do escopo atual |
+
+**Princípio adotado:** antes de propor qualquer implementação custom em auth/identity, **consultar as docs do Better Auth via `context7`** para confirmar que não existe feature built-in.
+
+#### Notas gerais
+
+- **Débitos críticos em produção:**
+  - **#22 (auditPlugin sem try/catch)** — pode derrubar requests em produção se DB de audit falhar
+  - **#31 (8 hooks de audit no Better Auth sem catch)** — mesmo padrão, mas em pontos mais sensíveis (signup, login, org ops)
+  - **MVP item #16 (requestId no envelope de erro)** — confirmado ausente no `errorPlugin`
+- **Débitos #1 (plugins mistos), #8 (emails duplicado) e #22 (audit bloqueante)** são os de maior impacto — merecem PRs dedicados
+- Demais débitos (#2–#7, #9–#21, #23–#30) são oportunistas: resolvem quando a Fase 3 tocar na área
+- Exceto #22, nenhum débito **bloqueia o MVP funcional** — são organização semântica + hardening leve
+- Débito **#20 (request timeout)** é hardening real — entra no bucket 🟡 early-stage (o default de 255s é tolerável em MVP)
+
+---
+
+## 8. Changelog
+
+Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
+
+### 2026-04-21 — Fase 0 concluída (contexto aplicado)
+
+- **Contexto fechado** (seção 7.1): 6 eixos preenchidos — MVP B2B, multi-tenant, monolito Elysia + Postgres, browser + server-to-server (API key Power BI do cliente), volume baixo, pública sem CDN
+- **Compliance mapeado** (seção 7.2): LGPD obrigatória com rigor extra em dados de saúde (atestados médicos, Art. 11); PCI N/A (delegado ao Pagar.me); SOC 2 / ISO 27001 sob demanda; eSocial é scale; NRs trabalhistas ativam retention policy
+- **Decisões arquiteturais registradas** (seção 7.3):
+  - Cloudflare Free Tier **como etapa final do early-stage** (requer alinhamento com cliente — DNS no registro.br)
+  - Sem WAF/CDN no MVP (decisão consciente; app assume responsabilidades do edge)
+  - eSocial direto = Scale
+  - LGPD tratada como **requisito integrado ao MVP/early-stage**, não fase separada
+- **Convenção semântica adotada** (seção 7.6): separar `src/lib/` (utilitários puros) de `src/plugins/` (plugins Elysia) e introduzir `src/routes/v1/` para composição. Migração gradual: novo código no lugar certo, legado migra oportunisticamente
+- **Padrão de emails decidido** (débito #8): seguir avocado-hp — tudo em `src/lib/emails/{senders, templates, components}`. Vira plano dedicado na Fase 3 pelo risco em auth
+- **10 débitos pré-audit identificados** (seção 7.7): plugins misturados em lib/, duplicação emails, helpers com lógica de domínio, request-context duplicado, lib/audit/ convivendo com modules/audit/, testes fora de padrão, arquivos grandes (auth.ts 24KB, email.tsx 12KB), falta de src/routes/
+- **Pontos de atenção para Fase 1 registrados** (seção 7.4): auth é 100% plugin-based; módulos críticos (webhook Pagar.me, public, admin/api-keys)
+- **Fluxo de trabalho de 4 fases** definido (seção 2): Contexto → Audit → Roadmap → Execução, com execução item-a-item (não separar refactor de implementação nova em macro-fases)
+
+**Referência de partida:** avocado-hp (`apps/server/src/`) — projeto previamente auditado juntos, usado como **benchmark pareado** de organização (não dogma). Synnerdata já supera avocado-hp em várias áreas (crypto/PII, supply chain scan, utilitários de resiliência, error tracking, infra de testes) — avocado-hp inspira principalmente em organização (`lib/` vs `plugins/`, emails em subpastas). A Fase 1 usará investigação independente com 4 fontes: código atual + docs Elysia (context7) + best practices web + avocado-hp como inspiração.
+
+### 2026-04-21 — Metodologia da Fase 1 formalizada
+
+- **Princípio:** investigação independente, não cópia de referência
+- **4 fontes ponderadas** para cada item (seção 7.4.2): código atual, docs Elysia via context7, best practices web, avocado-hp como inspiração
+- **6 veredictos possíveis** por item, incluindo 🏆 `synnerdata > avocado-hp` (para reconhecer quando este projeto está melhor)
+- **Pontos de partida sabidos** documentados — o que synnerdata tem que avocado-hp não tinha, e os débitos em comum prováveis
+
+### 2026-04-21 — Princípios adicionais e correções durante a Fase 1
+
+- **"Better Auth primeiro"**: antes de qualquer implementação custom em auth/session/rate-limit/CSRF/2FA/API-keys, verificar primeiro se Better Auth já oferece. Tabela de features já usadas vs não usadas em 7.7
+- **4ª dimensão de avaliação — Qualidade da implementação**: adicionada à metodologia após o Bloco 3 e aplicada retroativamente aos Blocos 1-3 (débitos #42-#53). Cobre tipagem, responsabilidade única, testabilidade, legibilidade
+- **Consulta obrigatória a fontes externas** para débitos 🟡/🔴 relevantes: context7 (docs do framework) + WebSearch (best practices 2026). Débitos #32 e #56 validados assim durante o Bloco 4
+- **Correção de débitos #22 e #31** (audit sem try/catch) — reavaliados após leitura do `modules/audit/audit.service.ts`: `AuditService.log()` já tem silent catch intencional, documentado no CLAUDE.md do módulo. Débitos revertidos
+
+### 2026-04-21 — Progresso da Fase 1
+
+- Bloco 1 (Bootstrap + env): ✅ concluído — 9 débitos (#11-#20)
+- Bloco 2 (Infra em lib/): ✅ concluído — 10 débitos (#21-#30)
+- Bloco 3 (Auth): ✅ concluído — 7 débitos (#31-#37)
+- Revisão retroativa de qualidade (Blocos 1-3): ✅ concluída — 12 débitos (#42-#53)
+- Bloco 4 (Módulos críticos): ✅ concluído — 14 débitos (#54-#67) + validações com fontes externas
+- Bloco 5 (Emails): ✅ concluído — 8 débitos (#68-#75), escopo mapeado via `grep`
+- Bloco 6 (CI/CD e deploy): ✅ concluído — 20 débitos (#76-#95)
+- Consolidação do relatório: ✅ concluído — [`docs/reports/2026-04-21-api-infrastructure-audit.md`](../reports/2026-04-21-api-infrastructure-audit.md)
+
+### 2026-04-21 — Fase 1 concluída
+
+**Números finais:**
+- **Total de débitos registrados:** 95 (#1-#95 na seção 7.7)
+- **Débitos revertidos após validação:** 2 (#22 e #31 — `AuditService.log` tem silent catch intencional)
+- **Veredictos nas tabelas 4/5:** ~65 itens avaliados com Status + Observações
+
+**Áreas em que synnerdata supera avocado-hp** (9 áreas destacadas no relatório): `lib/crypto/pii.ts`, config Better Auth rica, Sentry com proteção de headers sensíveis, correlation ID em sucesso+erro, OpenAPI com x-error-messages, CORS robusto, webhook com idempotência completa, Dependabot 3-ecosystems, Trivy+SARIF+affected tests.
+
+**Débitos críticos identificados (🔴 urgente):**
+1. #16 `requestId` ausente no body do erro (MVP)
+2. #54 API keys não auditam operações admin (compliance LGPD)
+3. #20 Request timeout não configurado
+4. #76 `bun pm audit` ausente em CI
+5. #22-24 auditPlugin em lugar errado + exige contexto manual + tipos frouxos
+6. Validar BOLA em cada service
+
+**Recomendação de priorização para Fase 2**: ver seção "Recomendação inicial de priorização" do relatório. Propõe-se 3 buckets com ações concretas em cada.
+
+**Próxima etapa:** Fase 2 — consolidar roadmap em seção 7.5 com aprovação do owner do projeto.
+
+### 2026-04-21 — Fase 2 concluída (roadmap priorizado)
+
+Seção 7.5 preenchida com **69 ações totais** divididas em 3 buckets:
+
+- **🔴 Urgente (10 ações, RU-1 a RU-10)** — hardening de env.ts, requestId no erro, request timeout, `bun pm audit` no CI, audit de API keys, fix do auditPlugin, BOLA testing, runbook backup Coolify. Prazo alvo: 30 dias.
+- **🟡 Curto prazo (38 ações, CP-1 a CP-38)** — 5 PRs dedicados (plugins/, emails, routes/v1/, split auth, clean errors) + 33 ações pontuais (segurança, Cloudflare Free, observabilidade, qualidade). Prazo alvo: 30-90 dias.
+- **🟢 Médio prazo / sob demanda (21 ações, MP-1 a MP-21)** — paginação cursor, cache Redis, BullMQ, tracing, eSocial, SOC 2, ISO 27001, etc. Só quando sinal real aparecer.
+
+**Estrutura padrão de cada ação:**
+- ID (RU-N / CP-N / MP-N) para referência em branches e PRs
+- Débitos cobertos (link para 7.7)
+- Tipo (config / new / refactor / docs / plan)
+- Esforço (S / M / L / XL)
+- Depende de (IDs bloqueadores)
+
+**Princípios de execução registrados:** (1) finalizar 🔴 antes de iniciar 🟡; (2) dentro de 🟡 priorizar PRs dedicados (CP-1 a CP-5) que destravam outras ações; (3) 🟢 só com sinal real; (4) atualizar o documento conforme progresso.
+
+**Próxima etapa:** Fase 3 — execução começando por **RU-1 (hardening `env.ts`)**.
+
+### 2026-04-21 — Metodologia de execução (Fase 3) documentada em 7.5.1
+
+Antes de iniciar a Fase 3, registradas em 7.5.1 todas as propostas e avaliações discutidas (que estavam só no chat) para garantir que o documento continua auto-contido:
+
+- **Template padrão** para planos de execução em `docs/plans/YYYY-MM-DD-<id>-<slug>.md`: Meta, Contexto, Pesquisa 4 fontes, Implementação, Validação, Rollback, Definition of Done. Ações S não precisam de plano formal — descrição no PR basta
+- **Agrupamento do bucket 🔴** em 5 PRs temáticos: Fundação (RU-1,2,3), CI (RU-4,5), Audit (RU-6,7,8), BOLA (RU-9), Docs (RU-10)
+- **Política de worktrees**: branches normais para Grupos 1/2/3/5; worktree para RU-9 se paralelo a outro grupo; worktree obrigatório para CP-1 e CP-2 (XL)
+- **Avaliação do [Compozy](https://github.com/compozy/compozy)** como alternativa ao template caseiro — matriz comparativa + sinais no repositório (skills-lock.json já tem 6 skills, `cy-*` disponíveis, sem `.compozy/` ainda criado)
+- **Matriz de escolha por esforço**: S via branches simples; M/L/XL via Compozy com `/cy-final-verify` e council em XL
+- **3 opções metodológicas** registradas (A pilot, B híbrido, C caseiro) com prós/contras para escolha explícita
+
+**Status:** 🔄 **Decisão metodológica em aberto** (seção 7.5.1 "Decisão"). Fase 3 aguarda escolha entre A/B/C antes de iniciar.
+
+### 2026-04-21 — Decisão metodológica: Opção B (Híbrido)
+
+Escolhida a **Opção B — Híbrido imediato**: ações S via branches simples imediatamente, Compozy setup em paralelo, a partir de RU-6 usar pipeline completo do Compozy (`/cy-create-prd` → `/cy-create-techspec` → `/cy-create-tasks` → `compozy start` → `/cy-final-verify`). Justificativa completa + consequências operacionais em 7.5.1.
+
+**Fase 3 iniciando.** Primeira ação: **RU-1 (hardening `env.ts`)** no Grupo 1 (Fundação).
+
+### 2026-04-21 — Política de testes documentada em 7.5.2
+
+Antes de iniciar RU-1, registrada política de testes escopada para a Fase 3:
+
+- **Princípio:** testar o que é tocado, não tudo. Coverage é sinal, não meta.
+- **4 categorias** de política por tipo de ação: (1) TDD clássico, (2) Não-regressão, (3) Teste mínimo focado, (4) N/A
+- **Escopo de execução**: rodar só testes diretos do arquivo tocado + testes de consumidores + testes novos da ação. Não rodar suite completa (>10min).
+- **Regras de ouro** (5): testar comportamento não implementação, não testar framework, edge case de segurança sempre testa, movimentos = rodar existentes, não adicionar teste que só dá trabalho.
+- **Tabela de políticas** para cada ação do bucket 🔴 (RU-1 a RU-10) com categoria, arquivos afetados, testes a rodar e a escrever.
+- **Definition of Done** do template de plano (7.5.1) atualizado com checklist de testes.
+
+**Próxima sub-etapa:** rodar `bun run test:coverage` como baseline + executar testes afetados pelo bucket 🔴 para confirmar estado verde antes de iniciar RU-1. Compozy ainda será discutido em mais detalhes antes de começar.
+
+### 2026-04-21 — Baseline de testes do bucket 🔴 executado
+
+Rodados testes que cobrem as áreas a serem tocadas pelo bucket 🔴 para confirmar estado verde antes de mexer no código:
+
+| Área | Testes | Resultado | Cobertura para |
+|---|---|---|---|
+| `src/lib/errors/__tests__/` | 11 | ✅ 11 pass, 0 fail (529ms) | RU-2 (baseline de `errorPlugin`) |
+| `src/modules/audit/__tests__/` | 20 (em 2 arquivos) | ✅ 20 pass, 0 fail (9.3s) | RU-7, RU-8 (cobre `AuditService`, não o plugin) |
+| `src/modules/admin/api-keys/__tests__/` | 31 (em 6 arquivos) | ✅ 31 pass, 0 fail (14.3s) | RU-6 (mas sem teste de audit trail) |
+
+**Baseline: 62 testes verdes** protegendo as áreas a serem refatoradas.
+
+**Gap crítico identificado e coberto:** `src/lib/audit/audit-plugin.ts` **não tinha nenhum teste direto** (e `createTestApp()` em `src/test/helpers/app.ts` não inclui o `auditPlugin`). Para refatorar RU-7/RU-8 com segurança, criado `src/lib/audit/__tests__/audit-plugin.test.ts` com 7 testes de baseline documentando o comportamento atual:
+
+1. Injeção do `audit()` no contexto + persistência completa do log
+2. Extração de IP de `x-forwarded-for` (primeiro valor quando múltiplos)
+3. Fallback para `x-real-ip` quando `x-forwarded-for` ausente
+4. `ipAddress`/`userAgent` null quando headers ausentes
+5. `organizationId: null` para ações system-level (login, user create)
+6. `resourceId` opcional
+7. Tipos frouxos (`AuditAction | string`) — será endurecido em RU-7
+
+**Resultado:** ✅ 7 pass, 0 fail (1.2s). Baseline verde pronto. O 7º teste serve como documentação viva do débito #24 — RU-7 irá atualizá-lo para tipos estritos.
+
+**Outras ações do bucket 🔴 — não precisam de baseline novo:**
+
+- **RU-1 (env.ts)**: teste `src/__tests__/env.test.ts` será escrito como parte da ação (TDD categoria 3). Estado atual não precisa de baseline — não há comportamento a proteger, só novas validações a adicionar.
+- **RU-2 (requestId no erro)**: 11 testes de errors já protegem shape do envelope; teste novo (`error.requestId`) vem no TDD da própria RU-2.
+- **RU-3, RU-4, RU-5, RU-10**: categoria (4) N/A — sem testes.
+- **RU-6 (audit api-keys)**: 31 testes atuais cobrem create/revoke/delete funcional; teste que valida emissão de `AuditService.log` vem no TDD da própria RU-6.
+- **RU-9 (BOLA)**: é inteiramente sobre escrever testes novos. Template reutilizável em `api-key-org-access.test.ts:70-103`.
+
+**Conclusão:** cobertura adequada garantida. Pronto para iniciar Fase 3 com "conforto" — qualquer regressão durante refactors do bucket 🔴 será detectada pelos 69 testes de baseline (62 existentes + 7 novos do auditPlugin).
+
+### 2026-04-21 — Compozy workspace configurado + `cy-idea-factory` diferida
+
+**Concluído:**
+- CLI `compozy 0.1.12` instalado globalmente
+- 9 skills core instaladas em `~/.claude/skills/` (compozy, cy-create-prd, cy-create-techspec, cy-create-tasks, cy-execute-task, cy-review-round, cy-fix-reviews, cy-final-verify, cy-workflow-memory)
+- `.compozy/config.toml` criado no repositório com defaults alinhados ao CLAUDE.md: `ide = "claude"`, `model = "opus"`, `auto_commit = false`, `reasoning_effort = "xhigh"`
+- `.compozy/` versionado (não está no `.gitignore`, conforme recomendação oficial — artifacts devem ser commitados)
+
+**Diferido (não instalado agora):**
+- Extensão `cy-idea-factory` — traz council de 6 agentes (security-advocate, architect-advisor, pragmatic-engineer, product-mind, devils-advocate, the-thinker) e skill `/cy-idea-factory`. Motivo: roadmap atual (bucket 🔴 + maior parte do 🟡) já tem escopo claro do audit; council é overkill para ações bem escopadas. Instalar apenas antes de CP-1/CP-2 (XL) ou qualquer item do bucket 🟢 (decisões com múltiplos trade-offs sem design pronto)
+
+**Estado:** pronto para iniciar Fase 3. Próxima ação — **RU-1 (hardening `env.ts`)** via fluxo simples (branch direta, sem Compozy).
+
+### 2026-04-21 — RU-1 concluído (hardening `src/env.ts`)
+
+**Branch:** `fix/urgent-foundation-hardening` (Grupo 1 — fundação; RU-2 e RU-3 virão na mesma branch).
+
+**Arquivos modificados:**
+- `src/env.ts` — schema endurecido: (a) `envSchema` exportado; (b) `NODE_ENV: z.enum(...)` com default; (c) `BETTER_AUTH_SECRET.min(32)`; (d) `PII_ENCRYPTION_KEY.regex(/^[0-9a-fA-F]{64}$/)`; (e) `SMTP_FROM: z.email()`; (f) `CORS_ORIGIN.describe(...)`; (g) `superRefine` exigindo `SMTP_USER`/`SMTP_PASSWORD` em produção; (h) `isProduction` agora usa `env.NODE_ENV` em vez de `process.env.NODE_ENV` direto.
+- `src/__tests__/env.test.ts` (novo) — 24 testes cobrindo todas as 6 regras novas.
+
+**Débitos resolvidos em 7.7:** #14, #15, #16, #17, #18, #19.
+
+**Validação executada:**
+- ✅ `bun run lint:types` — sem erros
+- ✅ `bun run lint:check` — 563 arquivos verificados, sem warnings
+- ✅ `bun test src/__tests__/env.test.ts` — 24 pass / 0 fail (169ms)
+- ✅ `bun test src/lib/audit/__tests__/` — 7 pass (baseline `auditPlugin` preservado)
+- ✅ Não-regressão: `errors/__tests__/` + `modules/audit/__tests__/` + `modules/admin/api-keys/__tests__/` — **62 pass / 0 fail** (20.4s)
+
+**Valores atuais em `.env` e `.env.test`** compatíveis com as novas regras: `BETTER_AUTH_SECRET` com 32 chars, `PII_ENCRYPTION_KEY` com 64 hex chars, defaults (`SMTP_FROM=noreply@synnerdata.com`) válidos. **Ação externa recomendada:** auditar o GitHub secret `BETTER_AUTH_SECRET` usado no `test.yml` para confirmar `.min(32)` (não auditável via código).
+
+**Próxima ação:** RU-2 (incluir `requestId` no body do erro — TDD no `errorPlugin`).
+
+---
+
+## 9. Referências
+
+- [OWASP API Security Top 10 — 2023](https://owasp.org/API-Security/editions/2023/en/0x11-t10/)
+- [OWASP API Security Project](https://owasp.org/www-project-api-security/)
+- [ElysiaJS — Deploy to Production](https://elysiajs.com/patterns/deploy)
+- [ElysiaJS — Config](https://elysiajs.com/patterns/configuration)
+- [elysiajs-helmet (GitHub)](https://github.com/aashahin/elysiajs-helmet)
+- [Node.js Security Best Practices 2026](https://medium.com/@sparklewebhelp/node-js-security-best-practices-for-2026-3b27fb1e8160)
+- [REST API Design — Idempotency, Pagination, Security (ByteByteGo)](https://blog.bytebytego.com/p/the-art-of-rest-api-design-idempotency)
+- [Postman — REST API Best Practices](https://blog.postman.com/rest-api-best-practices/)
+- [Node.js API Best Practices 2026 (OpenReplay)](https://blog.openreplay.com/nodejs-api-best-practices-2026/)

--- a/docs/reports/2026-04-21-api-infrastructure-audit.md
+++ b/docs/reports/2026-04-21-api-infrastructure-audit.md
@@ -1,0 +1,191 @@
+# Relatório de Auditoria de Infraestrutura da API
+
+**Data:** 2026-04-21
+**Escopo:** Fase 1 do fluxo definido em `docs/improvements/api-infrastructure-checklist.md`
+**Status:** ✅ Concluído (Blocos 1-6 + relatório)
+**Próximo passo:** Fase 2 — consolidação do roadmap priorizado (seção 7.5 do checklist)
+
+---
+
+## Resumo executivo
+
+Auditoria de **25 arquivos/pastas** em 6 blocos cobrindo bootstrap, infraestrutura, auth, módulos críticos, emails e CI/CD. Foram consultadas 4 fontes por item avaliado: código atual, docs oficiais via `context7` (Better Auth, Elysia), pesquisa web (OWASP, best practices 2026) e avocado-hp como benchmark pareado.
+
+**Veredito geral**: o projeto está em estado **acima da média** para um MVP B2B multi-tenant. Investimento em segurança (crypto PII, Better Auth, Sentry, Trivy, Dependabot) e observabilidade básica é sólido. Débitos encontrados são majoritariamente **hardening leve** e **organização semântica** — não há comprometimento funcional, mas há riscos reais em produção pelo cliente ativo.
+
+### Contagens consolidadas
+
+**Núcleo universal** (35 itens agnósticos):
+
+| Tabela | Total | ✅ | ⚠️ | ❌ | ? / N/A |
+|---|---|---|---|---|---|
+| 4.1 MVP universal | 19 | 13 | 4 | 2 | 0 |
+| 4.2 Early-stage universal | 10 | 3 | 4 | 2 | 1 |
+| 4.3 Scale universal | 6 | 0 | 0 | 6 | 0 |
+
+**Context-dependent** (30 itens filtrados pelo contexto do projeto):
+
+| Tabela | Total | ✅ | ⚠️ | ❌ | N/A |
+|---|---|---|---|---|---|
+| 5.1 MVP conforme contexto | 9 | 5 | 2 | 1 | 1 |
+| 5.2 Early-stage conforme contexto | 9 | 1 | 2 | 1 | 5 (? e N/A) |
+| 5.3 Scale conforme contexto | 12 | 0 | 0 | 10 | 2 |
+
+**Débitos totais registrados**: **95** (seção 7.7 do checklist), categorizados:
+- 🔴 crítico / urgente (impacto direto em produção): **3**
+- 🟡 hardening / curto prazo: **~40**
+- 🟢 qualidade / médio prazo: **~50**
+- Reavaliados e revertidos: **2** (#22 e #31 — `AuditService.log` já tem silent catch intencional)
+
+---
+
+## Achados surpreendentes
+
+### 🏆 Pontos em que synnerdata supera avocado-hp (referência pareada)
+
+Nove áreas onde a implementação do synnerdata é **objetivamente superior** ao projeto-referência usado como benchmark:
+
+1. **`lib/crypto/pii.ts`** — AES-256-GCM com scrypt KDF + salt per-encrypt + helpers de mask (CPF/email/phone/PIS/RG). Avocado-hp não tem nada equivalente. Ótima base para compliance LGPD com dados de saúde.
+2. **Better Auth configurado de forma rica** — rate limit com 5 customRules (sign-in 5/min, forgot-password 3/5min), 2FA OTP encrypted, backup codes encrypted, admin plugin, organization plugin completo, apiKey plugin com rate limit próprio (200/min). Resolve vários débitos de MVP **sem código custom**.
+3. **`lib/sentry.ts` com `beforeSend`** — remove `authorization` e `cookie` dos requests enviados ao GlitchTip (proteção contra vazamento de credenciais em error tracking).
+4. **Correlation ID (`X-Request-ID`) injetado em sucesso E erro** — avocado-hp só injetava em sucesso.
+5. **OpenAPI com `x-error-messages`** extraído dos checks do Zod v4 — frontend pode gerar validações ricas via Kubb.
+6. **CORS robusto com `parseOrigins`** (múltiplas origins), `maxAge: 86400`, expose headers de RateLimit.
+7. **Webhook Pagar.me com idempotência completa** — check `pagarmeEventId` + `processedAt`, timing-safe compare em Basic Auth, timestamp ordering em subscription updates.
+8. **Dependabot com 3 ecosystems** (npm + docker + github-actions), groups, security patches como prioridade.
+9. **CI Trivy + SARIF upload para GitHub Security tab** + affected tests via `scripts/affected-tests.sh` (diff-based).
+
+### Achados negativos surpreendentes
+
+Débitos encontrados que **não eram esperados** dado o estado geral do projeto:
+
+1. **#16 `requestId` ausente no body do erro** (MVP faltante) — 1 linha de mudança, impacta suporte direto. Surpreendente que não esteja implementado dado o resto do logging robusto.
+2. **#54 API keys não auditam operações admin** — `ApiKeyService.create/revoke/delete` não chamam `AuditService.log`. Gap de compliance em um módulo de alta criticidade (cliente em produção consumindo via Power BI).
+3. **#76 `bun pm audit` ausente em todos os workflows** — README afirma que existe, mas não está nem no `package.json` nem nos workflows. Trivy cobre imagem mas não deps JS específicas (Dependabot é reativo, não bloqueia PR).
+4. **`lib/email.tsx` com 476 linhas** concentrando transporter + 19 senders — mesmo padrão repetitivo. Refactor mapeado (débito #8/#9) é grande mas seguro (apenas 6 consumidores externos).
+5. **`lib/auth.ts` com 24KB** misturando config Better Auth + 9 helpers de audit + validators + hooks — candidato óbvio para divisão.
+6. **Plugins Elysia em `src/lib/`** (cron, audit, request-context, auth, logger) convivendo com utilitários puros — organização semântica dispersa.
+7. **`src/lib/helpers/employee-status.ts`** com lógica de domínio — pertence a `modules/employees/`.
+8. **Débitos #22 e #31 (audit sem try/catch) revertidos** — análise superficial levou a falso positivo. `AuditService.log` já tem silent catch intencional documentado no CLAUDE.md do módulo. Lembrete: ler CLAUDE.md antes de julgar.
+
+---
+
+## Riscos imediatos em produção
+
+Cliente ativo consumindo a API via front web + API keys (Power BI). Os seguintes débitos representam **risco real hoje** e devem ser endereçados no bucket **🔴 Urgente** da Fase 2:
+
+| # | Débito | Impacto potencial |
+|---|---|---|
+| 16 (MVP) | `requestId` ausente no body do erro | Suporte não correlaciona tickets com logs sem pedir header manualmente |
+| 54 | API keys não auditam create/revoke/delete | Gap de compliance LGPD + rastreabilidade |
+| 20 | Request timeout não configurado | Handler travado pode derrubar servidor |
+| 76 | `bun pm audit` ausente | Supply chain scan parcial (Trivy cobre imagem, não deps JS) |
+| 22/23/24 (audit plugin) | `auditPlugin` em `lib/audit/` (lugar errado) + exige contexto manual + tipos frouxos | Inconsistência com `modules/audit/` + propenso a erro humano |
+| BOLA (5.1 #3) | Isolamento por `organizationId` depende de disciplina por-service | Validar com testes cruzados entre orgs em cada módulo |
+| 56 | Webhook Pagar.me usa Basic Auth em vez de HMAC | Credential estática trafega a cada webhook (mitigado por TLS + timing-safe compare) |
+| 77 | `SKIP_INTEGRATION_TESTS: "true"` no CI | Possível falsa sensação de cobertura — validar semântica |
+
+### Mitigações já existentes
+
+Antes de classificar como urgente absoluto, é importante reconhecer o que **já mitiga** parte desses riscos:
+
+- GlitchTip captura 5xx mesmo sem requestId no body
+- Audit via Better Auth hooks cobre user/session/org/members (API keys é gap isolado)
+- `serve.maxRequestBodySize: 10MB` limita payload (sem timeout mas com limite de body)
+- Trivy + Dependabot cobrem parte da cadeia de supply chain
+- Rate limit do Better Auth em endpoints de auth (5 req/min em sign-in) protege brute-force
+- `useSecureCookies` + `trustedOrigins` + CSRF via Better Auth em ambiente de browser
+
+---
+
+## Recomendação inicial de priorização para Fase 2
+
+Proposta preliminar de buckets para o roadmap (a consolidar na Fase 2):
+
+### 🔴 Urgente (antes de 30 dias, cliente ativo em prod)
+
+**Supply chain e correlação:**
+- #76 Adicionar `bun pm audit --audit-level=high` no lint.yml
+- #16 Incluir `requestId` no body do erro (1 linha no errorPlugin)
+- #54 Auditar create/revoke/delete de API keys
+
+**Hardening básico:**
+- #20 Configurar request timeout (`serve.idleTimeout`)
+- #22-24 Corrigir débitos do auditPlugin (mover para `src/plugins/audit/`, remover contexto manual, fix tipos)
+- #77 Validar/corrigir `SKIP_INTEGRATION_TESTS` no CI
+- #92 Documentar backup policy do Postgres Coolify em runbook
+
+**Validar BOLA em prod:**
+- Auditar cada service de `modules/` para garantir filtro `organizationId` + adicionar testes cruzados entre orgs
+
+### 🟡 Curto prazo (30-90 dias)
+
+**Organização semântica (plano dedicado):**
+- **PR #1:** Criar `src/plugins/` e migrar plugins de `lib/` (débito #1)
+- **PR #2:** Consolidar emails em `src/lib/emails/{senders,templates,components,mailer}` (débitos #8, #9)
+- **PR #3:** Criar `src/routes/v1/` e padronizar versionamento (débitos #10, #13)
+- **PR #4:** Quebrar `lib/auth.ts` (24KB) e `lib/auth-plugin.ts` (369 linhas) em arquivos menores (débitos #38, #49)
+- **PR #5:** Mover erros de domínio de `lib/errors/` para `modules/<domínio>/errors.ts` (débito #21)
+
+**Env.ts hardening:**
+- #14-19 Ajustar validações do Zod: min em BETTER_AUTH_SECRET, SMTP condicional, hex validation em PII_ENCRYPTION_KEY, NODE_ENV enum, etc.
+
+**Segurança adicional:**
+- #56 Migrar webhook Pagar.me para HMAC (após confirmar suporte em docs.pagar.me)
+- #84 Adicionar gitleaks/trufflehog para scan de histórico
+- #85 Gerar SBOM via Trivy
+- #88 HEALTHCHECK deep (não só liveness)
+- #89 wait-for-db no entrypoint
+
+**Preparação Cloudflare Free Tier (decisão 7.3 #1):**
+- Alinhar com cliente para apontar DNS registro.br → Cloudflare → Coolify
+- Configurar WAF básico + rate limit + HSTS + compression no edge
+
+**Observabilidade:**
+- #2 Métricas básicas (OTel Metrics ou Prometheus)
+- #9 Política de deprecation (headers `Deprecation`/`Sunset`)
+- #82 Trivy filesystem scan (`trivy fs .`)
+- #78 Playwright E2E em workflow CI
+
+### 🟢 Médio prazo / sob demanda
+
+- Paginação por cursor (quando alguma listagem exceder SLA)
+- Cache layer Redis (quando queries repetidas dominarem)
+- BullMQ + Redis (quando emails/jobs exigirem fila externa)
+- Rate limit do Better Auth com `storage: "database"` (se escalar horizontalmente)
+- SOC 2 / ISO 27001 (se cliente enterprise exigir)
+- eSocial direto (quando roadmap comercial priorizar)
+- Débitos de qualidade #42-75 em geral (oportunísticos)
+
+---
+
+## Referências usadas na auditoria
+
+**Fontes externas consultadas (seção 7.4.2 metodologia):**
+
+- [OWASP API Security Top 10 — 2023](https://owasp.org/API-Security/editions/2023/en/0x11-t10/)
+- [Better Auth — Rate Limit (context7)](https://github.com/better-auth/better-auth/blob/main/docs/content/docs/concepts/rate-limit.mdx) — validou débito #32
+- [Better Auth — Options (context7)](https://github.com/better-auth/better-auth/blob/main/docs/content/docs/reference/options.mdx)
+- [Webhook Security Fundamentals 2026](https://www.hooklistener.com/learn/webhook-security-fundamentals) — validou débito #56
+- [HMAC Signature Validation (Didit)](https://didit.me/blog/webhook-security-hmac-signature-validation/)
+- [SHA256 Webhook Signature Verification (Hookdeck)](https://hookdeck.com/webhooks/guides/how-to-implement-sha256-webhook-signature-verification)
+- [Using Helmet in Node.js (LogRocket)](https://blog.logrocket.com/using-helmet-node-js-secure-application/) — validou priorização de CSP
+- [Pagar.me Webhook Documentation](https://docs.pagar.me/reference/vis%C3%A3o-geral-sobre-webhooks)
+- [ElysiaJS Documentation (context7)](https://elysiajs.com/)
+- [Node.js Security Best Practices 2026](https://medium.com/@sparklewebhelp/node-js-security-best-practices-for-2026-3b27fb1e8160)
+
+**Fontes internas:**
+- `docs/improvements/api-infrastructure-checklist.md` — matriz de referência
+- `docs/code-standards/module-code-standards.md` — padrões do projeto
+- CLAUDE.md por módulo (audit, payments/webhook, admin, admin/api-keys, public, logger)
+- avocado-hp (`apps/server/src/`) — benchmark pareado
+
+---
+
+## Próximos passos concretos
+
+1. **Publicar este relatório** em PR separado ou commit dedicado
+2. **Atualizar seção 7.0** do checklist — Fase 1 ✅ concluída → Fase 2 🔄 próxima
+3. **Atualizar Changelog** do checklist (seção 8)
+4. **Aguardar aprovação** para iniciar Fase 2 (roadmap priorizado)
+5. **Fase 3 (execução)** começa pelos itens do bucket 🔴 Urgente

--- a/src/__tests__/env.test.ts
+++ b/src/__tests__/env.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import { envSchema } from "@/env";
+
+/**
+ * RU-1 — hardening do `src/env.ts`.
+ *
+ * Cobre débitos #14-19 da seção 7.7 de `docs/improvements/api-infrastructure-checklist.md`:
+ *   #14 — BETTER_AUTH_SECRET sem .min(32)
+ *   #15 — SMTP_USER / SMTP_PASSWORD opcional sem refine condicional em produção
+ *   #16 — PII_ENCRYPTION_KEY.length(64) não valida hex
+ *   #17 — SMTP_FROM: z.string() aceita não-email
+ *   #18 — NODE_ENV não validado no schema
+ *   #19 — CORS_ORIGIN formato comma-separated implícito (documentar via .describe())
+ *
+ * Política de teste: categoria (3) — teste mínimo focado. Cobre apenas as
+ * regras novas, não toda a superfície do env.
+ */
+
+// Valores mínimos válidos — reusados em cada teste com overrides pontuais.
+const VALID_ENV = {
+  NODE_ENV: "test",
+  PORT: "3333",
+  CORS_ORIGIN: "http://localhost:3000",
+  DATABASE_URL: "postgresql://postgres:password@localhost:5432/test",
+  BETTER_AUTH_SECRET: "a".repeat(32),
+  BETTER_AUTH_URL: "http://localhost:3333",
+  API_URL: "http://localhost:3333",
+  APP_URL: "http://localhost:3000",
+  PAGARME_BASE_URL: "https://api.pagar.me/core/v5",
+  PAGARME_SECRET_KEY: "sk_test_xxx",
+  PAGARME_PUBLIC_KEY: "pk_test_xxx",
+  PAGARME_WEBHOOK_USERNAME: "webhook_user",
+  PAGARME_WEBHOOK_PASSWORD: "webhook_pass",
+  SMTP_HOST: "localhost",
+  SMTP_PORT: "1025",
+  SMTP_FROM: "noreply@example.com",
+  SUPER_ADMIN_EMAILS: "",
+  ADMIN_EMAILS: "",
+  INTERNAL_API_KEY: "a".repeat(32),
+  PII_ENCRYPTION_KEY: "f".repeat(64),
+} as const;
+
+describe("envSchema — BETTER_AUTH_SECRET minimum length (débito #14)", () => {
+  test("rejects value shorter than 32 chars", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, BETTER_AUTH_SECRET: "a".repeat(31) })
+    ).toThrow();
+  });
+
+  test("accepts value with exactly 32 chars", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, BETTER_AUTH_SECRET: "a".repeat(32) })
+    ).not.toThrow();
+  });
+
+  test("accepts value longer than 32 chars", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, BETTER_AUTH_SECRET: "a".repeat(64) })
+    ).not.toThrow();
+  });
+});
+
+describe("envSchema — PII_ENCRYPTION_KEY hex format (débito #16)", () => {
+  test("rejects 64-char non-hex value", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, PII_ENCRYPTION_KEY: "z".repeat(64) })
+    ).toThrow();
+  });
+
+  test("rejects 64-char value with mixed non-hex characters", () => {
+    const almostHex = `${"0".repeat(63)}G`;
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, PII_ENCRYPTION_KEY: almostHex })
+    ).toThrow();
+  });
+
+  test("accepts 64 lowercase hex chars", () => {
+    expect(() =>
+      envSchema.parse({
+        ...VALID_ENV,
+        PII_ENCRYPTION_KEY: "0123456789abcdef".repeat(4),
+      })
+    ).not.toThrow();
+  });
+
+  test("accepts 64 uppercase hex chars", () => {
+    expect(() =>
+      envSchema.parse({
+        ...VALID_ENV,
+        PII_ENCRYPTION_KEY: "0123456789ABCDEF".repeat(4),
+      })
+    ).not.toThrow();
+  });
+
+  test("rejects value shorter than 64 chars", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, PII_ENCRYPTION_KEY: "a".repeat(63) })
+    ).toThrow();
+  });
+
+  test("rejects value longer than 64 chars", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, PII_ENCRYPTION_KEY: "a".repeat(65) })
+    ).toThrow();
+  });
+});
+
+describe("envSchema — SMTP_FROM email validation (débito #17)", () => {
+  test("rejects non-email string", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, SMTP_FROM: "not-an-email" })
+    ).toThrow();
+  });
+
+  test("rejects plain word", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, SMTP_FROM: "noreply" })
+    ).toThrow();
+  });
+
+  test("accepts valid email address", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, SMTP_FROM: "noreply@synnerdata.com" })
+    ).not.toThrow();
+  });
+});
+
+describe("envSchema — NODE_ENV enum (débito #18)", () => {
+  test("rejects invalid value (typo)", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, NODE_ENV: "prdoction" })
+    ).toThrow();
+  });
+
+  test("rejects arbitrary string", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, NODE_ENV: "staging" })
+    ).toThrow();
+  });
+
+  test.each([
+    "development",
+    "production",
+    "test",
+  ] as const)("accepts %s", (value) => {
+    // production precisa de SMTP_USER/SMTP_PASSWORD (db #15) — para este teste de enum,
+    // passamos valores válidos também
+    expect(() =>
+      envSchema.parse({
+        ...VALID_ENV,
+        NODE_ENV: value,
+        ...(value === "production"
+          ? { SMTP_USER: "user@smtp", SMTP_PASSWORD: "pass" }
+          : {}),
+      })
+    ).not.toThrow();
+  });
+
+  test("defaults to development when NODE_ENV is absent", () => {
+    const { NODE_ENV: _, ...rest } = VALID_ENV;
+    const parsed = envSchema.parse(rest);
+    expect(parsed.NODE_ENV).toBe("development");
+  });
+});
+
+describe("envSchema — SMTP credentials required in production (débito #15)", () => {
+  test("rejects production without SMTP_USER", () => {
+    expect(() =>
+      envSchema.parse({
+        ...VALID_ENV,
+        NODE_ENV: "production",
+        SMTP_PASSWORD: "pass",
+      })
+    ).toThrow();
+  });
+
+  test("rejects production without SMTP_PASSWORD", () => {
+    expect(() =>
+      envSchema.parse({
+        ...VALID_ENV,
+        NODE_ENV: "production",
+        SMTP_USER: "user@smtp",
+      })
+    ).toThrow();
+  });
+
+  test("rejects production without either credential", () => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, NODE_ENV: "production" })
+    ).toThrow();
+  });
+
+  test("accepts production with both SMTP_USER and SMTP_PASSWORD", () => {
+    expect(() =>
+      envSchema.parse({
+        ...VALID_ENV,
+        NODE_ENV: "production",
+        SMTP_USER: "user@smtp",
+        SMTP_PASSWORD: "pass",
+      })
+    ).not.toThrow();
+  });
+
+  test.each([
+    "development",
+    "test",
+  ] as const)("accepts %s without SMTP credentials", (nodeEnv) => {
+    expect(() =>
+      envSchema.parse({ ...VALID_ENV, NODE_ENV: nodeEnv })
+    ).not.toThrow();
+  });
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,36 +1,82 @@
 import "dotenv/config";
 import { z } from "zod";
 
-const envSchema = z.object({
-  PORT: z.coerce.number().default(3333),
-  CORS_ORIGIN: z.string().default("http://localhost:3000"),
-  DATABASE_URL: z.url().startsWith("postgresql://"),
-  BETTER_AUTH_SECRET: z.string(),
-  BETTER_AUTH_URL: z.url().default("http://localhost:3333"),
-  API_URL: z.url().default("http://localhost:3333"),
-  APP_URL: z.url().default("http://localhost:3000"),
-  PAGARME_BASE_URL: z.url(),
-  PAGARME_SECRET_KEY: z.string().min(1),
-  PAGARME_PUBLIC_KEY: z.string().min(1),
-  PAGARME_WEBHOOK_USERNAME: z.string().min(1),
-  PAGARME_WEBHOOK_PASSWORD: z.string().min(1),
-  SMTP_HOST: z.string().default("localhost"),
-  SMTP_PORT: z.coerce.number().default(1025),
-  SMTP_USER: z.string().optional(),
-  SMTP_PASSWORD: z.string().optional(),
-  SMTP_FROM: z.string().default("noreply@synnerdata.com"),
-  // Admin emails - users with these emails will be assigned admin roles on signup
-  SUPER_ADMIN_EMAILS: z.string().default(""),
-  ADMIN_EMAILS: z.string().default(""),
-  // Internal API key for scheduled jobs endpoints
-  INTERNAL_API_KEY: z.string().min(32),
-  // PII Encryption key - 32 bytes hex (64 characters)
-  // Generate with: openssl rand -hex 32
-  PII_ENCRYPTION_KEY: z.string().length(64),
-  // Sentry/GlitchTip DSN for error tracking (optional — disabled when absent)
-  SENTRY_DSN: z.url().optional(),
-});
+/**
+ * Environment variables schema.
+ *
+ * Validated at application boot via `envSchema.parse(process.env)`.
+ * Exported for testing purposes — see `src/__tests__/env.test.ts`.
+ *
+ * Hardening (RU-1):
+ *   - NODE_ENV restricted to enum (development/production/test)
+ *   - BETTER_AUTH_SECRET requires minimum 32 characters
+ *   - PII_ENCRYPTION_KEY must be 64 hex characters (openssl rand -hex 32)
+ *   - SMTP_FROM must be a valid email
+ *   - In production, SMTP_USER and SMTP_PASSWORD are mandatory
+ *   - CORS_ORIGIN format (comma-separated origins) documented via .describe()
+ */
+export const envSchema = z
+  .object({
+    NODE_ENV: z
+      .enum(["development", "production", "test"])
+      .default("development"),
+    PORT: z.coerce.number().default(3333),
+    CORS_ORIGIN: z
+      .string()
+      .default("http://localhost:3000")
+      .describe(
+        "Comma-separated list of allowed CORS origins. Parsed by parseOrigins() in lib/cors.ts"
+      ),
+    DATABASE_URL: z.url().startsWith("postgresql://"),
+    BETTER_AUTH_SECRET: z.string().min(32),
+    BETTER_AUTH_URL: z.url().default("http://localhost:3333"),
+    API_URL: z.url().default("http://localhost:3333"),
+    APP_URL: z.url().default("http://localhost:3000"),
+    PAGARME_BASE_URL: z.url(),
+    PAGARME_SECRET_KEY: z.string().min(1),
+    PAGARME_PUBLIC_KEY: z.string().min(1),
+    PAGARME_WEBHOOK_USERNAME: z.string().min(1),
+    PAGARME_WEBHOOK_PASSWORD: z.string().min(1),
+    SMTP_HOST: z.string().default("localhost"),
+    SMTP_PORT: z.coerce.number().default(1025),
+    SMTP_USER: z.string().optional(),
+    SMTP_PASSWORD: z.string().optional(),
+    SMTP_FROM: z.email().default("noreply@synnerdata.com"),
+    // Admin emails - users with these emails will be assigned admin roles on signup
+    SUPER_ADMIN_EMAILS: z.string().default(""),
+    ADMIN_EMAILS: z.string().default(""),
+    // Internal API key for scheduled jobs endpoints
+    INTERNAL_API_KEY: z.string().min(32),
+    // PII Encryption key - 32 bytes hex (64 hexadecimal characters)
+    // Generate with: openssl rand -hex 32
+    PII_ENCRYPTION_KEY: z
+      .string()
+      .regex(
+        /^[0-9a-fA-F]{64}$/,
+        "PII_ENCRYPTION_KEY must be 64 hexadecimal characters (generate with: openssl rand -hex 32)"
+      ),
+    // Sentry/GlitchTip DSN for error tracking (optional — disabled when absent)
+    SENTRY_DSN: z.url().optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.NODE_ENV === "production") {
+      if (!val.SMTP_USER) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["SMTP_USER"],
+          message: "SMTP_USER is required when NODE_ENV=production",
+        });
+      }
+      if (!val.SMTP_PASSWORD) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["SMTP_PASSWORD"],
+          message: "SMTP_PASSWORD is required when NODE_ENV=production",
+        });
+      }
+    }
+  });
 
 export const env = envSchema.parse(process.env);
 
-export const isProduction = process.env.NODE_ENV === "production";
+export const isProduction = env.NODE_ENV === "production";

--- a/src/lib/audit/__tests__/audit-plugin.test.ts
+++ b/src/lib/audit/__tests__/audit-plugin.test.ts
@@ -1,0 +1,310 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { desc, eq } from "drizzle-orm";
+import { Elysia } from "elysia";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { type AuditEntry, auditPlugin } from "@/lib/audit/audit-plugin";
+import { createTestOrganization } from "@/test/helpers/organization";
+
+type AuditContext = {
+  audit: (
+    entry: AuditEntry,
+    context: { userId: string; organizationId?: string | null }
+  ) => Promise<void>;
+};
+
+/**
+ * Baseline tests for auditPlugin — establish the current contract before RU-7 and RU-8 refactor it.
+ *
+ * Current contract (pre-refactor, to be changed):
+ *   - Plugin injects `audit(entry, context)` into the scoped Elysia context.
+ *   - `context: { userId, organizationId? }` must be passed manually by each caller.
+ *   - `entry.action` and `entry.resource` are typed as `AuditAction | string` (loose).
+ *   - IP is extracted from `x-forwarded-for` (first value) with fallback to `x-real-ip`.
+ *   - userAgent is extracted from the request headers.
+ *
+ * After RU-7:
+ *   - `context` will be injected automatically from the `auth` macro session — manual context goes away.
+ *   - Tipes `action`/`resource` will be strict enums only (drop `| string`).
+ * After RU-8:
+ *   - Plugin moves to `src/plugins/audit/`. Imports update.
+ *
+ * These tests will need to be updated when RU-7 runs. Until then, they protect against accidental regression.
+ */
+describe("auditPlugin (baseline — pre RU-7/RU-8 refactor)", () => {
+  const testOrgIds: string[] = [];
+  const testUserIds: string[] = [];
+
+  afterAll(async () => {
+    // Cleanup audit logs created during tests
+    for (const orgId of testOrgIds) {
+      await db
+        .delete(schema.auditLogs)
+        .where(eq(schema.auditLogs.organizationId, orgId));
+    }
+    for (const userId of testUserIds) {
+      await db
+        .delete(schema.auditLogs)
+        .where(eq(schema.auditLogs.userId, userId));
+    }
+  });
+
+  test("injects audit() into context and persists log with full entry", async () => {
+    const org = await createTestOrganization();
+    testOrgIds.push(org.id);
+    const userId = `test-user-${crypto.randomUUID()}`;
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          {
+            action: "create",
+            resource: "employee",
+            resourceId: "emp-baseline-1",
+            changes: { after: { name: "Baseline User" } },
+          },
+          { userId, organizationId: org.id }
+        );
+        return { ok: true };
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+        headers: {
+          "user-agent": "baseline-test-agent/1.0",
+          "x-forwarded-for": "10.0.0.42",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.organizationId, org.id))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log).toBeDefined();
+    expect(log.action).toBe("create");
+    expect(log.resource).toBe("employee");
+    expect(log.resourceId).toBe("emp-baseline-1");
+    expect(log.userId).toBe(userId);
+    expect(log.organizationId).toBe(org.id);
+    expect(log.ipAddress).toBe("10.0.0.42");
+    expect(log.userAgent).toBe("baseline-test-agent/1.0");
+    expect(log.changes).toEqual({ after: { name: "Baseline User" } });
+  });
+
+  test("extracts ipAddress from x-forwarded-for taking first value when multiple present", async () => {
+    const org = await createTestOrganization();
+    testOrgIds.push(org.id);
+    const userId = `test-user-${crypto.randomUUID()}`;
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          { action: "update", resource: "document" },
+          { userId, organizationId: org.id }
+        );
+        return { ok: true };
+      });
+
+    await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+        headers: {
+          "x-forwarded-for": "203.0.113.5, 10.0.0.1, 172.16.0.1",
+        },
+      })
+    );
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.organizationId, org.id))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log.ipAddress).toBe("203.0.113.5");
+  });
+
+  test("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+    const org = await createTestOrganization();
+    testOrgIds.push(org.id);
+    const userId = `test-user-${crypto.randomUUID()}`;
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          { action: "delete", resource: "document" },
+          { userId, organizationId: org.id }
+        );
+        return { ok: true };
+      });
+
+    await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+        headers: { "x-real-ip": "198.51.100.7" },
+      })
+    );
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.organizationId, org.id))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log.ipAddress).toBe("198.51.100.7");
+  });
+
+  test("stores null ipAddress and userAgent when headers are absent", async () => {
+    const org = await createTestOrganization();
+    testOrgIds.push(org.id);
+    const userId = `test-user-${crypto.randomUUID()}`;
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          {
+            action: "create",
+            resource: "document",
+            resourceId: "doc-no-headers",
+          },
+          { userId, organizationId: org.id }
+        );
+        return { ok: true };
+      });
+
+    await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+      })
+    );
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.organizationId, org.id))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log.ipAddress).toBeNull();
+    expect(log.userAgent).toBeNull();
+  });
+
+  test("accepts organizationId=null for system-level actions (login, user create)", async () => {
+    const userId = `test-user-${crypto.randomUUID()}`;
+    testUserIds.push(userId);
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          { action: "login", resource: "session", resourceId: "sess-baseline" },
+          { userId, organizationId: null }
+        );
+        return { ok: true };
+      });
+
+    const response = await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.userId, userId))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log.organizationId).toBeNull();
+    expect(log.action).toBe("login");
+    expect(log.resource).toBe("session");
+  });
+
+  test("omits optional resourceId when not provided", async () => {
+    const org = await createTestOrganization();
+    testOrgIds.push(org.id);
+    const userId = `test-user-${crypto.randomUUID()}`;
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          { action: "export", resource: "report" },
+          { userId, organizationId: org.id }
+        );
+        return { ok: true };
+      });
+
+    await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+      })
+    );
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.organizationId, org.id))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log.resourceId).toBeNull();
+    expect(log.action).toBe("export");
+    expect(log.resource).toBe("report");
+  });
+
+  /**
+   * Current behavior documents loose typing (AuditAction | string) — see débito #24.
+   * RU-7 will tighten this to strict enums; this test will need to be updated or removed then.
+   */
+  test("accepts arbitrary action/resource strings (loose typing — to be tightened in RU-7)", async () => {
+    const org = await createTestOrganization();
+    testOrgIds.push(org.id);
+    const userId = `test-user-${crypto.randomUUID()}`;
+
+    const app = new Elysia()
+      .use(auditPlugin)
+      .post("/audit-trigger", async ({ audit }: AuditContext) => {
+        await audit(
+          {
+            action: "custom_ad_hoc_action",
+            resource: "custom_ad_hoc_resource",
+            resourceId: "loose-1",
+          },
+          { userId, organizationId: org.id }
+        );
+        return { ok: true };
+      });
+
+    await app.handle(
+      new Request("http://localhost/audit-trigger", {
+        method: "POST",
+      })
+    );
+
+    const [log] = await db
+      .select()
+      .from(schema.auditLogs)
+      .where(eq(schema.auditLogs.organizationId, org.id))
+      .orderBy(desc(schema.auditLogs.createdAt))
+      .limit(1);
+
+    expect(log.action).toBe("custom_ad_hoc_action");
+    expect(log.resource).toBe("custom_ad_hoc_resource");
+  });
+});


### PR DESCRIPTION
## Summary

- **RU-1** — Hardens `src/env.ts` validation: `BETTER_AUTH_SECRET.min(32)`, `PII_ENCRYPTION_KEY` hex regex, `SMTP_FROM` as email, `NODE_ENV` enum, SMTP credentials required in production (`superRefine`), `CORS_ORIGIN` format documented.
- **Baseline tests** for `src/lib/audit/audit-plugin.ts` added before the upcoming RU-7/RU-8 refactors (the plugin had zero direct test coverage).
- **Compozy workspace** initialized (`.compozy/config.toml`) with defaults aligned to project CLAUDE.md (`auto_commit=false`). Used from RU-6 onwards under the hybrid methodology (Option B).
- **Phase 2+3 roadmap** (`docs/improvements/api-infrastructure-checklist.md`) and **audit report** (`docs/reports/2026-04-21-api-infrastructure-audit.md`) added as living artifacts. `.gitignore` adjusted to allow versioning of `docs/improvements/` and `docs/reports/` while keeping other new docs ignored.

Resolves debts **#14–#19** from section 7.7 of the infrastructure checklist. First action of the 🔴 Urgent bucket (Group 1 — Foundation).

## Commits

1. `chore(compozy)`: initialize workspace configuration
2. `test(audit)`: add baseline tests for auditPlugin before refactor
3. `fix(env)`: harden validation schema with stricter rules (RU-1)
4. `chore(git)`: allow versioning of docs/improvements and docs/reports
5. `docs(improvements)`: add Phase 2+3 infrastructure roadmap and audit

## Test plan

- [x] `bun run lint:types` — clean
- [x] `bun run lint:check` — 563 files, no warnings
- [x] `bun test src/__tests__/env.test.ts` — 24/24 pass (169ms)
- [x] `bun test src/lib/audit/__tests__/` — 7/7 pass (baseline preserved)
- [x] Non-regression: `bun test src/lib/errors/__tests__/ src/modules/audit/__tests__/ src/modules/admin/api-keys/__tests__/` — **62/62 pass** (20.4s)
- [ ] CI: affected tests + Trivy + lint
- [ ] Verify GitHub secret `BETTER_AUTH_SECRET` is ≥ 32 chars (cannot audit via code)

## Backward compatibility

Existing values in `.env` and `.env.test` already comply with the new rules (`BETTER_AUTH_SECRET` has exactly 32 chars, `PII_ENCRYPTION_KEY` is 64 hex chars, defaults are valid). **No local dev workflow breaks.**

The only external concern is the CI secret `BETTER_AUTH_SECRET` — if it is shorter than 32 chars, the parse will fail at boot in the test workflow. Worth confirming in the repo Settings → Secrets before merging.

## Next actions

- **RU-2** — Include `requestId` in the error envelope body (TDD on `errorPlugin`). Same branch.
- **RU-3** — Request timeout via `serve.idleTimeout`. Same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)