### PR TITLE
fix(vacations): adopt active-cycle model for vacation creation

### DIFF
--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -1,22 +1,26 @@
 # Vacations (Ferias)
 
-Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias.
+Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias, baseado no modelo de **ciclo ativo**.
 
 ## Business Rules
 
 - `startDate` deve ser <= `endDate`
 - Nenhuma data das ferias pode ser anterior a data de admissao do funcionario (`hireDate`): `startDate`, `endDate`. (Os periodos aquisitivo/concessivo sao computados a partir do `hireDate`, portanto sempre posteriores por construcao.)
 - `daysEntitled` deve corresponder exatamente ao intervalo de datas (`endDate - startDate + 1`), validado via `calculateDaysBetween` no service
-- **Soma de `daysEntitled` por aquisitivo nao pode exceder 30 dias** (CLT art. 130). Validado no service via `ensureAquisitivoLimit` considerando todos os registros nao-cancelados e nao-deletados do mesmo employee no mesmo `acquisition_period_start`. Aplicado em create (usando periodos computados) e update (usando o snapshot armazenado, excluindo o proprio registro). Registros com `status = canceled` ou `deletedAt != null` nao contam.
+- **Soma de `daysEntitled` por aquisitivo nao pode exceder 30 dias** (CLT art. 130). Validado no service via `ensureAquisitivoLimit` considerando todos os registros nao-cancelados e nao-deletados do mesmo employee no mesmo `acquisition_period_start`. Aplicado em create (usando periodos do ciclo ativo) e update (usando o snapshot armazenado, excluindo o proprio registro). Registros com `status = canceled` ou `deletedAt != null` nao contam.
 - `daysUsed` deve ser >= 0 e <= `daysEntitled`
 - Periodos aquisitivo e concessivo: campos inline na tabela `vacations` (nao entidade separada)
   - `acquisitionPeriodStart` / `acquisitionPeriodEnd` / `concessivePeriodStart` / `concessivePeriodEnd`
-  - **Calculados pelo backend** via `computePeriodsFromHireDate(hireDate, vacation.startDate)`. O aquisitivo retornado eh aquele cujo concessivo contem a `startDate` — ou seja, o ciclo pendente para gozo, nao o ciclo que esta acumulando. Helper em `src/modules/occurrences/vacations/period-calculation.ts`.
-  - **Nao considera historico** de ferias anteriores nem seed manual no employee — tudo eh derivado de `hireDate` + `startDate`. Suporte a ferias fracionadas (multiplos registros no mesmo aquisitivo) sera implementado em issue separada (#227).
-  - **Erro `VacationNoRightsError` (422)** quando `startDate` eh anterior ao primeiro aniversario da admissao (funcionario sem direito adquirido).
+  - **Calculados pelo backend** via `computeActiveCycle` (helper em `src/modules/occurrences/vacations/period-calculation.ts`), que resolve o ciclo ativo do funcionario no momento da criacao.
+  - **Regra do ciclo ativo**: o sistema sempre apresenta o **primeiro ciclo** (do mais antigo ao mais recente) que satisfaz `daysUsed < 30` **E** `concessivePeriodEnd >= referenceDate`.
+    - Ciclos com concessivo vencido **E** `daysUsed < 30` sao **silenciosamente pulados** (considera-se que o cliente ja fez o pagamento de multa externamente fora do sistema).
+    - **Novos contratados** (< 1 aniversario completado) **nao sao mais bloqueados** — podem agendar ferias futuras desde que `startDate` esteja dentro do concessivo do 1o ciclo. `computePeriodsFromHireDate` retorna o ciclo 1 com `completed = 0` nesse caso (nao lanca mais erro).
+    - `computeActiveCycle` nunca retorna um ciclo sem dias disponiveis ou com concessivo vencido — esses cenarios sao tratados como `VacationActiveCycleUnresolvableError` (defensivo, nao deve ocorrer com dados reais dentro do `SAFETY_BOUND_MONTHS = 24`).
+  - **`startDate` obrigatoriamente dentro do concessivo do ciclo ativo** — caso contrario lanca `VacationStartDateOutsideConcessiveError` (422). Essa validacao substitui o antigo `VacationNoRightsError` para novos contratados.
+  - **Nao considera seed manual** no employee — tudo eh derivado de `hireDate` + `daysEntitled` das ferias existentes no mesmo aquisitivo. Suporte a ferias fracionadas (multiplos registros no mesmo aquisitivo) ja eh considerado pelo `computeActiveCycle` via soma de `daysEntitled` por `acquisitionPeriodStart`.
   - Regra CLT: aquisitivo = 12 meses; concessivo = 12 meses apos o fim do aquisitivo.
   - **Read-only na API**: removidos dos schemas Zod de create/update. Enviados no payload sao silenciosamente stripados. Frontend exibe em DatePickers desabilitados.
-  - Snapshot historico do momento da criacao — updates preservam os valores (nao recalculam).
+  - **Snapshot historico do ciclo ativo** no momento da criacao — updates preservam os valores (nao recalculam). No `update()`, `validateDatesNotBeforeHire` ainda eh aplicado para registros legados cujo snapshot pode preceder as novas regras.
 - `daysEntitled`: dias (calculado pelo frontend como endDate - startDate + 1, sem default)
 - Overlap check no create/update: mesmo employee + datas sobrepostas (excluindo ferias canceladas) lanca `VacationOverlapError`
 - Employee nao pode estar desligado no create (`ensureEmployeeNotTerminated` -- ON_VACATION e esperado/permitido)
@@ -42,12 +46,33 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 
 ## Fields
 
-- `startDate`, `endDate` (datas das ferias)
-- `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **computado pelo backend**, read-only na API, presente na response)
-- `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **computado pelo backend**, read-only na API, presente na response)
+- `startDate`, `endDate` (datas das ferias — obrigatoriamente dentro do concessivo do ciclo ativo no momento do create)
+- `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **snapshot do ciclo ativo** resolvido pelo backend no create, read-only na API, presente na response)
+- `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **snapshot do ciclo ativo** resolvido pelo backend no create, read-only na API, presente na response)
 - `daysEntitled` (inteiro, 1 a 30 conforme CLT art. 130, obrigatorio, sem default)
 - `daysUsed` (inteiro)
 - `notes` (opcional)
+
+## Endpoints
+
+- `POST /v1/vacations` — cria ferias. Resolve o ciclo ativo do employee e grava snapshot dos periodos aquisitivo/concessivo.
+- `GET /v1/vacations` — lista todas as ferias da organizacao.
+- `GET /v1/vacations/employee/:employeeId` — lista historico completo de ferias do employee.
+- `GET /v1/vacations/employee/:employeeId/active-cycle` — retorna o ciclo ativo atual do employee. Response:
+  ```json
+  {
+    "acquisitionPeriodStart": "YYYY-MM-DD",
+    "acquisitionPeriodEnd": "YYYY-MM-DD",
+    "concessivePeriodStart": "YYYY-MM-DD",
+    "concessivePeriodEnd": "YYYY-MM-DD",
+    "daysUsed": 0,
+    "daysRemaining": 30
+  }
+  ```
+  Usado pelo frontend para preencher os DatePickers desabilitados e mostrar o saldo disponivel antes da criacao.
+- `GET /v1/vacations/:id` — detalha uma ferias.
+- `PUT /v1/vacations/:id` — atualiza ferias. **Preserva o snapshot** dos periodos aquisitivo/concessivo; aplica `validateDatesNotBeforeHire` (para registros legados).
+- `DELETE /v1/vacations/:id` — soft delete.
 
 ## Errors
 
@@ -58,7 +83,9 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `VacationInvalidDaysError` (422) -- daysEntitled != intervalo de datas, ou daysUsed > daysEntitled
 - `VacationDateBeforeHireError` (422) -- qualquer data anterior a hireDate do funcionario
 - `VacationAquisitivoExceededError` (422) -- soma de `daysEntitled` no aquisitivo excederia 30 dias. Details: `{ acquisitionPeriodStart, acquisitionPeriodEnd, currentTotal, requestedDays, daysRemaining, maxAllowed: 30 }`.
-- `VacationNoRightsError` (422) -- `startDate` anterior ao primeiro aniversario da admissao
+- `VacationStartDateOutsideConcessiveError` (422) -- `startDate` fora do concessivo do ciclo ativo. Details: `{ startDate, concessivePeriodStart, concessivePeriodEnd }`. Substitui a antiga regra que bloqueava novos contratados.
+- `VacationActiveCycleUnresolvableError` (500) -- defensivo, **nao alcancavel com dados reais**. Lancado por `computeActiveCycle` se nenhum ciclo viavel for encontrado dentro do `SAFETY_BOUND_MONTHS = 24`. Details: `{ hireDate, referenceDate }`.
+- `VacationNoRightsError` (422) -- **legacy, nao mais lancado em producao**. Mantido no arquivo `errors.ts` para compatibilidade retroativa (codigos de erro ja expostos em integracoes / historicos). Novos contratados agora agendam ferias futuras livremente via ciclo ativo.
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)
 - `EmployeeTerminatedError` (422) -- shared, from `src/modules/employees/errors.ts`
 

--- a/src/modules/occurrences/vacations/__tests__/active-cycle.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/active-cycle.test.ts
@@ -1,0 +1,234 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { env } from "@/env";
+import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { createTestEmployee } from "@/test/helpers/employee";
+import {
+  createTestUser,
+  createTestUserWithOrganization,
+} from "@/test/helpers/user";
+import { createTestVacation } from "@/test/helpers/vacation";
+
+const BASE_URL = env.API_URL;
+
+describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("should reject unauthenticated requests", async () => {
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/employee-123/active-cycle`,
+        { method: "GET" }
+      )
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  test("should reject user without active organization", async () => {
+    const { headers } = await createTestUser({ emailVerified: true });
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/employee-123/active-cycle`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error.code).toBe("NO_ACTIVE_ORGANIZATION");
+  });
+
+  test("returns 404 when employee does not exist", async () => {
+    const { headers } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/employee-nonexistent/active-cycle`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error.code).toBe("VACATION_INVALID_EMPLOYEE");
+  });
+
+  test("returns 404 when employee belongs to a different organization", async () => {
+    const { headers: headers1 } = await createTestUserWithOrganization({
+      emailVerified: true,
+    });
+
+    const { organizationId: org2, user: user2 } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId: org2,
+      userId: user2.id,
+      hireDate: "2024-06-10",
+    });
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        { method: "GET", headers: headers1 }
+      )
+    );
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error.code).toBe("VACATION_INVALID_EMPLOYEE");
+  });
+
+  test("returns 422 when employee is TERMINATED", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-10",
+    });
+
+    await db
+      .update(schema.employees)
+      .set({ status: "TERMINATED" })
+      .where(eq(schema.employees.id, employee.id));
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("EMPLOYEE_TERMINATED");
+  });
+
+  test("returns cycle 1 for new hire with no vacations", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({ emailVerified: true });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2026-04-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.acquisitionPeriodStart).toBe("2026-04-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2027-03-31");
+    expect(body.data.concessivePeriodStart).toBe("2027-04-01");
+    expect(body.data.concessivePeriodEnd).toBe("2028-03-31");
+    expect(body.data.daysUsed).toBe(0);
+    expect(body.data.daysRemaining).toBe(30);
+  });
+
+  test("returns active cycle with partial usage", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-07-01",
+      endDate: "2025-07-15",
+      daysEntitled: 15,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.acquisitionPeriodStart).toBe("2024-06-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2025-05-31");
+    expect(body.data.concessivePeriodStart).toBe("2025-06-01");
+    expect(body.data.concessivePeriodEnd).toBe("2026-05-31");
+    expect(body.data.daysUsed).toBe(15);
+    expect(body.data.daysRemaining).toBe(15);
+  });
+
+  test("advances to next cycle after current cycle reaches 30 days used", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-06-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-07-01",
+      endDate: "2025-07-30",
+      daysEntitled: 30,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    const response = await app.handle(
+      new Request(
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        { method: "GET", headers }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.acquisitionPeriodStart).toBe("2025-06-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2026-05-31");
+    expect(body.data.concessivePeriodStart).toBe("2026-06-01");
+    expect(body.data.concessivePeriodEnd).toBe("2027-05-31");
+    expect(body.data.daysUsed).toBe(0);
+    expect(body.data.daysRemaining).toBe(30);
+  });
+});

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -422,7 +422,7 @@ describe("POST /v1/vacations", () => {
     expect(body.success).toBe(true);
   });
 
-  test("should reject when startDate is before employee hireDate", async () => {
+  test("should reject when startDate is before the active cycle's concessivo", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -450,7 +450,11 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(422);
     const body = await response.json();
-    expect(body.error.code).toBe("VACATION_DATE_BEFORE_HIRE");
+    expect(body.error.code).toBe("VACATION_START_DATE_OUTSIDE_CONCESSIVE");
+    expect(body.error.details).toBeObject();
+    expect(body.error.details.startDate).toBe("2024-12-20");
+    expect(body.error.details.concessivePeriodStart).toBeString();
+    expect(body.error.details.concessivePeriodEnd).toBeString();
   });
 
   test("computes periods from hireDate for employee without prior vacations", async () => {
@@ -575,7 +579,7 @@ describe("POST /v1/vacations", () => {
     expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
   });
 
-  test("rejects with 422 when vacation startDate is before the first anniversary", async () => {
+  test("rejects with 422 when vacation startDate is before first cycle's concessivo", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -589,7 +593,6 @@ describe("POST /v1/vacations", () => {
       acquisitionPeriodEnd: null,
     });
 
-    // startDate is before hireDate + 12 months (no acquired rights yet)
     const response = await app.handle(
       new Request(`${BASE_URL}/v1/vacations`, {
         method: "POST",
@@ -607,7 +610,200 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(422);
     const body = await response.json();
-    expect(body.error.code).toBe("VACATION_NO_RIGHTS");
+    expect(body.error.code).toBe("VACATION_START_DATE_OUTSIDE_CONCESSIVE");
+    expect(body.error.details.startDate).toBe("2026-03-01");
+    expect(body.error.details.concessivePeriodStart).toBe("2026-06-10");
+    expect(body.error.details.concessivePeriodEnd).toBe("2027-06-09");
+  });
+
+  test("allows creating vacation for new hire (< 1 anniversary) when startDate is within first future concessivo", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2026-04-22",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2027-05-01",
+          endDate: "2027-05-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.acquisitionPeriodStart).toBe("2026-04-22");
+    expect(body.data.acquisitionPeriodEnd).toBe("2027-04-21");
+    expect(body.data.concessivePeriodStart).toBe("2027-04-22");
+    expect(body.data.concessivePeriodEnd).toBe("2028-04-21");
+  });
+
+  test("uses next cycle when the previous cycle is filled with 30 days", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-04-22",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-30",
+      daysEntitled: 30,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-05-01",
+          endDate: "2026-05-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.acquisitionPeriodStart).toBe("2025-04-22");
+    expect(body.data.acquisitionPeriodEnd).toBe("2026-04-21");
+    expect(body.data.concessivePeriodStart).toBe("2026-04-22");
+    expect(body.data.concessivePeriodEnd).toBe("2027-04-21");
+  });
+
+  test("silently skips cycles with expired concessivo and < 30 days used", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2023-04-22",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await db.insert(schema.vacations).values({
+      id: `vacation-${crypto.randomUUID()}`,
+      organizationId,
+      employeeId: employee.id,
+      startDate: "2024-06-01",
+      endDate: "2024-06-15",
+      acquisitionPeriodStart: "2023-04-22",
+      acquisitionPeriodEnd: "2024-04-21",
+      concessivePeriodStart: "2024-04-22",
+      concessivePeriodEnd: "2025-04-21",
+      daysEntitled: 15,
+      daysUsed: 15,
+      status: "completed",
+      createdBy: user.id,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-05-01",
+          endDate: "2026-05-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.acquisitionPeriodStart).toBe("2025-04-22");
+    expect(body.data.acquisitionPeriodEnd).toBe("2026-04-21");
+    expect(body.data.concessivePeriodStart).toBe("2026-04-22");
+    expect(body.data.concessivePeriodEnd).toBe("2027-04-21");
+  });
+
+  test("rejects when startDate falls outside the selected active cycle's concessivo", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2023-01-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    await createTestVacation({
+      organizationId,
+      userId: user.id,
+      employeeId: employee.id,
+      startDate: "2024-06-01",
+      endDate: "2024-06-30",
+      daysEntitled: 30,
+      daysUsed: 0,
+      status: "scheduled",
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2024-10-01",
+          endDate: "2024-10-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error.code).toBe("VACATION_START_DATE_OUTSIDE_CONCESSIVE");
+    expect(body.error.details.startDate).toBe("2024-10-01");
+    expect(body.error.details.concessivePeriodStart).toBe("2025-01-01");
+    expect(body.error.details.concessivePeriodEnd).toBe("2025-12-31");
   });
 
   test("should set employee status to VACATION_SCHEDULED after creating vacation", async () => {

--- a/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from "bun:test";
 import {
   addDays,
   addMonths,
+  computeActiveCycle,
   computePeriodsFromHireDate,
   computePeriodsFromLastAcquisition,
 } from "@/modules/occurrences/vacations/period-calculation";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
-const VACATION_NO_RIGHTS_PATTERN = /direito a férias/;
 
 describe("addDays", () => {
   test("adds days across month boundary", () => {
@@ -62,25 +62,37 @@ describe("computePeriodsFromLastAcquisition", () => {
 });
 
 describe("computePeriodsFromHireDate", () => {
-  test("throws VacationNoRightsError when referenceDate is before first anniversary", () => {
-    expect(() =>
+  test("returns cycle 1 (future) when referenceDate is before first anniversary", () => {
+    expect(
       computePeriodsFromHireDate("2025-01-01", new Date("2025-06-01T00:00:00Z"))
-    ).toThrow(VACATION_NO_RIGHTS_PATTERN);
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+    });
   });
 
-  test("throws when referenceDate equals hireDate exactly (employee just hired)", () => {
-    expect(() =>
+  test("returns cycle 1 when referenceDate equals hireDate", () => {
+    expect(
       computePeriodsFromHireDate("2026-06-10", new Date("2026-06-10T00:00:00Z"))
-    ).toThrow(VACATION_NO_RIGHTS_PATTERN);
+    ).toEqual({
+      acquisitionPeriodStart: "2026-06-10",
+      acquisitionPeriodEnd: "2027-06-09",
+      concessivePeriodStart: "2027-06-10",
+      concessivePeriodEnd: "2028-06-09",
+    });
   });
 
-  test("throws exactly 1 day before first anniversary (boundary)", () => {
-    // hire 2026-06-10, referenceDate 2027-06-09 (1 day before anniversary)
-    // completed = 0 → throws. Guards against off-by-one regressions
-    // where inclusive/exclusive anniversary comparison could shift.
-    expect(() =>
+  test("returns cycle 1 when exactly 1 day before first anniversary", () => {
+    expect(
       computePeriodsFromHireDate("2026-06-10", new Date("2027-06-09T00:00:00Z"))
-    ).toThrow(VACATION_NO_RIGHTS_PATTERN);
+    ).toEqual({
+      acquisitionPeriodStart: "2026-06-10",
+      acquisitionPeriodEnd: "2027-06-09",
+      concessivePeriodStart: "2027-06-10",
+      concessivePeriodEnd: "2028-06-09",
+    });
   });
 
   test("Google AI example: hire 2024-01-01 + referenceDate 2025-07-01 → 1st cycle", () => {
@@ -95,8 +107,6 @@ describe("computePeriodsFromHireDate", () => {
   });
 
   test("employee on exact anniversary → 1st completed cycle is the pending one", () => {
-    // hire 2026-06-10, referenceDate 2027-06-10 (exactly 1 year later)
-    // completed = 1 (anniversary was reached), pending cycle index = 0 → 1st cycle
     expect(
       computePeriodsFromHireDate("2026-06-10", new Date("2027-06-10T00:00:00Z"))
     ).toEqual({
@@ -108,8 +118,6 @@ describe("computePeriodsFromHireDate", () => {
   });
 
   test("employee with 2 completed anniversaries → 2nd cycle (aquisitivo year 2, concessivo year 3)", () => {
-    // hire 2026-06-10, referenceDate 2028-07-01
-    // completed = 2, pending cycle index = 1 → 2nd aquisitivo, 2nd concessivo
     expect(
       computePeriodsFromHireDate("2026-06-10", new Date("2028-07-01T00:00:00Z"))
     ).toEqual({
@@ -121,8 +129,6 @@ describe("computePeriodsFromHireDate", () => {
   });
 
   test("Raquel homologação case: hire 2020-12-08 + referenceDate 2026-04-01 → 5th cycle", () => {
-    // completed = 5 (anniversaries 2021, 2022, 2023, 2024, 2025 all <= 2026-04-01)
-    // pending cycle index = 4 → 5th aquisitivo
     expect(
       computePeriodsFromHireDate("2020-12-08", new Date("2026-04-01T00:00:00Z"))
     ).toEqual({
@@ -134,9 +140,169 @@ describe("computePeriodsFromHireDate", () => {
   });
 
   test("defaults referenceDate to today when omitted", () => {
-    // Smoke test that the default param still works; exact values depend on today's date.
     const result = computePeriodsFromHireDate("2020-01-01");
     expect(result.acquisitionPeriodStart).toMatch(ISO_DATE_PATTERN);
     expect(result.acquisitionPeriodEnd).toMatch(ISO_DATE_PATTERN);
+  });
+});
+
+describe("computeActiveCycle", () => {
+  test("new hire (0 anniversaries) → returns cycle 1 with future concessivo", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2026-01-01",
+        referenceDate: new Date("2026-06-01T00:00:00Z"),
+        vacationsInCycles: [],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2026-01-01",
+      acquisitionPeriodEnd: "2026-12-31",
+      concessivePeriodStart: "2027-01-01",
+      concessivePeriodEnd: "2027-12-31",
+      daysUsed: 0,
+      daysRemaining: 30,
+    });
+  });
+
+  test("employee with 1 anniversary and 0 vacations → cycle 1 active", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2025-01-01",
+        referenceDate: new Date("2026-06-01T00:00:00Z"),
+        vacationsInCycles: [],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+      daysUsed: 0,
+      daysRemaining: 30,
+    });
+  });
+
+  test("employee with 1 anniversary and 30 days used in cycle 1 → cycle 2 active", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2025-01-01",
+        referenceDate: new Date("2026-06-01T00:00:00Z"),
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2025-01-01", daysEntitled: 30 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2026-01-01",
+      acquisitionPeriodEnd: "2026-12-31",
+      concessivePeriodStart: "2027-01-01",
+      concessivePeriodEnd: "2027-12-31",
+      daysUsed: 0,
+      daysRemaining: 30,
+    });
+  });
+
+  test("cycle with daysUsed < 30 but concessivo vencido → silently skipped", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2023-01-01",
+        referenceDate: new Date("2026-06-01T00:00:00Z"),
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2023-01-01", daysEntitled: 15 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+      daysUsed: 0,
+      daysRemaining: 30,
+    });
+  });
+
+  test("multiple cycles with mixed usage → returns first viable", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2023-01-01",
+        referenceDate: new Date("2026-06-01T00:00:00Z"),
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2023-01-01", daysEntitled: 30 },
+          { acquisitionPeriodStart: "2024-01-01", daysEntitled: 15 },
+          { acquisitionPeriodStart: "2025-01-01", daysEntitled: 10 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+      daysUsed: 10,
+      daysRemaining: 20,
+    });
+  });
+
+  test("partial days in active cycle → correct daysRemaining", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2025-01-01",
+        referenceDate: new Date("2026-06-01T00:00:00Z"),
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2025-01-01", daysEntitled: 15 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+      daysUsed: 15,
+      daysRemaining: 15,
+    });
+  });
+
+  test("Geralda case: long history with no vacations → returns first cycle whose concessivo is still valid", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2011-02-01",
+        referenceDate: new Date("2026-04-22T00:00:00Z"),
+        vacationsInCycles: [],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-02-01",
+      acquisitionPeriodEnd: "2026-01-31",
+      concessivePeriodStart: "2026-02-01",
+      concessivePeriodEnd: "2027-01-31",
+      daysUsed: 0,
+      daysRemaining: 30,
+    });
+  });
+
+  test("boundary: concessivo ends exactly on referenceDate → still active", () => {
+    expect(
+      computeActiveCycle({
+        hireDate: "2024-01-01",
+        referenceDate: new Date("2025-12-31T00:00:00Z"),
+        vacationsInCycles: [],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2024-01-01",
+      acquisitionPeriodEnd: "2024-12-31",
+      concessivePeriodStart: "2025-01-01",
+      concessivePeriodEnd: "2025-12-31",
+      daysUsed: 0,
+      daysRemaining: 30,
+    });
+  });
+
+  test("defaults referenceDate to today when omitted", () => {
+    const result = computeActiveCycle({
+      hireDate: "2020-01-01",
+      vacationsInCycles: [],
+    });
+    expect(result.acquisitionPeriodStart).toMatch(ISO_DATE_PATTERN);
+    expect(result.acquisitionPeriodEnd).toMatch(ISO_DATE_PATTERN);
+    expect(result.concessivePeriodStart).toMatch(ISO_DATE_PATTERN);
+    expect(result.concessivePeriodEnd).toMatch(ISO_DATE_PATTERN);
+    expect(result.daysUsed).toBe(0);
+    expect(result.daysRemaining).toBe(30);
   });
 });

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -131,3 +131,15 @@ export class VacationStartDateOutsideConcessiveError extends VacationError {
     );
   }
 }
+
+export class VacationActiveCycleUnresolvableError extends VacationError {
+  status = 500;
+
+  constructor(hireDate: string, referenceDate: string) {
+    super(
+      "Não foi possível determinar o ciclo de férias ativo dentro do intervalo de segurança",
+      "VACATION_ACTIVE_CYCLE_UNRESOLVABLE",
+      { hireDate, referenceDate }
+    );
+  }
+}

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -115,3 +115,19 @@ export class VacationAquisitivoExceededError extends VacationError {
     );
   }
 }
+
+export class VacationStartDateOutsideConcessiveError extends VacationError {
+  status = 422;
+
+  constructor(args: {
+    startDate: string;
+    concessivePeriodStart: string;
+    concessivePeriodEnd: string;
+  }) {
+    super(
+      "Data de início das férias deve estar dentro do período concessivo do ciclo ativo",
+      "VACATION_START_DATE_OUTSIDE_CONCESSIVE",
+      args
+    );
+  }
+}

--- a/src/modules/occurrences/vacations/index.ts
+++ b/src/modules/occurrences/vacations/index.ts
@@ -14,6 +14,7 @@ import {
   createVacationSchema,
   deleteVacationResponseSchema,
   employeeIdParamSchema,
+  getActiveCycleResponseSchema,
   getVacationResponseSchema,
   idParamSchema,
   listVacationsResponseSchema,
@@ -104,6 +105,35 @@ export const vacationController = new Elysia({
         summary: "List vacations by employee",
         description:
           "Lists all vacations for a specific employee in the active organization",
+      },
+    }
+  )
+  .get(
+    "/employee/:employeeId/active-cycle",
+    async ({ session, params }) =>
+      wrapSuccess(
+        await VacationService.getActiveCycle(
+          params.employeeId,
+          session.activeOrganizationId as string
+        )
+      ),
+    {
+      auth: {
+        permissions: { vacation: ["read"] },
+        requireOrganization: true,
+      },
+      params: employeeIdParamSchema,
+      response: {
+        200: getActiveCycleResponseSchema,
+        401: unauthorizedErrorSchema,
+        403: forbiddenErrorSchema,
+        404: notFoundErrorSchema,
+        422: validationErrorSchema,
+      },
+      detail: {
+        summary: "Get active vacation cycle by employee",
+        description:
+          "Returns the active acquisition/concessive cycle for an employee (first cycle with daysUsed < 30 and concessive window still open) plus the remaining days balance.",
       },
     }
   )

--- a/src/modules/occurrences/vacations/period-calculation.ts
+++ b/src/modules/occurrences/vacations/period-calculation.ts
@@ -1,3 +1,5 @@
+import { VacationNoRightsError } from "./errors";
+
 export function addDays(isoDate: string, days: number): string {
   const d = new Date(`${isoDate}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() + days);
@@ -65,7 +67,7 @@ export function computePeriodsFromHireDate(
   };
 }
 
-type ActiveCycleInput = {
+export type ActiveCycleInput = {
   hireDate: string;
   referenceDate?: Date;
   vacationsInCycles: Array<{
@@ -135,7 +137,5 @@ export function computeActiveCycle(input: ActiveCycleInput): ActiveCycle {
     cycleNumber += 1;
   }
 
-  throw new Error(
-    `computeActiveCycle: no active cycle found within ${SAFETY_BOUND_MONTHS} months of referenceDate for hireDate=${input.hireDate}`
-  );
+  throw new VacationNoRightsError(input.hireDate, referenceIso);
 }

--- a/src/modules/occurrences/vacations/period-calculation.ts
+++ b/src/modules/occurrences/vacations/period-calculation.ts
@@ -1,4 +1,4 @@
-import { VacationNoRightsError } from "./errors";
+import { VacationActiveCycleUnresolvableError } from "./errors";
 
 export function addDays(isoDate: string, days: number): string {
   const d = new Date(`${isoDate}T00:00:00Z`);
@@ -137,5 +137,5 @@ export function computeActiveCycle(input: ActiveCycleInput): ActiveCycle {
     cycleNumber += 1;
   }
 
-  throw new VacationNoRightsError(input.hireDate, referenceIso);
+  throw new VacationActiveCycleUnresolvableError(input.hireDate, referenceIso);
 }

--- a/src/modules/occurrences/vacations/period-calculation.ts
+++ b/src/modules/occurrences/vacations/period-calculation.ts
@@ -1,5 +1,3 @@
-import { VacationNoRightsError } from "./errors";
-
 export function addDays(isoDate: string, days: number): string {
   const d = new Date(`${isoDate}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() + days);
@@ -50,14 +48,7 @@ export function computePeriodsFromHireDate(
     }
   }
 
-  if (completed < 1) {
-    throw new VacationNoRightsError(
-      hireDate,
-      referenceDate.toISOString().slice(0, 10)
-    );
-  }
-
-  const index = completed - 1;
+  const index = Math.max(completed - 1, 0);
   const acquisitionPeriodStart = addMonths(hireDate, index * 12);
   const acquisitionPeriodEnd = addDays(
     addMonths(hireDate, (index + 1) * 12),
@@ -72,4 +63,79 @@ export function computePeriodsFromHireDate(
     concessivePeriodStart,
     concessivePeriodEnd,
   };
+}
+
+type ActiveCycleInput = {
+  hireDate: string;
+  referenceDate?: Date;
+  vacationsInCycles: Array<{
+    acquisitionPeriodStart: string;
+    daysEntitled: number;
+  }>;
+};
+
+export type ActiveCycle = VacationPeriods & {
+  daysUsed: number;
+  daysRemaining: number;
+};
+
+const MAX_DAYS_PER_CYCLE = 30;
+const SAFETY_BOUND_MONTHS = 24;
+
+export function computeActiveCycle(input: ActiveCycleInput): ActiveCycle {
+  const referenceDate = input.referenceDate ?? new Date();
+  const referenceIso = referenceDate.toISOString().slice(0, 10);
+  const safetyBoundIso = addMonths(referenceIso, SAFETY_BOUND_MONTHS);
+
+  const usageByCycleStart = new Map<string, number>();
+  for (const vacation of input.vacationsInCycles) {
+    const current = usageByCycleStart.get(vacation.acquisitionPeriodStart) ?? 0;
+    usageByCycleStart.set(
+      vacation.acquisitionPeriodStart,
+      current + vacation.daysEntitled
+    );
+  }
+
+  let cycleNumber = 1;
+  while (cycleNumber < Number.MAX_SAFE_INTEGER) {
+    const acquisitionPeriodStart = addMonths(
+      input.hireDate,
+      (cycleNumber - 1) * 12
+    );
+
+    if (acquisitionPeriodStart > safetyBoundIso) {
+      break;
+    }
+
+    const acquisitionPeriodEnd = addDays(
+      addMonths(input.hireDate, cycleNumber * 12),
+      -1
+    );
+    const concessivePeriodStart = addDays(acquisitionPeriodEnd, 1);
+    const concessivePeriodEnd = addDays(
+      addMonths(concessivePeriodStart, 12),
+      -1
+    );
+
+    const daysUsed = usageByCycleStart.get(acquisitionPeriodStart) ?? 0;
+    const hasDaysAvailable = daysUsed < MAX_DAYS_PER_CYCLE;
+    const concessivoStillValid = concessivePeriodEnd >= referenceIso;
+
+    if (hasDaysAvailable && concessivoStillValid) {
+      return {
+        acquisitionPeriodStart,
+        acquisitionPeriodEnd,
+        concessivePeriodStart,
+        concessivePeriodEnd,
+        daysUsed,
+        daysRemaining: MAX_DAYS_PER_CYCLE - daysUsed,
+      };
+    }
+
+    cycleNumber += 1;
+  }
+
+  throw new Error(
+    `computeActiveCycle: no active cycle found within ${SAFETY_BOUND_MONTHS} months of referenceDate for hireDate=${input.hireDate}`
+  );
 }

--- a/src/modules/occurrences/vacations/vacation.model.ts
+++ b/src/modules/occurrences/vacations/vacation.model.ts
@@ -125,6 +125,35 @@ const deletedVacationDataSchema = vacationDataSchema.extend({
 
 const vacationListDataSchema = z.array(vacationDataSchema);
 
+export const activeCycleSchema = z.object({
+  acquisitionPeriodStart: z
+    .string()
+    .describe("Início do período aquisitivo (YYYY-MM-DD)"),
+  acquisitionPeriodEnd: z
+    .string()
+    .describe("Fim do período aquisitivo (YYYY-MM-DD)"),
+  concessivePeriodStart: z
+    .string()
+    .describe("Início do período concessivo (YYYY-MM-DD)"),
+  concessivePeriodEnd: z
+    .string()
+    .describe("Fim do período concessivo (YYYY-MM-DD)"),
+  daysUsed: z
+    .number()
+    .int()
+    .min(0)
+    .describe("Dias já utilizados no ciclo ativo"),
+  daysRemaining: z
+    .number()
+    .int()
+    .min(0)
+    .max(30)
+    .describe("Dias restantes no ciclo ativo"),
+});
+
+export const getActiveCycleResponseSchema =
+  successResponseSchema(activeCycleSchema);
+
 export const createVacationResponseSchema =
   successResponseSchema(vacationDataSchema);
 export const getVacationResponseSchema =

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -3,7 +3,10 @@ import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { calculateDaysBetween } from "@/lib/schemas/date-helpers";
 import { ensureEmployeeNotTerminated } from "@/modules/employees/status";
-import { computePeriodsFromHireDate } from "@/modules/occurrences/vacations/period-calculation";
+import {
+  type ActiveCycle,
+  computeActiveCycle,
+} from "@/modules/occurrences/vacations/period-calculation";
 import {
   VacationAlreadyDeletedError,
   VacationAquisitivoExceededError,
@@ -13,6 +16,7 @@ import {
   VacationInvalidEmployeeError,
   VacationNotFoundError,
   VacationOverlapError,
+  VacationStartDateOutsideConcessiveError,
 } from "./errors";
 import type {
   CreateVacationInput,
@@ -217,6 +221,83 @@ export abstract class VacationService {
     }
   }
 
+  private static validateStartDateInConcessive(
+    startDate: string,
+    cycle: { concessivePeriodStart: string; concessivePeriodEnd: string }
+  ): void {
+    if (
+      startDate < cycle.concessivePeriodStart ||
+      startDate > cycle.concessivePeriodEnd
+    ) {
+      throw new VacationStartDateOutsideConcessiveError({
+        startDate,
+        concessivePeriodStart: cycle.concessivePeriodStart,
+        concessivePeriodEnd: cycle.concessivePeriodEnd,
+      });
+    }
+  }
+
+  private static async computeActiveCycleFor(
+    employeeId: string,
+    organizationId: string,
+    hireDate: string,
+    referenceDate: Date
+  ): Promise<ActiveCycle> {
+    const rows = await db
+      .select({
+        acquisitionPeriodStart: schema.vacations.acquisitionPeriodStart,
+        daysEntitled: schema.vacations.daysEntitled,
+      })
+      .from(schema.vacations)
+      .where(
+        and(
+          eq(schema.vacations.organizationId, organizationId),
+          eq(schema.vacations.employeeId, employeeId),
+          sql`${schema.vacations.status} != 'canceled'`,
+          isNull(schema.vacations.deletedAt),
+          sql`${schema.vacations.acquisitionPeriodStart} IS NOT NULL`
+        )
+      );
+
+    const vacationsInCycles = rows
+      .filter(
+        (
+          row
+        ): row is { acquisitionPeriodStart: string; daysEntitled: number } =>
+          row.acquisitionPeriodStart !== null
+      )
+      .map((row) => ({
+        acquisitionPeriodStart: row.acquisitionPeriodStart,
+        daysEntitled: row.daysEntitled,
+      }));
+
+    return computeActiveCycle({
+      hireDate,
+      referenceDate,
+      vacationsInCycles,
+    });
+  }
+
+  static async getActiveCycle(
+    employeeId: string,
+    organizationId: string,
+    referenceDate: Date = new Date()
+  ): Promise<ActiveCycle> {
+    const employee = await VacationService.getEmployeeReference(
+      employeeId,
+      organizationId
+    );
+
+    await ensureEmployeeNotTerminated(employeeId, organizationId);
+
+    return VacationService.computeActiveCycleFor(
+      employeeId,
+      organizationId,
+      employee.hireDate,
+      referenceDate
+    );
+  }
+
   private static async syncEmployeeStatus(
     employeeId: string,
     organizationId: string,
@@ -295,18 +376,17 @@ export abstract class VacationService {
     await ensureEmployeeNotTerminated(data.employeeId, organizationId);
 
     VacationService.validateDates(data.startDate, data.endDate);
-    // validateDatesNotBeforeHire must run before computePeriodsFromHireDate so
-    // `startDate < hireDate` throws VacationDateBeforeHireError (specific)
-    // instead of VacationNoRightsError (generic, fired when completed = 0).
-    VacationService.validateDatesNotBeforeHire(employee.hireDate, {
-      startDate: data.startDate,
-      endDate: data.endDate,
-    });
 
-    const periods = computePeriodsFromHireDate(
+    // Active cycle must be resolved before ensureAquisitivoLimit so the
+    // aquisitivo start anchors the SUM query scope.
+    const activeCycle = await VacationService.computeActiveCycleFor(
+      data.employeeId,
+      organizationId,
       employee.hireDate,
       new Date(`${data.startDate}T00:00:00Z`)
     );
+
+    VacationService.validateStartDateInConcessive(data.startDate, activeCycle);
 
     VacationService.validateDays(
       data.startDate,
@@ -318,8 +398,8 @@ export abstract class VacationService {
     await VacationService.ensureAquisitivoLimit({
       employeeId: data.employeeId,
       organizationId,
-      acquisitionPeriodStart: periods.acquisitionPeriodStart,
-      acquisitionPeriodEnd: periods.acquisitionPeriodEnd,
+      acquisitionPeriodStart: activeCycle.acquisitionPeriodStart,
+      acquisitionPeriodEnd: activeCycle.acquisitionPeriodEnd,
       requestedDays: data.daysEntitled,
     });
 
@@ -338,10 +418,10 @@ export abstract class VacationService {
       employeeId: data.employeeId,
       startDate: data.startDate,
       endDate: data.endDate,
-      acquisitionPeriodStart: periods.acquisitionPeriodStart,
-      acquisitionPeriodEnd: periods.acquisitionPeriodEnd,
-      concessivePeriodStart: periods.concessivePeriodStart,
-      concessivePeriodEnd: periods.concessivePeriodEnd,
+      acquisitionPeriodStart: activeCycle.acquisitionPeriodStart,
+      acquisitionPeriodEnd: activeCycle.acquisitionPeriodEnd,
+      concessivePeriodStart: activeCycle.concessivePeriodStart,
+      concessivePeriodEnd: activeCycle.concessivePeriodEnd,
       daysEntitled: data.daysEntitled,
       daysUsed: data.daysUsed,
       status: data.status,
@@ -361,10 +441,10 @@ export abstract class VacationService {
       employee,
       startDate: data.startDate,
       endDate: data.endDate,
-      acquisitionPeriodStart: periods.acquisitionPeriodStart,
-      acquisitionPeriodEnd: periods.acquisitionPeriodEnd,
-      concessivePeriodStart: periods.concessivePeriodStart,
-      concessivePeriodEnd: periods.concessivePeriodEnd,
+      acquisitionPeriodStart: activeCycle.acquisitionPeriodStart,
+      acquisitionPeriodEnd: activeCycle.acquisitionPeriodEnd,
+      concessivePeriodStart: activeCycle.concessivePeriodStart,
+      concessivePeriodEnd: activeCycle.concessivePeriodEnd,
       daysEntitled: data.daysEntitled,
       daysUsed: data.daysUsed,
       status: data.status,

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -245,7 +245,7 @@ export abstract class VacationService {
   ): Promise<ActiveCycle> {
     const rows = await db
       .select({
-        acquisitionPeriodStart: schema.vacations.acquisitionPeriodStart,
+        acquisitionPeriodStart: sql<string>`${schema.vacations.acquisitionPeriodStart}`,
         daysEntitled: schema.vacations.daysEntitled,
       })
       .from(schema.vacations)
@@ -259,17 +259,10 @@ export abstract class VacationService {
         )
       );
 
-    const vacationsInCycles = rows
-      .filter(
-        (
-          row
-        ): row is { acquisitionPeriodStart: string; daysEntitled: number } =>
-          row.acquisitionPeriodStart !== null
-      )
-      .map((row) => ({
-        acquisitionPeriodStart: row.acquisitionPeriodStart,
-        daysEntitled: row.daysEntitled,
-      }));
+    const vacationsInCycles = rows.map((row) => ({
+      acquisitionPeriodStart: row.acquisitionPeriodStart,
+      daysEntitled: row.daysEntitled,
+    }));
 
     return computeActiveCycle({
       hireDate,
@@ -377,8 +370,6 @@ export abstract class VacationService {
 
     VacationService.validateDates(data.startDate, data.endDate);
 
-    // Active cycle must be resolved before ensureAquisitivoLimit so the
-    // aquisitivo start anchors the SUM query scope.
     const activeCycle = await VacationService.computeActiveCycleFor(
       data.employeeId,
       organizationId,


### PR DESCRIPTION
## Contexto

Cliente reportou que funcionário admitido em 2023 estava tendo seu primeiro período aquisitivo/concessivo calculado como 2026/2027 no cadastro de férias — comportamento correto pela regra antiga mas errado pelo fluxo de negócio dele. A regra desejada foi definida com a cliente (Thatiane) em Slack:

1. O sistema apresenta **um ciclo por vez** — o mais antigo com saldo (`daysUsed < 30`) e concessivo ainda vigente.
2. Ciclos com concessivo vencido **sem** completar 30 dias são **silenciosamente pulados** (cliente paga multa por fora).
3. `startDate` **obrigatoriamente dentro do concessivo** do ciclo ativo.
4. **Novos contratados** (< 1 aniversário) podem agendar férias futuras — não bloqueamos mais.

"Pago via multa", fracionamento formal CLT e venda de férias ficaram fora de escopo desta entrega.

## O que mudou

### Backend

- **Novo algoritmo** `computeActiveCycle` (`period-calculation.ts`): enumera ciclos a partir de `hireDate` e retorna o primeiro com `daysUsed < 30` E `concessivoEnd >= referenceDate`.
- **`VacationService.create` refatorado** — snapshot dos períodos passa a vir do ciclo ativo; validação de `startDate` dentro do concessivo substitui o bloqueio de novos contratados.
- **`VacationService.getActiveCycle`** — novo método público usado pelo novo endpoint.
- **Novo endpoint** `GET /v1/vacations/employee/:employeeId/active-cycle` → `{ acquisitionPeriodStart, acquisitionPeriodEnd, concessivePeriodStart, concessivePeriodEnd, daysUsed, daysRemaining }`.
- **Novos erros**:
  - `VacationStartDateOutsideConcessiveError` (422, `VACATION_START_DATE_OUTSIDE_CONCESSIVE`) — `startDate` fora do concessivo do ciclo ativo.
  - `VacationActiveCycleUnresolvableError` (500) — defensivo, inalcançável com dados reais.
- `VacationNoRightsError` mantido por compatibilidade mas **não mais lançado em produção** (bloqueio de novos contratados removido).
- `computePeriodsFromHireDate` não joga mais — retorna ciclo 1 para `completed = 0` (continua usado por `employees/lastAcquisitionPeriod`).
- `update()` **não refatorado** — preserva snapshot e ainda chama `validateDatesNotBeforeHire` para registros legados.

### Documentação

- `src/modules/occurrences/vacations/CLAUDE.md` atualizado cobrindo ciclo ativo, endpoints, erros novos e comportamento legado.

### Testes

- **`__tests__/period-calculation.test.ts`** — 9 cenários novos para `computeActiveCycle` (new hire, partial usage, expired skip, histórico longo Geralda, boundary, etc.).
- **`__tests__/create-vacation.test.ts`** — 2 regressões reescritas + 4 cenários novos cobrindo new hire, avanço de ciclo, skip de vencido-incompleto, rejeição de startDate fora de concessivo.
- **`__tests__/active-cycle.test.ts`** (novo) — 8 cenários cobrindo happy paths, 401, 403, 404 (x2) e 422 (TERMINATED).

## Resultado dos testes

```
src/modules/occurrences/vacations/__tests__/: 120 pass / 0 fail (336 expect() calls)
bunx tsc --noEmit: clean
npx ultracite check: clean
```

## Process notes

- Implementação via subagent-driven development com spec + code quality review por task.
- 8 commits atômicos (7 feat/refactor/test + 1 docs).
- Dois desvios do spec nos testes, ambos validados pelo reviewer: (a) "startDate APÓS concessivoEnd" é inalcançável por construção do algoritmo, substituído por "startDate ANTES do concessivoStart"; (b) 403 por role é inalcançável (todos os roles organizacionais têm `vacation:read`), substituído por 403 `NO_ACTIVE_ORGANIZATION`.

## Riscos conhecidos para homologação

- **R1** — Novo contratado recebe ciclo cujo concessivo é futuro. Frontend precisa UX tipo "disponível a partir de DD/MM/AAAA".
- **R2** — `getActiveCycle` usa `new Date()` mas `create` usa `startDate` como referenceDate. Ao mudar `startDate` no form, o ciclo mostrado pode divergir do que o BE vai snapshotar. Frontend deve recomputar ao mudar a data ou tratar o BE como fonte de verdade.
- **R3** — Registros legados com `acquisitionPeriodStart NULL` não entram no SUM de `daysUsed`. Auditoria de dados recomendada antes do deploy em prod se houver dados migrados.
- **R4** — Aritmética de datas é UTC; edge case de 3h de diferença BRT no dia exato de expiração do concessivo. Impacto baixo.

## Follow-up fora deste PR

- Convenção de schema 422 em endpoints da vacations usa `validationErrorSchema` (Zod validation) mesmo quando o erro real é `EmployeeTerminatedError` etc. Não introduzido aqui — convenção pré-existente em todo o controller. Refator cross-module sugerido em PR separada.
- Página de histórico dedicada no perfil do funcionário — fora de escopo, próxima iteração.

## Plano de integração

1. Merge em `preview` após CI verde.
2. FE PR em `synnerdata-web-n` (próxima entrega): regenera Kubb contra preview, ajusta `vacation-form.tsx` para consumir `/active-cycle`, trata riscos R1/R2.
3. Validação manual em homologação pelo cliente.
4. `preview` → `main` → deploy.

## Test plan

- [ ] CI passa
- [ ] Deploy preview OK
- [ ] Frontend regenera Kubb e passa no smoke test contra preview
- [ ] Validação manual em homologação pelo cliente cobrindo: novo contratado, funcionário com ciclo atual em uso, funcionário com ciclo vencido sem 30/30, tentativa de startDate fora do concessivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)