### PR TITLE
docs(runbooks): database backup procedure — closes bucket vermelho (RU-10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ package-lock.json
 !/docs/improvements/**
 !/docs/reports/
 !/docs/reports/**
+!/docs/runbooks/
+!/docs/runbooks/**
 
 # worktrees
 .worktrees/

--- a/docs/improvements/api-infrastructure-checklist.md
+++ b/docs/improvements/api-infrastructure-checklist.md
@@ -262,9 +262,9 @@ Seção específica do projeto. Começa pelo **status atual** da iniciativa (7.0
 | **0. Contexto aplicado** | ✅ Concluída | 2026-04-21 | Seções 7.1–7.3, 7.6, 7.7 preenchidas + convenção semântica + 10 débitos pré-audit |
 | **1. Audit item a item** | ✅ Concluída | 2026-04-21 | Status nas seções 4 e 5 preenchidos (~65 itens); 95 débitos totais em 7.7; relatório em [`docs/reports/2026-04-21-api-infrastructure-audit.md`](../reports/2026-04-21-api-infrastructure-audit.md) |
 | **2. Roadmap priorizado** | ✅ Concluída | 2026-04-21 | Seção 7.5 com 69 ações organizadas em 3 buckets (🔴 10 urgentes / 🟡 38 curto prazo / 🟢 21 sob demanda) com IDs, dependências, tipo e esforço |
-| **3. Execução** | 🔄 Em execução | 2026-04-22 | RU-1..RU-9 concluídas. Grupo 3 fechado. `src/plugins/` inaugurado. BOLA audit completo (0 gaps em 50 services). CP-39..CP-44 registrados como follow-ups. Débitos #96 identificados. 9/10 ações do bucket 🔴 concluídas. |
+| **3. Execução** | 🔄 Em execução | 2026-04-22 | **Bucket 🔴 concluído (10/10)**. RU-1..RU-10 entregues em PRs sequenciais em `preview`. Grupo 3 fechado. `src/plugins/` inaugurado. BOLA audit completo (0 gaps). Runbook de backup em `docs/runbooks/`. CP-39..CP-45 registrados como follow-ups. Débito #96 identificado. |
 
-**➡️ Próxima ação:** **RU-10 (runbook backup Coolify)** — única pendente do bucket 🔴, ação S/docs. Criar `docs/runbooks/database-backup.md` documentando frequência, retention, processo de restore e teste periódico. Sem dependências.
+**➡️ Próxima ação:** **Priorização do bucket 🟡** com o dono do projeto. 44 ações disponíveis; candidatos naturais para começar: (a) **CP-40** (triagem de dev deps highs → destrava subir audit threshold para `high`), (b) **CP-1/2** (XL refactors que destravam outros CPs), (c) **CP-42/CP-43** (convenção de `changes` + audit de reads sensíveis — LGPD). Ver seção 7.5 bucket 🟡 para a lista completa.
 
 ### 7.1 Contexto do projeto
 
@@ -560,8 +560,9 @@ Organizado em **5 PRs dedicados** (refactors grandes) + ações pontuais.
 | **CP-42** | Convenção de `changes: { before, after }` em audit de mutations — documentar em `src/modules/audit/CLAUDE.md` (ou ADR) regras: (a) toda mutation em entidade versionada preenche diff dos campos alterados, não record inteiro; (b) campos PII sensíveis (CPF, salário, atestado médico, data nascimento) logam `"<redacted>"` ou hash — nunca plaintext; (c) resources obrigatórios: `employee`, `medical_certificate`, `labor_lawsuit`, `subscription`, `member`, `api_key`. Aplicar retroativamente nos 3 módulos críticos (employees, occurrences/medical-certificates, payments/subscription) | #96 (parcial), LGPD Art. 18/48 | refactor | M | — |
 | **CP-43** | Audit de reads em dados sensíveis (Art. 11 LGPD) — usar `auditPlugin` pós RU-7 (signature `audit(entry)` simples) em GET handlers de recursos sensíveis: `medical_certificate`, `labor_lawsuit`, `employee` (quando incluir CPF/salário), `cpf_analysis`. Granularidade: get individual + export sempre; listagem opcional (batch). Destrava reconstituição de acessos para Art. 48 LGPD | #96 (parcial), LGPD Art. 11 | new | M | RU-7 |
 | **CP-44** | Audit BOLA automatizado em CI — script que AST-scan `src/modules/**/*.service.ts` identificando queries `db.select/update/delete` em tabelas org-scoped sem filtro `organizationId`. Falha PR se gap novo introduzido. Preventivo contra regressão após RU-9 ter validado o estado limpo atual | Follow-up de RU-9 | new | M | — |
+| **CP-45** | Ajustar Local Backup Retention no Coolify — atual está com todos os valores em 0 (unlimited), significa que dumps locais nunca são limpos. Sugestão: 7 backups / 7 dias / 2 GB (R2 com 30 dias segue como fonte de verdade off-site). Ação operacional pura na UI do Coolify, sem código. Ver `docs/runbooks/database-backup.md` §Atenção | Follow-up de RU-10 | config | S | — |
 
-**Total bucket 🟡: 44 ações. Execução sugerida em paralelo por tema (PRs dedicados CP-1…CP-5 podem rodar em paralelo com ações pontuais).**
+**Total bucket 🟡: 45 ações. Execução sugerida em paralelo por tema (PRs dedicados CP-1…CP-5 podem rodar em paralelo com ações pontuais).**
 
 #### 🟢 Bucket Médio Prazo / Sob Demanda (quando houver sinal real)
 
@@ -600,7 +601,7 @@ Não investir antes do sinal. Cada item lista o **sinal que justifica investir**
 | Bucket | Ações | Esforço consolidado | Prazo alvo |
 |---|---|---|---|
 | 🔴 Urgente | 10 | ~7 S/M + 1 L = 2-3 semanas com foco parcial | até 30 dias |
-| 🟡 Curto prazo | 44 (5 plans dedicados + 39 pontuais) | 5 planos XL/L + ~36 S/M | 30-90 dias |
+| 🟡 Curto prazo | 45 (5 plans dedicados + 40 pontuais) | 5 planos XL/L + ~37 S/M | 30-90 dias |
 | 🟢 Médio prazo | 21 | Sob demanda | indefinido (monitorar sinais) |
 
 **Princípios de execução:**
@@ -1355,6 +1356,53 @@ Rodados testes que cobrem as áreas a serem tocadas pelo bucket 🔴 para confir
 - Extensão `cy-idea-factory` — traz council de 6 agentes (security-advocate, architect-advisor, pragmatic-engineer, product-mind, devils-advocate, the-thinker) e skill `/cy-idea-factory`. Motivo: roadmap atual (bucket 🔴 + maior parte do 🟡) já tem escopo claro do audit; council é overkill para ações bem escopadas. Instalar apenas antes de CP-1/CP-2 (XL) ou qualquer item do bucket 🟢 (decisões com múltiplos trade-offs sem design pronto)
 
 **Estado:** pronto para iniciar Fase 3. Próxima ação — **RU-1 (hardening `env.ts`)** via fluxo simples (branch direta, sem Compozy).
+
+### 2026-04-22 — RU-10 concluída (runbook de backup) + **Bucket 🔴 fechado**
+
+Última ação pendente do bucket urgente. Cria `docs/runbooks/database-backup.md` documentando o processo de backup existente em Coolify + Cloudflare R2.
+
+**Configuração atual validada via UI do Coolify:**
+- Backup habilitado, database `synnerdata`, frequência diária 00:00 UTC, timeout 3600s.
+- Storage dual: local (`/data/coolify/backups/...`) + Cloudflare R2.
+- Retention R2: 30 backups / 30 dias / 8 GB (whichever first).
+- Formato: `pg_dump` .dmp; tamanho atual ~310 KB.
+
+**Conteúdo do runbook (6 seções):**
+1. Estado atual (tabela com valores concretos)
+2. Como verificar saúde dos backups (passos na UI)
+3. Procedimento de restore — caminho A (UI Coolify, recomendado) e caminho B (pg_restore direto, offline)
+4. Teste periódico trimestral — checklist preenchível + tabela histórica de execuções (primeira execução pendente)
+5. Atenção sobre local retention ilimitada (rastreado como CP-45)
+6. Contatos e escalação (template)
+
+**Finding operacional**: Local Backup Retention está configurado como 0/0/0 = unlimited. Com a base atual é inofensivo (~113 MB/ano), mas vai acumular indefinidamente. Registrado como **CP-45** (🟡, S) — ajuste operacional simples na UI do Coolify quando conveniente.
+
+**Débito resolvido em 7.7:** #92 (backup policy não documentada).
+
+**Validação:**
+- ✅ Arquivo renderiza (markdown); links internos corretos.
+- ✅ Pasta `docs/runbooks/` adicionada ao allowlist do `.gitignore` (seguindo padrão de `docs/improvements/` e `docs/reports/`).
+- ✅ Referências cruzadas: changelog → runbook → CP-45 no checklist formam circuito coerente.
+
+**Lições:**
+- **Operational knowledge > generic best practices**: escrever runbook com valores concretos extraídos da UI do Coolify (frequência, retention, caminhos de storage) vale muito mais que um template genérico com `<!-- TODO -->`. Custo marginal: 1 screenshot do dono + 5min lendo. Benefício: runbook imediatamente operacional.
+- **Runbook é vivo**: a tabela de histórico de testes trimestrais (primeira execução pendente) torna o documento autoatualizável — cada teste adiciona linha. Diferente de documentos estáticos que envelhecem sem sinal.
+
+## **Bucket 🔴 concluído (10/10) — 2026-04-22**
+
+Fechamento do bucket urgente. Cronograma original era "até 30 dias"; foi entregue em 1 dia (2026-04-21 audit → 2026-04-22 todas as 10 RUs mergeadas) — menos pelo ritmo, mais pelo fato de muitas ações revelaram-se menos complexas do que o pessimismo inicial do audit. Ações que surpreenderam:
+
+- **RU-1** virou urgente de verdade (hotfix SMTP_FROM pós-merge)
+- **RU-4** explodiu de S → L (2 criticals + 17 highs em deps, split em RU-4a/RU-4b/CP-40)
+- **RU-7** mudou de direção (recomendei deletar, usuário rejeitou, executei refactor) — lição "unused ≠ dead"
+- **RU-9** encolheu de L → M (padrão já estava limpo; audit virou confirmação)
+- **RU-10** foi S real (UI do Coolify tinha todos os valores prontos)
+
+**CPs gerados ao longo do bucket**: CP-39 (SMTP_FROM split), CP-40 (dev deps highs), CP-41 (integration tests workflow), CP-42 (changes convention LGPD), CP-43 (read audit LGPD), CP-44 (BOLA CI automation), CP-45 (Coolify local retention). 7 follow-ups úteis que saíram da execução.
+
+**Débitos resolvidos no bucket 🔴** (seção 7.7): #14-#20, #22, #23, #24, #30, #54, #76, #77, #92, #96 (parcial via CP-42/43). Total: ~15 débitos fechados.
+
+Próximo passo: priorização do bucket 🟡 com o dono — 45 ações disponíveis.
 
 ### 2026-04-22 — RU-9 concluída (BOLA audit + cross-org isolation tests)
 

--- a/docs/runbooks/database-backup.md
+++ b/docs/runbooks/database-backup.md
@@ -1,0 +1,167 @@
+# Database Backup — Coolify + Cloudflare R2
+
+Runbook do processo de backup do Postgres em produção. Gerenciado pelo Coolify (UI) com storage dual — disco local do servidor + Cloudflare R2 (S3-compatible).
+
+Cobre débito #92 do [checklist de infra](../improvements/api-infrastructure-checklist.md) e serve como evidência operacional para LGPD (Art. 41 — capacidade de reconstituir dados em caso de incidente).
+
+## Estado atual
+
+Configuração validada em 2026-04-22 via Coolify v4.0.0-beta.460 → `synnerdata/production/postgresql-production/Backups`.
+
+| Eixo | Valor | Observação |
+|---|---|---|
+| Backup habilitado | ✅ Sim | Agendamento automático ativo |
+| Database alvo | `synnerdata` | Apenas a DB da aplicação (não "Backup All Databases") |
+| Frequência | `daily` | Dispara diariamente |
+| Timezone | UTC | Horário de execução: **00:00 UTC** (≈ 21:00 BRT dia anterior) |
+| Timeout | 3600s (1h) | Dump + upload devem completar dentro disso |
+| Storage local | ✅ Habilitado | `/data/coolify/backups/databases/root-team-0/postgresql-production-<id>/` |
+| Storage S3 | ✅ Habilitado | Cloudflare R2 (credentials em Coolify → S3 Storages) |
+| Retention local | ⚠️ **ilimitada** | Veja [§ Atenção — local retention](#atenção--local-retention-ilimitada) |
+| Retention S3 (R2) | 30 backups / 30 dias / 8 GB | Whichever limit hits first triggers cleanup |
+| Formato do dump | `pg_dump` (.dmp) | Arquivo nome: `pg-dump-synnerdata-<timestamp>.dmp` |
+
+Tamanho típico do dump (abril/2026): ~310 KB (base com 1 cliente ativo). Esperar crescimento conforme base de funcionários aumenta.
+
+## Como verificar que os backups estão rodando
+
+1. Coolify UI → `Projects` → `production` → `postgresql-production`.
+2. Aba `Backups`.
+3. Seção `Executions`: lista paginada de todas as runs, mais recentes no topo.
+4. Um backup saudável tem:
+   - Status `Success`
+   - Duração < 1min para a base atual
+   - Linha `Backup Availability: Local Storage ✅ · S3 Storage ✅`
+   - Botão `Download` funcional
+
+**Sinais de alerta** que requerem investigação imediata:
+- `Failed` em qualquer execution (veja `Logs` do container postgresql-production).
+- Ausência de execution no último período de 36h (cron do Coolify não rodou).
+- `Local Storage ✅ · S3 Storage ❌` — R2 upload falhou; backup local existe mas sem cópia off-site.
+- Size súbito de 0 KB ou muito menor que a média → dump pode estar corrompido.
+
+Se houver falha consecutiva em ≥ 2 backups diários, acionar o dono imediatamente.
+
+## Procedimento de restore
+
+**Premissas**: você tem acesso à UI do Coolify. Para o caminho manual (B), também precisa de acesso SSH ao servidor Coolify e credenciais do Postgres.
+
+### Caminho A — Restore via UI do Coolify (recomendado para incidentes típicos)
+
+1. Identificar qual backup restaurar:
+   - UI → Backups → Executions → localizar a run desejada (mais próxima do momento antes do incidente).
+   - Clicar `Download` — baixa o arquivo `.dmp` para sua máquina.
+2. Provisionar um **Postgres temporário** para staging do restore:
+   - Coolify → `Projects` → `production` → `+ New` → `Database` → Postgres.
+   - Nomear como `postgresql-restore-staging-<data>`.
+   - Usar mesma versão de Postgres do produção (`postgres:17-alpine`).
+3. Carregar o dump no staging:
+   - Coolify → o novo DB → Terminal.
+   - `pg_restore -U postgres -d <db_name> --no-owner --no-acl /tmp/dump.dmp` (upload prévio do dump pro container via `docker cp`).
+4. **Smoke test** no staging antes de promover:
+   - Rodar queries de sanity (ver [§ Teste periódico](#teste-periódico-trimestral) para lista).
+   - Validar contagens esperadas (organizations, employees, subscriptions ativas).
+5. Decidir a estratégia de swap:
+   - **Se a base de produção sobrevive**: aplicar dump seletivo (apenas tabelas/linhas afetadas) via `psql` no staging → exportar patch → aplicar em produção com transaction wrapping.
+   - **Se a base de produção está totalmente corrompida**: parar o container `postgresql-production`, renomear volume, promover staging para produção atualizando env vars da API (`DATABASE_URL`) via Coolify → `app` → Environment Variables.
+6. Após swap, **não descartar o staging por 48h** — serve como failback.
+
+### Caminho B — Restore direto via `pg_restore` (offline, recuperação avançada)
+
+Usar quando UI do Coolify está inacessível ou quando precisa restaurar em ambiente isolado.
+
+1. SSH no servidor Coolify.
+2. Localizar o dump local mais recente:
+   ```bash
+   ls -laht /data/coolify/backups/databases/root-team-0/postgresql-production-*/pg-dump-synnerdata-*.dmp | head -5
+   ```
+3. Alternativa — baixar do R2 (se local está inacessível):
+   ```bash
+   # credenciais em Coolify → S3 Storages → Cloudflare R2 (mostra accessKey/secretKey/endpoint)
+   aws s3 ls s3://<bucket>/ --endpoint-url <r2-endpoint>
+   aws s3 cp s3://<bucket>/<key> ./restore.dmp --endpoint-url <r2-endpoint>
+   ```
+4. Restaurar num Postgres isolado (não produção):
+   ```bash
+   docker run --rm -d --name pg-restore \
+     -e POSTGRES_PASSWORD=restore \
+     -p 5433:5432 \
+     postgres:17-alpine
+   docker cp /path/to/dump.dmp pg-restore:/tmp/
+   docker exec pg-restore createdb -U postgres synnerdata_restore
+   docker exec pg-restore pg_restore -U postgres -d synnerdata_restore --no-owner --no-acl /tmp/dump.dmp
+   ```
+5. Smoke test (ver [§ Teste periódico](#teste-periódico-trimestral)).
+6. Se a decisão for promover, seguir passos 5-6 do caminho A.
+
+### Pontos de atenção no restore
+
+- **`--no-owner --no-acl`**: importante para evitar erros de permissão quando o dump foi tirado por um user diferente do de restore.
+- **Extensions**: o dump inclui `CREATE EXTENSION` para as extensões necessárias. Se restore falhar por missing extension, verificar que o Postgres de destino tem os pacotes instalados.
+- **Migrations futuras**: se o dump é antigo, talvez não tenha o schema mais novo. Após restore, rodar `bun run db:migrate` para aplicar migrations pendentes antes de promover.
+- **Conexões ativas**: antes de swap de produção, parar a API (Coolify → app → Stop) para evitar writes concorrentes no DB antigo.
+
+## Teste periódico trimestral
+
+Cadência recomendada: **a cada 3 meses**. Agendar no calendário do dono do projeto. Objetivo: provar que backups são restauráveis antes do primeiro incidente real.
+
+**Checklist do teste** (preencher uma cópia a cada execução):
+
+- [ ] Data do teste: ____________________
+- [ ] Responsável: ____________________
+- [ ] Backup utilizado (execution timestamp): ____________________
+- [ ] Tamanho do dump (KB): ____________________
+- [ ] Origem (Local / R2): ____________________
+- [ ] Ambiente de restore (Postgres temporário — container local ou staging): ____________________
+- [ ] **Queries de sanity** executadas com sucesso:
+  - [ ] `SELECT count(*) FROM organizations` → valor esperado ≈ ____ (compara com prod)
+  - [ ] `SELECT count(*) FROM employees WHERE deleted_at IS NULL` → valor esperado ≈ ____
+  - [ ] `SELECT count(*) FROM org_subscriptions WHERE status = 'active'` → valor esperado ≈ ____
+  - [ ] `SELECT max(created_at) FROM audit_logs` → deve estar ≤ timestamp do backup + 24h
+  - [ ] `SELECT count(*) FROM medical_certificates` → valor esperado ≈ ____
+- [ ] Tempo total do restore: ____________________
+- [ ] Anomalias encontradas: ____________________
+- [ ] Staging descartado após teste: [ ] sim / [ ] não
+- [ ] Resultado: [ ] ✅ sucesso / [ ] ⚠️ sucesso com ressalvas / [ ] ❌ falhou
+
+**Se falhar**: abrir incidente no repo, escalar ao dono, priorizar correção imediata — backup que não restaura não é backup.
+
+**Registrar execuções** neste arquivo (histórico acumulado):
+
+| Data | Responsável | Resultado | Ressalvas |
+|---|---|---|---|
+| _primeira execução pendente_ | — | — | — |
+
+## Atenção — local retention ilimitada
+
+A config atual de **Local Backup Retention** no Coolify está com todos os valores em 0 (Number=0, Days=0, Max storage=0), o que o próprio Coolify interpreta como "ilimitado":
+
+> "Setting a value to 0 means unlimited retention."
+
+Na prática, os dumps locais em `/data/coolify/backups/databases/.../` nunca são removidos. Com a base atual (~310 KB/dump, 1 dump/dia), são ~113 MB/ano — não há risco imediato. Mas conforme a base cresce e o tempo passa, o disco do Coolify vai encher.
+
+**Recomendação** (rastreada como CP-45 no bucket 🟡 do checklist de infra):
+
+- Ajustar Local Backup Retention para valores finitos: sugestão **7 backups / 7 dias / 2 GB**.
+- O storage off-site (R2) com 30 dias permanece como a fonte de verdade de longo prazo.
+- Local continua sendo útil para restore rápido (sem egress do R2) nos casos mais comuns (últimos 7 dias).
+
+**Onde ajustar**: Coolify → `postgresql-production` → `Backups` → `Backup Retention Settings` → `Local Backup Retention`.
+
+## Contatos e escalação
+
+| Função | Quem | Quando acionar |
+|---|---|---|
+| Dono do sistema | _____________ | Falha consecutiva de backup, teste trimestral, restore real |
+| Acesso ao Coolify | _____________ | Precisa executar restore via UI |
+| Acesso SSH ao servidor | _____________ | Recuperação offline (caminho B) |
+| Contato Cloudflare R2 (billing/quota) | _____________ | Quota de R2 estourou ou problema com bucket |
+
+_Preencher os campos acima com os contatos/logins reais antes da primeira execução do teste trimestral._
+
+## Referências
+
+- [Coolify — Backup documentation](https://coolify.io/docs/databases/backups)
+- [Postgres pg_restore man page](https://www.postgresql.org/docs/current/app-pgrestore.html)
+- [Cloudflare R2 — S3 API compatibility](https://developers.cloudflare.com/r2/api/s3/)
+- Débito #92 em `docs/improvements/api-infrastructure-checklist.md` (seção 7.7)


### PR DESCRIPTION
## Summary

Última ação do bucket 🔴. Cria `docs/runbooks/database-backup.md` documentando o processo de backup em Coolify + Cloudflare R2 com valores concretos extraídos da UI (não um template genérico). Marca **bucket 🔴 concluído (10/10)**.

## Changes

| Arquivo | Propósito |
|---|---|
| `docs/runbooks/database-backup.md` | Runbook operacional com 6 seções (estado atual, verificação de saúde, restore A/B, teste trimestral, atenção retention, contatos) |
| `.gitignore` | Adiciona `docs/runbooks/` ao allowlist (seguindo padrão já usado para `improvements/` e `reports/`) |
| `docs/improvements/api-infrastructure-checklist.md` | 7.0 com bucket 🔴 em 10/10. CP-45 registrado. Changelog de RU-10 + seção de fechamento do bucket com retrospectiva. |

## Estado atual do backup (do print da UI do Coolify)

| Eixo | Valor |
|---|---|
| Frequência | Daily @ 00:00 UTC |
| Database | `synnerdata` |
| Storage | Local + Cloudflare R2 |
| Retention R2 | 30 backups / 30 dias / 8 GB |
| Retention local | **⚠️ ilimitada** (findings) |
| Formato | `pg_dump` (.dmp) |
| Size atual | ~310 KB |

## CP-45 registrado

**Ajustar Local Backup Retention** — config atual é `0/0/0` = unlimited. Risco baixo hoje (~113 MB/ano) mas vai acumular. Sugestão: `7 backups / 7 dias / 2 GB`. R2 segue como fonte de verdade off-site. Ação S operacional na UI (sem código).

## Fechamento do bucket 🔴

**10/10 concluídas**. Cronograma original: 30 dias. Entregue em: 1 dia (audit 2026-04-21 → todas as RUs mergeadas 2026-04-22).

Surpresas de escopo durante a execução (documentadas no changelog):
- **RU-1** (env hardening): hotfix urgente pós-merge (SMTP_FROM com display name)
- **RU-4** (`bun audit` no CI): escopo explodiu S → L (2 criticals + 17 highs em deps reais — split em RU-4a/4b/CP-40)
- **RU-7** (auditPlugin refactor): mudança de direção (recomendei deletar, você rejeitou corretamente, executei refactor) — lição "unused ≠ dead" para infra de compliance
- **RU-9** (BOLA audit): encolheu L → M (padrão já estava limpo, audit virou confirmação)
- **RU-10** (runbook backup): S real — UI do Coolify tinha tudo pronto

**7 follow-ups gerados** e registrados no bucket 🟡: CP-39, CP-40, CP-41, CP-42, CP-43, CP-44, CP-45.

**Débitos resolvidos em 7.7**: #14-#20, #22, #23, #24, #30, #54, #76, #77, #92, e #96 parcialmente (via CP-42/CP-43). ~15 débitos fechados.

## Próximo passo

Priorização do **bucket 🟡** (45 ações) com o dono. Candidatos naturais:
- **CP-40** — destrava `--audit-level=high` no CI
- **CP-1/CP-2** — XL refactors que destravam outros CPs (lib/ → plugins/, emails consolidados)
- **CP-42/CP-43** — convenção de `changes` + audit de reads sensíveis (LGPD)

## Test plan

Categoria (4) N/A — doc-only.

- [x] Runbook renderiza coerente
- [x] Links internos funcionam (runbook → CP-45 no checklist)
- [x] `.gitignore` allowlist atualizado
- [x] Valores do runbook batem com o print da UI do Coolify

🤖 Generated with [Claude Code](https://claude.com/claude-code)