### PR TITLE
refactor(lib): ErrorReporter wrapper closes CP-6 testability debt

### DIFF
--- a/docs/improvements/api-infrastructure-checklist.md
+++ b/docs/improvements/api-infrastructure-checklist.md
@@ -1225,6 +1225,18 @@ A consultar via `context7` e docs oficiais quando surgir gap específico — **n
 
 Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
 
+### 2026-04-23 — Onda 5 PR #7 entregue (CP-6 follow-up): `ErrorReporter` wrapper fecha débito de testabilidade
+
+- **Follow-up explícito** do débito declarado no corpo de PR #263 (CP-6, commit `947ae4d`): a chamada `captureException(error, { tags })` dentro do catch do `webhook.service.ts` não tinha teste unitário porque `spyOn` / `mock.module` em named import ESM não intercepta a const local já capturada no load do módulo.
+- **Solução (Opção A — wrapper)**: novo `src/lib/error-reporter.ts` expõe `ErrorReporter.capture(error, context?)` wrapping `captureException` do `@sentry/bun` diretamente. Consumers chamam `ErrorReporter.capture(...)` — property access em objeto compartilhado, trivialmente mockável via `spyOn(ErrorReporter, "capture")`.
+- **Migração de 3 callsites** (todos os consumers de `captureException` em código de produção): `webhook.service.ts:134` (catch do webhook), `error-plugin.ts:63` (5xx AppError branch), `error-plugin.ts:105` (unhandled error branch). `src/lib/sentry.ts` perdeu o re-export de `captureException` e virou puramente side-effect (init com `beforeSend` PII-stripping); `index.ts` continua importando via `import "@/lib/sentry"`.
+- **2 novos tests** (`webhook.error-escalation.test.ts`):
+  - (a) `ErrorReporter.capture` invocada com `(error, { tags: { webhook_event_type, pagarme_event_id } })` quando handler do webhook rejeita
+  - (b) DB `subscription_events.error` persiste a mensagem + `processedAt` fica null + promise rejeita upstream (anti-regressão contra silent swallow)
+- **Suite**: 63 → 65 tests em `webhook/__tests__/`. Full payments suite permanece 448/448.
+- **Por que é Opção A (wrapper) e não B (DI) ou C (@sentry/testing) ou D (preload global)**: wrapper é o caminho de menor custo que destrava testabilidade em **todos os 3 callsites** de uma vez, sem poluir signatures (DI) ou alterar config global de tests (preload). Futuros call sites de reporte de erro usam a mesma API.
+- **PR #7** da Onda 5 — branch simples `refactor/cp-6-error-reporter` (sem worktree, é S).
+
 ### 2026-04-22 — Onda 5 PR #6 entregue (CP-6): webhook Pagar.me hardening
 
 - **CP-6 (M)** — escopo **reframado** após research das docs Pagar.me v5. 3 commits atômicos; branch simples (S/M, sem worktree).

--- a/src/lib/error-reporter.ts
+++ b/src/lib/error-reporter.ts
@@ -1,0 +1,12 @@
+import { captureException } from "@sentry/bun";
+
+type CaptureContext = {
+  tags?: Record<string, string>;
+  extra?: Record<string, unknown>;
+};
+
+export const ErrorReporter = {
+  capture(error: unknown, context?: CaptureContext): string {
+    return captureException(error, context);
+  },
+};

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,4 +1,4 @@
-import { init, captureException as sentryCaptureException } from "@sentry/bun";
+import { init } from "@sentry/bun";
 import { env, isProduction } from "@/env";
 
 const dsn = env.SENTRY_DSN;
@@ -17,5 +17,3 @@ if (dsn) {
     },
   });
 }
-
-export const captureException = sentryCaptureException;

--- a/src/modules/payments/webhook/__tests__/webhook.error-escalation.test.ts
+++ b/src/modules/payments/webhook/__tests__/webhook.error-escalation.test.ts
@@ -1,7 +1,10 @@
-import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { env } from "@/env";
+import { ErrorReporter } from "@/lib/error-reporter";
 import { logger } from "@/lib/logger";
+import { SubscriptionService } from "@/modules/payments/subscription/subscription.service";
 import { WebhookService } from "@/modules/payments/webhook/webhook.service";
+import { WebhookPayloadBuilder } from "@/test/builders/webhook-payload.builder";
 
 function createValidAuthHeader(): string {
   const credentials = `${env.PAGARME_WEBHOOK_USERNAME}:${env.PAGARME_WEBHOOK_PASSWORD}`;
@@ -65,6 +68,99 @@ describe("WebhookService error escalation", () => {
       expect(row).toBeDefined();
       expect(row.processedAt).not.toBeNull();
       expect(row.error).toBeNull();
+    });
+  });
+
+  describe("ErrorReporter escalation on handler failure", () => {
+    let captureSpy: ReturnType<typeof spyOn<typeof ErrorReporter, "capture">>;
+
+    beforeEach(() => {
+      captureSpy = spyOn(ErrorReporter, "capture").mockImplementation(
+        () => "mock-sentry-id"
+      );
+      captureSpy.mockClear();
+    });
+
+    test("invokes ErrorReporter.capture with tags { webhook_event_type, pagarme_event_id } when handler throws", async () => {
+      const failure = new Error("handler exploded");
+      const originalMarkActive = SubscriptionService.markActive;
+      const stubbedMarkActive = mock(() => Promise.reject(failure));
+      (
+        SubscriptionService as unknown as {
+          markActive: typeof SubscriptionService.markActive;
+        }
+      ).markActive =
+        stubbedMarkActive as unknown as typeof SubscriptionService.markActive;
+
+      const payload = new WebhookPayloadBuilder()
+        .chargePaid()
+        .withOrganizationId("org-forcing-markActive")
+        .build();
+
+      try {
+        await expect(
+          WebhookService.process(payload, createValidAuthHeader())
+        ).rejects.toThrow("handler exploded");
+
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+        const [capturedError, context] = captureSpy.mock.calls[0];
+        expect(capturedError).toBe(failure);
+        expect(context).toMatchObject({
+          tags: {
+            webhook_event_type: "charge.paid",
+            pagarme_event_id: payload.id,
+          },
+        });
+      } finally {
+        (
+          SubscriptionService as unknown as {
+            markActive: typeof SubscriptionService.markActive;
+          }
+        ).markActive = originalMarkActive;
+      }
+    });
+
+    test("still persists the error message to subscription_events.error and rethrows", async () => {
+      const failure = new Error("transient DB timeout");
+      const originalMarkPastDue = SubscriptionService.markPastDue;
+      const stubbedMarkPastDue = mock(() => Promise.reject(failure));
+      (
+        SubscriptionService as unknown as {
+          markPastDue: typeof SubscriptionService.markPastDue;
+        }
+      ).markPastDue =
+        stubbedMarkPastDue as unknown as typeof SubscriptionService.markPastDue;
+
+      const payload = new WebhookPayloadBuilder()
+        .chargePaymentFailed()
+        .withOrganizationId("org-forcing-markPastDue")
+        .build();
+
+      try {
+        await expect(
+          WebhookService.process(payload, createValidAuthHeader())
+        ).rejects.toThrow("transient DB timeout");
+
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+
+        const { db } = await import("@/db");
+        const { schema } = await import("@/db/schema");
+        const { eq } = await import("drizzle-orm");
+        const [row] = await db
+          .select()
+          .from(schema.subscriptionEvents)
+          .where(eq(schema.subscriptionEvents.pagarmeEventId, payload.id))
+          .limit(1);
+
+        expect(row.error).toBe("transient DB timeout");
+        expect(row.processedAt).toBeNull();
+      } finally {
+        (
+          SubscriptionService as unknown as {
+            markPastDue: typeof SubscriptionService.markPastDue;
+          }
+        ).markPastDue = originalMarkPastDue;
+      }
     });
   });
 });

--- a/src/modules/payments/webhook/webhook.service.ts
+++ b/src/modules/payments/webhook/webhook.service.ts
@@ -3,8 +3,8 @@ import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { env } from "@/env";
+import { ErrorReporter } from "@/lib/error-reporter";
 import { logger } from "@/lib/logger";
-import { captureException } from "@/lib/sentry";
 import { WebhookValidationError } from "@/modules/payments/errors";
 import { PaymentHooks } from "@/modules/payments/hooks";
 import { SubscriptionService } from "@/modules/payments/subscription/subscription.service";
@@ -131,7 +131,7 @@ export abstract class WebhookService {
         .set({ processedAt: new Date() })
         .where(eq(schema.subscriptionEvents.id, eventId));
     } catch (error) {
-      captureException(error, {
+      ErrorReporter.capture(error, {
         tags: {
           webhook_event_type: payload.type,
           pagarme_event_id: payload.id,

--- a/src/plugins/errors/error-plugin.ts
+++ b/src/plugins/errors/error-plugin.ts
@@ -1,9 +1,9 @@
 import { Elysia } from "elysia";
 import { isProduction } from "@/env";
+import { ErrorReporter } from "@/lib/error-reporter";
 import { AppError } from "@/lib/errors/base-error";
 import { logger } from "@/lib/logger";
 import { getRequestId } from "@/lib/request-context";
-import { captureException } from "@/lib/sentry";
 
 const isDev = !isProduction;
 
@@ -60,7 +60,7 @@ export const errorPlugin = new Elysia({ name: "error-handler" })
 
     if (error instanceof AppError) {
       if (error.status >= 500) {
-        captureException(error);
+        ErrorReporter.capture(error);
         const pathname = new URL(request.url).pathname;
         logger.error(
           {
@@ -102,7 +102,7 @@ export const errorPlugin = new Elysia({ name: "error-handler" })
       };
     }
 
-    captureException(error);
+    ErrorReporter.capture(error);
 
     const errorDetail = formatErrorDetail(error);
     const pathname = new URL(request.url).pathname;


### PR DESCRIPTION
## Summary

Follow-up explícito do débito declarado em [PR #263 (CP-6)](https://github.com/tlthiago/synnerdata-api-b/pull/263): a chamada `captureException(error, { tags })` dentro do catch do webhook não tinha teste unitário porque `spyOn` / `mock.module` em named import ESM não intercepta a const local já capturada no load do módulo.

3 commits atômicos, 979/979 tests verdes (zero regressão), 2 tests novos que agora cobrem o caminho de escalation.

## Solução — Opção A (wrapper)

Das 4 opções apresentadas no debate da PR anterior:

| Opção | Custo | Decisão |
|---|---|---|
| **A — ErrorReporter wrapper** | 1 arquivo novo, 3 imports trocados | ✅ **Escolhida** |
| B — Dependency injection no service | Signature cresce em cada consumer | Rejeitada: não escala pra 3+ callsites |
| C — `@sentry/testing` transport | Config Sentry em test env, mais acoplamento | Overkill |
| D — Bun preload global | Mock de Sentry em TODOS os tests | Política global indesejável |

Wrapper é o caminho de menor custo que destrava testabilidade em **todos os 3 callsites de `captureException`** de uma vez, sem poluir signatures ou alterar config global.

## Por que `spyOn` agora funciona

Antes:
```ts
// webhook.service.ts
import { captureException } from "@/lib/sentry";
// ...
captureException(error, { tags });  // const local capturada no module load
```
`spyOn(sentry, "captureException")` substitui a propriedade do módulo, mas a const local já tinha a referência ao valor original. Binding morto.

Agora:
```ts
// webhook.service.ts
import { ErrorReporter } from "@/lib/error-reporter";
// ...
ErrorReporter.capture(error, { tags });  // property access em objeto compartilhado
```
`spyOn(ErrorReporter, "capture")` substitui a propriedade do objeto `ErrorReporter` — quando o consumer faz `ErrorReporter.capture(...)`, o lookup da propriedade acontece no momento da chamada, pegando a versão spyada.

## Escopo entregue

### Commit 1 — `53eeaaa` · `refactor(lib): introduce ErrorReporter wrapper`

- **`src/lib/error-reporter.ts` novo** — expõe `ErrorReporter.capture(error, context?)` wrapping `captureException` do `@sentry/bun` direto
- **`src/lib/sentry.ts`** perde o re-export de `captureException` e vira puramente side-effect (init com `beforeSend` PII-stripping). `index.ts` continua importando via `import \"@/lib/sentry\"`
- **3 callsites migrados** (todos os consumers de `captureException` em código de produção):
  - `src/modules/payments/webhook/webhook.service.ts:134` — catch do webhook processor
  - `src/plugins/errors/error-plugin.ts:63` — 5xx AppError branch do onError global
  - `src/plugins/errors/error-plugin.ts:105` — unhandled error branch do onError global

### Commit 2 — `e47e131` · `test(webhook): assert ErrorReporter.capture invocation`

2 novos tests em `webhook.error-escalation.test.ts`:

1. **ErrorReporter.capture é chamada com tags corretas** quando handler do webhook rejeita — stub de `SubscriptionService.markActive` force o catch path, assert `(error, { tags: { webhook_event_type, pagarme_event_id } })`
2. **Persistência e rethrow preservados** — stub de `markPastDue`, verifica `subscription_events.error` tem a mensagem, `processedAt` fica null, promise rejeita upstream (anti-regressão contra silent swallow)

### Commit 3 — `50cfcbc` · `docs(infra): log CP-6 follow-up`

Seção 8 Changelog: entrada 2026-04-23 \"Onda 5 PR #7 entregue (CP-6 follow-up)\" com full delivery notes + racional da Opção A vs B/C/D.

## Test plan

- [x] `bunx tsc --noEmit` limpo após cada commit
- [x] `npx ultracite check` limpo (pre-commit hook validou os 3 commits)
- [x] Webhook suite: 63 (CP-6 baseline) → **65 tests** (+2 do Sentry escalation)
- [x] Full payments + error-plugin suite: **979/979 tests** em 79 arquivos — zero regressão
- [ ] Suite completa via CI na PR

## Mudanças aos arquivos

| Arquivo | Natureza |
|---|---|
| `src/lib/error-reporter.ts` | novo — API `ErrorReporter.capture` |
| `src/lib/sentry.ts` | remove re-export de `captureException`; fica só init |
| `src/modules/payments/webhook/webhook.service.ts` | troca import e callsite |
| `src/plugins/errors/error-plugin.ts` | troca import e 2 callsites |
| `src/modules/payments/webhook/__tests__/webhook.error-escalation.test.ts` | +2 tests cobrindo Sentry escalation |
| `docs/improvements/api-infrastructure-checklist.md` | entrada na seção 8 |

## Rubrica arquitetural preservada

- **\"No re-exports or barrel files\"** (CLAUDE.md): `ErrorReporter` não é barrel/re-export — é um wrapper consciente com 1 nível de indireção que adiciona valor (testabilidade)
- **`src/lib/`** convention firmada em CP-1: util puro, não Elysia instance — `error-reporter.ts` cabe aqui
- **`src/lib/sentry.ts` agora é side-effect-only** — alinhado com a rubrica de \"side-effect inits ficam em lib/\"

## Referências

- Independente (nenhuma dep sobre outros CPs)
- Onda 5 PR #7 — continua #257 (CP-1), #258 (CP-4), #260 (CP-33), #261 (CP-26+28+32), #262 (CP-5), #263 (CP-6)
- Não é novo CP no 7.5 — fecha débito inline declarado na PR #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)