### PR TITLE
fix(errors): include requestId in error response envelope (RU-2)

### DIFF
--- a/src/lib/errors/__tests__/error-plugin.test.ts
+++ b/src/lib/errors/__tests__/error-plugin.test.ts
@@ -3,6 +3,9 @@ import { Elysia } from "elysia";
 import { z } from "zod";
 import { AppError } from "@/lib/errors/base-error";
 import { errorPlugin } from "@/lib/errors/error-plugin";
+import { loggerPlugin } from "@/lib/logger";
+
+const REQUEST_ID_PATTERN = /^req-[0-9a-f-]{36}$/;
 
 const testBodySchema = z.object({
   email: z.string().email(),
@@ -28,6 +31,7 @@ class TestNotFoundError extends AppError {
 
 function createTestApp() {
   return new Elysia()
+    .use(loggerPlugin)
     .use(errorPlugin)
     .post("/validate", ({ body }) => ({ success: true, data: body }), {
       body: testBodySchema,
@@ -210,6 +214,62 @@ describe("errorPlugin", () => {
       const body = await response.json();
       expect(body.success).toBe(true);
       expect(body.data).toBe("ok");
+    });
+  });
+
+  describe("requestId in error envelope (RU-2)", () => {
+    test("AppError response body carries requestId matching X-Request-ID header", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/domain-error")
+      );
+
+      const body = await response.json();
+      expect(body.error.requestId).toMatch(REQUEST_ID_PATTERN);
+      expect(response.headers.get("X-Request-ID")).toBe(body.error.requestId);
+    });
+
+    test("AppError 404 response body carries requestId matching X-Request-ID header", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/not-found-error")
+      );
+
+      const body = await response.json();
+      expect(body.error.requestId).toMatch(REQUEST_ID_PATTERN);
+      expect(response.headers.get("X-Request-ID")).toBe(body.error.requestId);
+    });
+
+    test("VALIDATION response body carries requestId matching X-Request-ID header", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/validate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: "invalid", name: "Test" }),
+        })
+      );
+
+      const body = await response.json();
+      expect(body.error.requestId).toMatch(REQUEST_ID_PATTERN);
+      expect(response.headers.get("X-Request-ID")).toBe(body.error.requestId);
+    });
+
+    test("NOT_FOUND (unknown route) response body carries requestId matching X-Request-ID header", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/non-existent-route")
+      );
+
+      const body = await response.json();
+      expect(body.error.requestId).toMatch(REQUEST_ID_PATTERN);
+      expect(response.headers.get("X-Request-ID")).toBe(body.error.requestId);
+    });
+
+    test("unhandled 500 response body carries requestId matching X-Request-ID header", async () => {
+      const response = await app.handle(
+        new Request("http://localhost/unhandled-error")
+      );
+
+      const body = await response.json();
+      expect(body.error.requestId).toMatch(REQUEST_ID_PATTERN);
+      expect(response.headers.get("X-Request-ID")).toBe(body.error.requestId);
     });
   });
 });

--- a/src/lib/errors/base-error.ts
+++ b/src/lib/errors/base-error.ts
@@ -3,6 +3,7 @@ export type ErrorResponse = {
   error: {
     code: string;
     message: string;
+    requestId?: string;
     details?: unknown;
   };
 };
@@ -18,7 +19,7 @@ export abstract class AppError extends Error {
     this.details = details;
   }
 
-  toResponse(): ErrorResponse {
+  toResponse(requestId?: string): ErrorResponse {
     const response: ErrorResponse = {
       success: false,
       error: {
@@ -26,6 +27,10 @@ export abstract class AppError extends Error {
         message: this.message,
       },
     };
+
+    if (requestId !== undefined) {
+      response.error.requestId = requestId;
+    }
 
     if (this.details !== undefined) {
       response.error.details = this.details;

--- a/src/lib/errors/error-plugin.ts
+++ b/src/lib/errors/error-plugin.ts
@@ -1,5 +1,6 @@
 import { Elysia } from "elysia";
 import { logger } from "@/lib/logger";
+import { getRequestId } from "@/lib/request-context";
 import { captureException } from "@/lib/sentry";
 import { AppError } from "./base-error";
 
@@ -47,9 +48,9 @@ function formatErrorDetail(error: unknown): Record<string, unknown> {
 export const errorPlugin = new Elysia({ name: "error-handler" })
   .error({ AppError })
   .onError({ as: "global" }, ({ code, error, set, request }) => {
-    // Custom AppError instances
+    const requestId = getRequestId() as string;
+
     if (error instanceof AppError) {
-      // Report 5xx AppErrors to Sentry/GlitchTip
       if (error.status >= 500) {
         captureException(error);
         const pathname = new URL(request.url).pathname;
@@ -65,10 +66,9 @@ export const errorPlugin = new Elysia({ name: "error-handler" })
         );
       }
       set.status = error.status;
-      return error.toResponse();
+      return error.toResponse(requestId);
     }
 
-    // Elysia validation errors
     if (code === "VALIDATION") {
       set.status = 422;
       return {
@@ -76,12 +76,12 @@ export const errorPlugin = new Elysia({ name: "error-handler" })
         error: {
           code: "VALIDATION_ERROR",
           message: "Dados de requisição inválidos",
+          requestId,
           details: formatValidationErrors(error.all),
         },
       };
     }
 
-    // Route not found
     if (code === "NOT_FOUND") {
       set.status = 404;
       return {
@@ -89,11 +89,11 @@ export const errorPlugin = new Elysia({ name: "error-handler" })
         error: {
           code: "NOT_FOUND",
           message: "Rota não encontrada",
+          requestId,
         },
       };
     }
 
-    // Unhandled errors — report to Sentry/GlitchTip and log with full detail
     captureException(error);
 
     const errorDetail = formatErrorDetail(error);
@@ -113,7 +113,7 @@ export const errorPlugin = new Elysia({ name: "error-handler" })
       error: {
         code: "INTERNAL_ERROR",
         message: "Ocorreu um erro inesperado",
-        // In development, expose the real error to help debugging
+        requestId,
         ...(isDev && { cause: errorDetail }),
       },
     };

--- a/src/lib/logger/CLAUDE.md
+++ b/src/lib/logger/CLAUDE.md
@@ -13,21 +13,26 @@ O sistema de logging tem duas camadas com responsabilidades distintas:
 ### Fluxo de uma request
 
 ```
-derive → handler → onAfterHandle (header) → onAfterResponse (access log)
-                ↘ onError (header + error log) → onAfterResponse (access log)
+onRequest (requestId + header) → derive (context) → handler → onAfterResponse (access log)
+                                                           ↘ onError (errorPlugin) → onAfterResponse
 ```
 
-- `derive`: gera `requestId`, entra no `AsyncLocalStorage`, retorna `requestId` + `requestStart`
-- `onAfterHandle`: injeta `X-Request-ID` no header (só sucesso)
-- `onError` (logger): injeta `X-Request-ID` no header (só erros — `onAfterHandle` não executa quando há erro)
-- `onError` (errorPlugin): formata resposta, seta `set.status`, loga detalhes de 5xx/unhandled
+- `onRequest`: gera `requestId`, entra no `AsyncLocalStorage` via `enterRequestContext`, injeta `X-Request-ID` no header. Dispara em **toda** request — incluindo 404 unmatched e parse errors, que ocorrem antes do route matching
+- `derive`: retorna `{ requestId, requestStart }` no context tipado do Elysia, lendo o `requestId` já gravado no `AsyncLocalStorage`
+- `onError` (errorPlugin): formata resposta, seta `set.status`, loga detalhes de 5xx/unhandled. O header já foi setado em `onRequest`, não precisa reinjetar
 - `onAfterResponse`: access log com status real via `set.status` — executa **sempre** (sucesso e erro)
 
 ## Decisões Técnicas
 
+### `onRequest` e não `derive` para gerar o `requestId`
+
+`derive` executa **após** o route matching do Elysia, então não dispara para rotas 404 unmatched nem para parse errors — cenários em que `onError` é chamado com context vazio (ver [elysiajs/elysia#1467](https://github.com/elysiajs/elysia/issues/1467)). Gerar o `requestId` em `onRequest` (primeiro hook do lifecycle, executa antes do route matching) garante que 100% das responses — incluindo 404 de scanners/bots e payloads malformados — tenham `X-Request-ID` no header e `error.requestId` no body para correlacionar com logs.
+
+O `derive` permanece, mas agora apenas **lê** o `requestId` do `AsyncLocalStorage` pra expô-lo no context tipado do Elysia (mantém compatibilidade com hooks que fazem `({ requestId }) => …`).
+
 ### `enterWith` e não `run` no AsyncLocalStorage
 
-Elysia's `derive` retorna um valor — não aceita callback wrapper. `enterWith` é a API correta para o modelo de hooks do Elysia: define o store para o restante da execução síncrona e persiste nas chamadas assíncronas seguintes. Não é workaround.
+`enterWith` é a API correta para o modelo de hooks do Elysia: define o store para o restante da execução síncrona e persiste nas chamadas assíncronas seguintes. Usado em `onRequest` logo que a request entra no servidor.
 
 ### `mixin()` do Pino para injetar `requestId`
 
@@ -42,10 +47,6 @@ O access log (`onAfterResponse`) é sempre `logger.info()`, mesmo para 4xx/5xx. 
 ### `set.status` para capturar status real
 
 O Elysia tem bugs conhecidos com `status()` que não atualiza `set.status` no lifecycle ([#1501](https://github.com/elysiajs/elysia/issues/1501)). Porém, atribuição direta (`set.status = error.status`) funciona corretamente. O projeto proíbe `status()` (ver CLAUDE.md raiz), então `set.status` é confiável. O fallback `typeof set.status === "number" ? set.status : 200` protege contra edge cases.
-
-### `onError` no loggerPlugin para `X-Request-ID`
-
-`onAfterHandle` só executa em sucesso. Quando há erro, o lifecycle pula para `onError`. Por isso o `loggerPlugin` registra um `onError` próprio **apenas para injetar o header** — sem tocar na response. O `errorPlugin` cuida da formatação.
 
 ## Convenção dos campos de log
 

--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -41,19 +41,15 @@ export const logger = pino({
 });
 
 export const loggerPlugin = new Elysia({ name: "logger" })
-  .derive({ as: "global" }, () => {
+  .onRequest(({ set }) => {
     const requestId = generateRequestId();
     enterRequestContext({ requestId });
-    return { requestId, requestStart: performance.now() };
-  })
-  .onAfterHandle({ as: "global" }, ({ set, requestId }) => {
     set.headers["X-Request-ID"] = requestId;
   })
-  .onError({ as: "global" }, ({ set, requestId }) => {
-    if (requestId) {
-      set.headers["X-Request-ID"] = requestId;
-    }
-  })
+  .derive({ as: "global" }, () => ({
+    requestId: getRequestId() as string,
+    requestStart: performance.now(),
+  }))
   .onAfterResponse({ as: "global" }, ({ request, requestStart, set }) => {
     const pathname = new URL(request.url).pathname;
     if (shouldIgnore(pathname)) {


### PR DESCRIPTION
## Summary

- Adiciona `requestId` em todos os 4 branches do `errorPlugin` (AppError, VALIDATION, NOT_FOUND, unhandled) para correlacionar erros com logs sem precisar pedir ao suporte — cobre débito MVP #16 do roadmap.
- Move a geração de `requestId` de `derive` para `onRequest` no `loggerPlugin`. Correção arquitetural do gap documentado em [elysiajs/elysia#1467](https://github.com/elysiajs/elysia/issues/1467): `derive` executa após o route matching, então 404 de rotas desconhecidas e parse errors disparavam `onError` com `AsyncLocalStorage` vazio. Agora 100% das responses — incluindo 404 de scanners/bots e payloads malformados — têm `X-Request-ID` no header e `error.requestId` no body.
- Simplifica o `loggerPlugin`: remove os hooks `onAfterHandle` e `onError` redundantes (header agora é setado universalmente em `onRequest`).

## Changes

| Arquivo | O que mudou |
|---|---|
| `src/lib/logger/index.ts` | Gera `requestId` em `onRequest`; `derive` agora lê do store e expõe no context tipado |
| `src/lib/logger/CLAUDE.md` | ADR "onRequest e não derive"; diagrama de fluxo atualizado |
| `src/lib/errors/base-error.ts` | `ErrorResponse.error.requestId?` + `toResponse(requestId?)` |
| `src/lib/errors/error-plugin.ts` | Injeta `requestId` nos 4 branches |
| `src/lib/errors/__tests__/error-plugin.test.ts` | 5 testes novos, um por branch (AppError 400, AppError 404, VALIDATION, NOT_FOUND unmatched, unhandled 500) |

## Decisões

- **Escopo expandido vs escopo apertado**: optamos por incluir o fix do `loggerPlugin` na mesma PR em vez de separar como CP. Sem isso, a RU-2 deixaria ~30% dos erros 404 reais em produção (scanners/bots) sem `requestId` — o que enfraquece o valor de suporte da feature.
- **`getRequestId() as string`**: type assertion no `derive` e no `errorPlugin`. A invariante é garantida pelo lifecycle do Elysia (`onRequest` sempre roda antes de qualquer outro hook). Preferido ao throw defensivo (código morto) e ao `?? generateRequestId()` (gera ID inconsistente com a store).
- **Comentários descritivos removidos** do `errorPlugin` — alinhado com a regra de código autoexplicativo estabelecida nesta sessão.

## Test plan

- [x] `bun test src/lib/logger/__tests__/` — 11 pass (baseline preservado)
- [x] `bun test src/lib/errors/__tests__/` — 19 pass (14 baseline + 5 novos RU-2)
- [x] `bun test src/lib/request-context/__tests__/` — pass
- [x] `bun test src/lib/audit/__tests__/audit-plugin.test.ts` — pass
- [x] `bun run lint:types` — clean
- [x] `npx ultracite check src/lib/logger/ src/lib/errors/` — clean
- [ ] Validação pós-deploy em preview: gerar um 500 controlado e conferir `body.error.requestId` + header `X-Request-ID` batendo + aparecer no GlitchTip

## Out of scope (seguem como débitos registrados)

- CP-39: separar `SMTP_FROM` em `SMTP_FROM` + `SMTP_FROM_NAME` (registrado no checklist após hotfix)
- CP futuro: persistência de logs de container entre deploys no Coolify (gap operacional surfaceado nesta sessão — sem Sentry configurado, apenas GlitchTip + Uptime Kuma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)