### PR TITLE
refactor(auth): consolidate auditXxx helpers via buildAuditEntry (CP-33)

### DIFF
--- a/docs/improvements/api-infrastructure-checklist.md
+++ b/docs/improvements/api-infrastructure-checklist.md
@@ -262,7 +262,7 @@ Seção específica do projeto. Começa pelo **status atual** da iniciativa (7.0
 | **0. Contexto aplicado** | ✅ Concluída | 2026-04-21 | Seções 7.1–7.3, 7.6, 7.7 preenchidas + convenção semântica + 10 débitos pré-audit |
 | **1. Audit item a item** | ✅ Concluída | 2026-04-21 | Status nas seções 4 e 5 preenchidos (~65 itens); 95 débitos totais em 7.7; relatório em [`docs/reports/2026-04-21-api-infrastructure-audit.md`](../reports/2026-04-21-api-infrastructure-audit.md) |
 | **2. Roadmap priorizado** | ✅ Concluída | 2026-04-21 | Seção 7.5 com 69 ações organizadas em 3 buckets (🔴 10 urgentes / 🟡 38 curto prazo / 🟢 21 sob demanda) com IDs, dependências, tipo e esforço |
-| **3. Execução** | 🔄 Em execução | 2026-04-22 | **Bucket 🔴 concluído (10/10)**. Bucket 🟡 **Ondas 1/2/3 quase completas + Onda 5 em andamento** (CP-1 XL + CP-4 L entregues). Total concluídas no 🟡: **25 CPs** (CP-1, CP-4, CP-7, CP-8, CP-9, CP-13, CP-20, CP-21, CP-22, CP-23, CP-24, CP-25, CP-27, CP-29, CP-30, CP-31, CP-34, CP-35, CP-36, CP-37, CP-39, CP-40, CP-42, CP-43, CP-45). Resta **CP-41** (Onda 3 PR-D). CP-4 quebra `lib/auth.ts` (856→339) + `plugins/auth/auth-plugin.ts` (396→79) em sub-arquivos focados. Remaining next-up: CP-26/28/32 (destravados por CP-1), CP-33 (destravado por CP-4), CP-5. Débito #96 100% endereçado. |
+| **3. Execução** | 🔄 Em execução | 2026-04-22 | **Bucket 🔴 concluído (10/10)**. Bucket 🟡 **Ondas 1/2/3 quase completas + Onda 5 em andamento** (CP-1 XL + CP-4 L + CP-33 S entregues). Total concluídas no 🟡: **26 CPs** (CP-1, CP-4, CP-7, CP-8, CP-9, CP-13, CP-20, CP-21, CP-22, CP-23, CP-24, CP-25, CP-27, CP-29, CP-30, CP-31, CP-33, CP-34, CP-35, CP-36, CP-37, CP-39, CP-40, CP-42, CP-43, CP-45). Resta **CP-41** (Onda 3 PR-D). CP-33 consolida 10 auditXxx em `buildAuditEntry(...)`. Remaining next-up: CP-26/28/32 (destravados por CP-1), CP-5. Débito #96 100% endereçado. |
 
 **➡️ Próxima ação:** **Bucket 🟡 — Onda 5** (Refactors XL/L) — decisão do dono em 2026-04-22 priorizar Onda 5 antes de fechar Onda 3. **Ordem revisada:**
 
@@ -553,7 +553,7 @@ Organizado em **5 PRs dedicados** (refactors grandes) + ações pontuais.
 |---|---|---|---|---|---|
 | **CP-31** | ✅ **2026-04-22** — `src/env.ts` passa a exportar `isDev` e `isTest` além do `isProduction` existente. 7 arquivos que liam `process.env.NODE_ENV` direto (`lib/errors/error-plugin.ts`, `lib/logger/index.ts`, `lib/auth.ts`, `payments/{checkout,admin-checkout,plan-change}/*.model.ts`) passam a importar de `@/env`. `error-plugin` usa `!isProduction` (semântica "dev+test") para preservar comportamento anterior de `!= "production"`. Zero usos diretos restantes fora de `env.ts`. | #26, #41 | refactor | S | — |
 | **CP-32** | `cron-plugin.ts` — refatorar 7 jobs duplicados via array declarativo ou helper `createCronJob({ name, pattern, handler })` | #46 | refactor | M | CP-1 |
-| **CP-33** | `auth.ts` helpers `auditXxx` duplicados — consolidar em `buildAuditEntry(...)` | #51 (parcial — resto em CP-4) | refactor | S | CP-4 |
+| **CP-33** | ✅ **2026-04-22** — `src/lib/auth/audit-helpers.ts` agora exporta `buildAuditEntry(params): AuditLogEntry` com shape tipado (`AuditAction`/`AuditResource` enums de `audit.model`) e conversão flat→nested (`before`/`after` params → `changes: { before, after }` no output). 10 wrappers `auditXxx` chamam `AuditService.log(buildAuditEntry({...}))` — shape centralizado, types apertados. Zero mudança de comportamento. | #51 | refactor | S | CP-4 |
 | **CP-34** | ✅ **2026-04-22** — Branded type `EncryptedString` aplicado em `lib/crypto/pii.ts`. `PII.encrypt` retorna `Promise<EncryptedString>`; `PII.decrypt` exige `EncryptedString`; `PII.isEncrypted` vira type guard. Sem mudança de runtime. | #47 | refactor | S | — |
 | **CP-35** | ✅ **2026-04-22** — Wrapper `withApiKeyNotFoundFallback(keyId, fn)` em `api-key.service.ts`. Elimina try/catch duplicado em `getById`, `revoke` e `delete`. Métodos perdem `async` (retornam a promise do wrapper direto). | #61 | refactor | S | — |
 | **CP-36** | ✅ **2026-04-22** — `POST /v1/public/newsletter/subscribe` não revela mais existência de email: duplicado ativo agora retorna 200 silencioso (no-op). Removido `ConflictError` + schema 409 do controller. Teste atualizado para verificar body idêntico em 1ª e 2ª subscribe. CLAUDE.md do módulo documenta anti-enumeration. | #62 | refactor | S | — |
@@ -1223,6 +1223,15 @@ A consultar via `context7` e docs oficiais quando surgir gap específico — **n
 ## 8. Changelog
 
 Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
+
+### 2026-04-22 — Onda 5 PR #3 entregue (CP-33): `buildAuditEntry` builder
+
+- **CP-33 (S) — consolidar 10 `auditXxx` em `buildAuditEntry(...)`** no `src/lib/auth/audit-helpers.ts`. Refactor puro, zero mudança de comportamento. Destravado por CP-4 (que colocou `audit-helpers.ts` no lugar).
+- **Builder tipado**: `buildAuditEntry(params): AuditLogEntry` aceita `{ action, resource, resourceId, userId, organizationId?, before?, after? }` flat e retorna entry no shape do `AuditService.log`. Conversão `before`/`after` → `changes: { before, after }` é condicional (só cria `changes` se algum dos dois presente — preserva comportamento do `auditLogin` sem `changes`).
+- **Types apertados**: params usa `AuditAction` / `AuditResource` enums importados de `@/modules/audit/audit.model` (eram strings soltas antes). Typo em action/resource agora pega na compilação.
+- **10 wrappers refatorados**: cada um chama `AuditService.log(buildAuditEntry({...}))`. Shape central single-source.
+- **Tests**: 164/164 afetados (`src/modules/auth/__tests__/`, `member-hooks`, `audit/__tests__/`) — paridade com baseline. Lint limpo.
+- **PR #3** da Onda 5 — branch `refactor/cp-33-build-audit-entry` (sem worktree, é S).
 
 ### 2026-04-22 — Onda 5 PR #2 entregue (CP-4): auth split
 

--- a/src/lib/auth/CLAUDE.md
+++ b/src/lib/auth/CLAUDE.md
@@ -5,7 +5,7 @@ Sub-arquivos internos usados por `src/lib/auth.ts` (entry-point do Better Auth).
 ## Estrutura
 
 - **`admin-helpers.ts`** — `getAdminEmails()` lê `env.SUPER_ADMIN_EMAILS` / `env.ADMIN_EMAILS`; `handleWelcomeEmail(user)` envia welcome com error-handling local. Chamadas por `databaseHooks.user.create.before` (via `applyAdminRolesBeforeUserCreate`) e por `emailVerification.afterEmailVerification`.
-- **`audit-helpers.ts`** — 10 funções `auditXxx` disparando `AuditService.log` com shape padronizado: `auditUserCreate`, `auditUserDelete`, `auditLogin`, `auditOrganizationCreate`/`Update`/`Delete`, `auditMemberAdd`/`Remove`/`RoleUpdate`, `auditInvitationAccept`. **CP-33** (S, próximo) vai consolidar em `buildAuditEntry(...)`.
+- **`audit-helpers.ts`** — `buildAuditEntry(params)` constrói `AuditLogEntry` tipado (enums `AuditAction`/`AuditResource`) a partir de params flat (`before`/`after` em vez de `changes: {...}`). 10 wrappers `auditXxx` chamam `AuditService.log(buildAuditEntry({...}))` — shape single-source: `auditUserCreate`, `auditUserDelete`, `auditLogin`, `auditOrganizationCreate`/`Update`/`Delete`, `auditMemberAdd`/`Remove`/`RoleUpdate`, `auditInvitationAccept`.
 - **`validators.ts`** — `validateUniqueRole(role, organizationId)` garante role única por org (checa `members` + invitations `pending`). Lança `APIError("BAD_REQUEST", ...)`.
 - **`hooks.ts`** — callbacks maiores dos hooks do Better Auth extraídos como funções nomeadas:
   - `sendPasswordResetForProvisionOrDefault({ user, url })` — roteia para fluxo de admin-provision ou reset padrão.

--- a/src/lib/auth/audit-helpers.ts
+++ b/src/lib/auth/audit-helpers.ts
@@ -1,29 +1,62 @@
+import type {
+  AuditAction,
+  AuditLogEntry,
+  AuditResource,
+} from "@/modules/audit/audit.model";
 import { AuditService } from "@/modules/audit/audit.service";
+
+type AuditEntryParams = {
+  action: AuditAction;
+  resource: AuditResource;
+  resourceId: string;
+  userId: string;
+  organizationId?: string | null;
+  before?: Record<string, unknown>;
+  after?: Record<string, unknown>;
+};
+
+export function buildAuditEntry(params: AuditEntryParams): AuditLogEntry {
+  const hasChanges = params.before !== undefined || params.after !== undefined;
+  return {
+    action: params.action,
+    resource: params.resource,
+    resourceId: params.resourceId,
+    userId: params.userId,
+    organizationId: params.organizationId,
+    changes: hasChanges
+      ? { before: params.before, after: params.after }
+      : undefined,
+  };
+}
 
 export async function auditUserCreate(user: {
   id: string;
   email: string;
 }): Promise<void> {
-  await AuditService.log({
-    action: "create",
-    resource: "user",
-    resourceId: user.id,
-    userId: user.id,
-    changes: { after: { id: user.id, email: user.email } },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "create",
+      resource: "user",
+      resourceId: user.id,
+      userId: user.id,
+      after: { id: user.id, email: user.email },
+    })
+  );
 }
 
 export async function auditUserDelete(user: {
   id: string;
   email: string;
 }): Promise<void> {
-  await AuditService.log({
-    action: "delete",
-    resource: "user",
-    resourceId: user.id,
-    userId: user.id,
-    changes: { before: { id: user.id, email: user.email } },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "delete",
+      resource: "user",
+      resourceId: user.id,
+      userId: user.id,
+      before: { id: user.id, email: user.email },
+    })
+  );
 }
 
 export async function auditLogin(session: {
@@ -31,55 +64,63 @@ export async function auditLogin(session: {
   userId: string;
   activeOrganizationId?: string | null;
 }): Promise<void> {
-  await AuditService.log({
-    action: "login",
-    resource: "session",
-    resourceId: session.id,
-    userId: session.userId,
-    organizationId: session.activeOrganizationId ?? null,
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "login",
+      resource: "session",
+      resourceId: session.id,
+      userId: session.userId,
+      organizationId: session.activeOrganizationId ?? null,
+    })
+  );
 }
 
 export async function auditOrganizationCreate(
   org: { id: string; name: string },
   userId: string
 ): Promise<void> {
-  await AuditService.log({
-    action: "create",
-    resource: "organization",
-    resourceId: org.id,
-    userId,
-    organizationId: org.id,
-    changes: { after: { id: org.id, name: org.name } },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "create",
+      resource: "organization",
+      resourceId: org.id,
+      userId,
+      organizationId: org.id,
+      after: { id: org.id, name: org.name },
+    })
+  );
 }
 
 export async function auditOrganizationUpdate(
   org: { id: string; name: string },
   userId: string
 ): Promise<void> {
-  await AuditService.log({
-    action: "update",
-    resource: "organization",
-    resourceId: org.id,
-    userId,
-    organizationId: org.id,
-    changes: { after: { id: org.id, name: org.name } },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "update",
+      resource: "organization",
+      resourceId: org.id,
+      userId,
+      organizationId: org.id,
+      after: { id: org.id, name: org.name },
+    })
+  );
 }
 
 export async function auditOrganizationDelete(
   org: { id: string; name: string },
   userId: string
 ): Promise<void> {
-  await AuditService.log({
-    action: "delete",
-    resource: "organization",
-    resourceId: org.id,
-    userId,
-    organizationId: org.id,
-    changes: { before: { id: org.id, name: org.name } },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "delete",
+      resource: "organization",
+      resourceId: org.id,
+      userId,
+      organizationId: org.id,
+      before: { id: org.id, name: org.name },
+    })
+  );
 }
 
 export async function auditMemberAdd(
@@ -87,20 +128,16 @@ export async function auditMemberAdd(
   organizationId: string,
   addedByUserId: string
 ): Promise<void> {
-  await AuditService.log({
-    action: "create",
-    resource: "member",
-    resourceId: member.id,
-    userId: addedByUserId,
-    organizationId,
-    changes: {
-      after: {
-        id: member.id,
-        userId: member.userId,
-        role: member.role,
-      },
-    },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "create",
+      resource: "member",
+      resourceId: member.id,
+      userId: addedByUserId,
+      organizationId,
+      after: { id: member.id, userId: member.userId, role: member.role },
+    })
+  );
 }
 
 export async function auditMemberRemove(
@@ -108,20 +145,16 @@ export async function auditMemberRemove(
   organizationId: string,
   removedByUserId: string
 ): Promise<void> {
-  await AuditService.log({
-    action: "delete",
-    resource: "member",
-    resourceId: member.id,
-    userId: removedByUserId,
-    organizationId,
-    changes: {
-      before: {
-        id: member.id,
-        userId: member.userId,
-        role: member.role,
-      },
-    },
-  });
+  await AuditService.log(
+    buildAuditEntry({
+      action: "delete",
+      resource: "member",
+      resourceId: member.id,
+      userId: removedByUserId,
+      organizationId,
+      before: { id: member.id, userId: member.userId, role: member.role },
+    })
+  );
 }
 
 export async function auditMemberRoleUpdate(params: {
@@ -131,17 +164,17 @@ export async function auditMemberRoleUpdate(params: {
   organizationId: string;
   updatedByUserId: string;
 }): Promise<void> {
-  await AuditService.log({
-    action: "update",
-    resource: "member",
-    resourceId: params.member.id,
-    userId: params.updatedByUserId,
-    organizationId: params.organizationId,
-    changes: {
+  await AuditService.log(
+    buildAuditEntry({
+      action: "update",
+      resource: "member",
+      resourceId: params.member.id,
+      userId: params.updatedByUserId,
+      organizationId: params.organizationId,
       before: { role: params.previousRole },
       after: { role: params.newRole },
-    },
-  });
+    })
+  );
 }
 
 export async function auditInvitationAccept(
@@ -149,19 +182,19 @@ export async function auditInvitationAccept(
   member: { id: string; userId: string },
   organizationId: string
 ): Promise<void> {
-  await AuditService.log({
-    action: "accept",
-    resource: "invitation",
-    resourceId: invitation.id,
-    userId: member.userId,
-    organizationId,
-    changes: {
+  await AuditService.log(
+    buildAuditEntry({
+      action: "accept",
+      resource: "invitation",
+      resourceId: invitation.id,
+      userId: member.userId,
+      organizationId,
       after: {
         invitationId: invitation.id,
         email: invitation.email,
         role: invitation.role,
         memberId: member.id,
       },
-    },
-  });
+    })
+  );
 }


### PR DESCRIPTION
## Summary

**CP-33 (Onda 5 PR #3)** — Consolida os 10 helpers `auditXxx` em `src/lib/auth/audit-helpers.ts` usando um builder tipado `buildAuditEntry(...)`. Refactor puro, zero mudança de comportamento. Destravado pelo merge de CP-4 (`#258`).

- Issue referenciada: #51
- Size: S (single file, ~100 linhas mudadas)

## Mudanças

### `buildAuditEntry(params): AuditLogEntry`

Novo builder no topo de `audit-helpers.ts`:

```ts
type AuditEntryParams = {
  action: AuditAction;           // enum — era string solto antes
  resource: AuditResource;       // enum — era string solto antes
  resourceId: string;
  userId: string;
  organizationId?: string | null;
  before?: Record<string, unknown>;
  after?: Record<string, unknown>;
};

export function buildAuditEntry(params: AuditEntryParams): AuditLogEntry {
  const hasChanges = params.before !== undefined || params.after !== undefined;
  return {
    action: params.action,
    resource: params.resource,
    resourceId: params.resourceId,
    userId: params.userId,
    organizationId: params.organizationId,
    changes: hasChanges ? { before: params.before, after: params.after } : undefined,
  };
}
```

### Wrappers refatorados (10)

Cada um agora chama `AuditService.log(buildAuditEntry({...}))` com params flat em vez de construir `changes: { before/after: {...} }` inline. Exemplos:

**Antes:**
```ts
await AuditService.log({
  action: "create",
  resource: "user",
  resourceId: user.id,
  userId: user.id,
  changes: { after: { id: user.id, email: user.email } },
});
```

**Depois:**
```ts
await AuditService.log(
  buildAuditEntry({
    action: "create",
    resource: "user",
    resourceId: user.id,
    userId: user.id,
    after: { id: user.id, email: user.email },
  })
);
```

## Ganhos

1. **Shape single-source**: qualquer novo campo em `AuditLogEntry` (ex: `ipAddress`, `userAgent`) só precisa ser adicionado em um lugar.
2. **Types apertados**: `AuditAction` / `AuditResource` agora são enums importados de `@/modules/audit/audit.model`. Typo em action/resource pega na compilação.
3. **Conversão flat→nested centralizada**: `{ before, after }` viram `changes: { before, after }` condicionalmente num único lugar. Preserva comportamento do `auditLogin` (sem `changes` field).

## Fora de escopo (deliberado)

- **`buildAuditChanges` de `src/modules/audit/pii-redaction.ts`** (CP-42): os wrappers de auth **não** usam esse helper. Aplicá-lo redigiria `email` no audit log (mudaria comportamento). Fica para follow-up se alinharmos que auth logs também devem passar por PII redaction.
- Outros call-sites de `AuditService.log(...)` fora de `lib/auth/` (employees, medical-certificates, etc) não são tocados — eles já usam `buildAuditChanges` do módulo de audit.

## Test plan

- [x] `NODE_ENV=test bun test --env-file .env.test src/modules/auth/__tests__/ src/modules/organizations/__tests__/member-hooks.test.ts src/modules/audit/__tests__/` → **164/164 pass** (paridade com baseline pré-refactor)
- [x] `npx ultracite check src/lib/auth/audit-helpers.ts` → **0 issues**

🤖 Generated with [Claude Code](https://claude.com/claude-code)