### PR TITLE
test(vacations): cover anniversary boundary + legacy over-limit editability

### DIFF
--- a/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
@@ -74,6 +74,15 @@ describe("computePeriodsFromHireDate", () => {
     ).toThrow(VACATION_NO_RIGHTS_PATTERN);
   });
 
+  test("throws exactly 1 day before first anniversary (boundary)", () => {
+    // hire 2026-06-10, referenceDate 2027-06-09 (1 day before anniversary)
+    // completed = 0 → throws. Guards against off-by-one regressions
+    // where inclusive/exclusive anniversary comparison could shift.
+    expect(() =>
+      computePeriodsFromHireDate("2026-06-10", new Date("2027-06-09T00:00:00Z"))
+    ).toThrow(VACATION_NO_RIGHTS_PATTERN);
+  });
+
   test("Google AI example: hire 2024-01-01 + referenceDate 2025-07-01 → 1st cycle", () => {
     expect(
       computePeriodsFromHireDate("2024-01-01", new Date("2025-07-01T00:00:00Z"))

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -837,6 +837,59 @@ describe("PUT /v1/vacations/:id", () => {
     expect(updateResponse.status).toBe(200);
   });
 
+  test("allows editing legacy record with aquisitivo already over 30 days (notes-only update)", async () => {
+    // Regression guard for ensureAquisitivoLimit's skip-when-daysEntitled-absent
+    // branch. The skip exists specifically so legacy records (pre-CLT-sum-check
+    // or Zod-bypassed seeds) whose aquisitivo is already >30 days stay editable
+    // for non-day fields (notes, status). We insert directly into the DB to
+    // bypass Zod's .max(30) and the service's ensureAquisitivoLimit — mirroring
+    // the homologação state where such records exist (e.g., Raquel: 35+45+7=87
+    // in a single aquisitivo).
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2020-01-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const legacyVacationId = `vacation-${crypto.randomUUID()}`;
+    await db.insert(schema.vacations).values({
+      id: legacyVacationId,
+      organizationId,
+      employeeId: employee.id,
+      startDate: "2025-03-01",
+      endDate: "2025-04-04", // 35-day range, matches daysEntitled
+      acquisitionPeriodStart: "2024-01-01",
+      acquisitionPeriodEnd: "2024-12-31",
+      concessivePeriodStart: "2025-01-01",
+      concessivePeriodEnd: "2025-12-31",
+      daysEntitled: 35, // over CLT art. 130 limit — direct insert bypasses validation
+      daysUsed: 0,
+      status: "scheduled",
+      notes: null,
+      createdBy: user.id,
+    });
+
+    const updateResponse = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations/${legacyVacationId}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: "Observação em registro legado" }),
+      })
+    );
+
+    expect(updateResponse.status).toBe(200);
+    const body = await updateResponse.json();
+    expect(body.data.notes).toBe("Observação em registro legado");
+    expect(body.data.daysEntitled).toBe(35); // untouched
+  });
+
   test("update without daysEntitled change does not trigger the aquisitivo check", async () => {
     // Regression guard: legacy records already over-limit must still be editable
     // for non-day fields (status, notes) without being blocked by the new check.


### PR DESCRIPTION
## Resumo

Follow-up das PRs #231 (off-by-one + per-record CLT limit) e #233 (per-aquisitivo CLT limit). Fecha dois gaps de cobertura identificados em revisão:

1. **`period-calculation.test.ts`** — boundary de 1 dia antes do aniversário. O fix de #231 garante que `startDate < hireDate + 12 meses` lance `VacationNoRightsError`. Os testes existentes cobriam exatamente no hireDate (throws) e exatamente no aniversário (aceita), mas não o "aniversário - 1 dia" — que é exatamente onde um refactor inclusive/exclusive mais provavelmente regrediria.

2. **`update-vacation.test.ts`** — editabilidade de registros legados over-limit. O teste existente `update without daysEntitled change does not trigger the aquisitivo check` prova que o check é pulado quando `daysEntitled` está ausente do payload, mas usa um registro dentro do limite. Não prova a garantia real: **registros legados com `daysEntitled > 30` no DB continuam editáveis para campos não-dia**.

   O novo teste semeia diretamente via `db.insert` (bypass Zod + service) um registro com `daysEntitled: 35` e depois faz PUT só de `notes` → **200**. Espelha o estado de homologação (Raquel: 35+45+7=87 dias em um aquisitivo) para que refactors que removam o skip falhem aqui antes de chegar em prod.

Nenhuma mudança de código de produção — apenas testes.

## Commits

- `3ca8f64` test(vacations): cover anniversary boundary and legacy over-limit edit gaps

## Test plan

- [x] `NODE_ENV=test bun test --env-file .env.test src/modules/occurrences/vacations/__tests__/ src/modules/employees/__tests__/` → **177 pass, 0 fail** (baseline 175 + 2 novos), 2 runs consecutivos limpos
- [x] `npx tsc --noEmit` → clean
- [x] `npx ultracite check` → clean
- [ ] CI full suite

## Contexto (debate prévio)

Discussão com o PR author: análise inicial identificou 2 gaps "críticos" (C.4 precedência e E.3 legado). Ao verificar o código, **C.4 já estava coberto** (teste existente `should reject when startDate is before employee hireDate` já assera `error.code === "VACATION_DATE_BEFORE_HIRE"`). Restou E.3 + B.3 (desejável, barato). Esta PR entrega E.3 + B.3.

## Out of scope

- Backfill do DB para registros already-existing com `daysEntitled > 30` — cliente fará recadastro manual após #227 (fracionamento).
- Frontend UX para mostrar `daysRemaining` em mensagem de erro — tracking em #227.