### PR TITLE
refactor(vacations): history-based cycle model + rename endpoint to /next-cycle

### DIFF
--- a/src/modules/employees/__tests__/last-acquisition-period.test.ts
+++ b/src/modules/employees/__tests__/last-acquisition-period.test.ts
@@ -1,6 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { env } from "@/env";
-import { computePeriodsFromHireDate } from "@/modules/occurrences/vacations/period-calculation";
 import { VacationService } from "@/modules/occurrences/vacations/vacation.service";
 import { createTestApp, type TestApp } from "@/test/helpers/app";
 import { createTestEmployee } from "@/test/helpers/employee";
@@ -55,8 +54,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-02-01",
-      endDate: "2027-02-10",
+      startDate: "2026-02-01",
+      endDate: "2026-02-10",
       daysEntitled: 10,
     });
 
@@ -69,14 +68,9 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // The service computes periods using hireDate + vacation's startDate as reference.
-    const expected = computePeriodsFromHireDate(
-      "2025-01-01",
-      new Date("2027-02-01T00:00:00Z") // vacation startDate
-    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
-      start: expected.acquisitionPeriodStart,
-      end: expected.acquisitionPeriodEnd,
+      start: "2025-01-01",
+      end: "2025-12-31",
     });
   });
 
@@ -96,8 +90,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-03-01",
-      endDate: "2027-03-10",
+      startDate: "2025-03-01",
+      endDate: "2025-03-10",
       daysEntitled: 10,
     });
 
@@ -105,8 +99,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-04-01",
-      endDate: "2027-04-10",
+      startDate: "2025-04-01",
+      endDate: "2025-04-10",
       daysEntitled: 10,
     });
 
@@ -119,15 +113,9 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // The service computes each vacation's periods independently using its own startDate.
-    // getLastAcquisitionPeriod returns the one with the latest acquisitionPeriodEnd.
-    const secondPeriods = computePeriodsFromHireDate(
-      "2024-01-01",
-      new Date("2027-04-01T00:00:00Z") // second vacation startDate
-    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
-      start: secondPeriods.acquisitionPeriodStart,
-      end: secondPeriods.acquisitionPeriodEnd,
+      start: "2024-01-01",
+      end: "2024-12-31",
     });
   });
 
@@ -147,8 +135,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-05-01",
-      endDate: "2027-05-10",
+      startDate: "2025-05-01",
+      endDate: "2025-05-10",
       daysEntitled: 10,
     });
 
@@ -156,8 +144,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-06-01",
-      endDate: "2027-06-10",
+      startDate: "2025-06-01",
+      endDate: "2025-06-10",
       daysEntitled: 10,
     });
 
@@ -172,14 +160,9 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // Second vacation was deleted, so the last remaining period is from the first vacation.
-    const firstPeriods = computePeriodsFromHireDate(
-      "2024-01-01",
-      new Date("2027-05-01T00:00:00Z") // first vacation startDate
-    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
-      start: firstPeriods.acquisitionPeriodStart,
-      end: firstPeriods.acquisitionPeriodEnd,
+      start: "2024-01-01",
+      end: "2024-12-31",
     });
   });
 
@@ -199,8 +182,8 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-07-01",
-      endDate: "2027-07-10",
+      startDate: "2025-07-01",
+      endDate: "2025-07-10",
       daysEntitled: 10,
       status: "canceled",
     });
@@ -214,13 +197,9 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    const periods = computePeriodsFromHireDate(
-      "2024-01-01",
-      new Date("2027-07-01T00:00:00Z") // vacation startDate
-    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
-      start: periods.acquisitionPeriodStart,
-      end: periods.acquisitionPeriodEnd,
+      start: "2024-01-01",
+      end: "2024-12-31",
     });
   });
 
@@ -287,14 +266,12 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
       })
     );
 
-    // Create vacation — the service now computes periods using hireDate + vacation's
-    // startDate as reference, ignoring the manual seed.
     await createTestVacation({
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2027-08-01",
-      endDate: "2027-08-10",
+      startDate: "2025-08-01",
+      endDate: "2025-08-10",
       daysEntitled: 10,
     });
 
@@ -307,15 +284,9 @@ describe("GET /v1/employees/:id — lastAcquisitionPeriod", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // The vacation's periods are computed from hireDate + vacation's startDate,
-    // not from the manual seed. The vacation's period takes priority over the manual seed.
-    const vacationPeriods = computePeriodsFromHireDate(
-      "2024-01-01",
-      new Date("2027-08-01T00:00:00Z") // vacation startDate
-    );
     expect(body.data.lastAcquisitionPeriod).toEqual({
-      start: vacationPeriods.acquisitionPeriodStart,
-      end: vacationPeriods.acquisitionPeriodEnd,
+      start: "2024-01-01",
+      end: "2024-12-31",
     });
   });
 });

--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -1,26 +1,29 @@
 # Vacations (Ferias)
 
-Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias, baseado no modelo de **ciclo ativo**.
+Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias, baseado em **histórico de cadastros** (next cycle derivation).
 
 ## Business Rules
 
 - `startDate` deve ser <= `endDate`
 - Nenhuma data das ferias pode ser anterior a data de admissao do funcionario (`hireDate`): `startDate`, `endDate`. (Os periodos aquisitivo/concessivo sao computados a partir do `hireDate`, portanto sempre posteriores por construcao.)
 - `daysEntitled` deve corresponder exatamente ao intervalo de datas (`endDate - startDate + 1`), validado via `calculateDaysBetween` no service
-- **Soma de `daysEntitled` por aquisitivo nao pode exceder 30 dias** (CLT art. 130). Validado no service via `ensureAquisitivoLimit` considerando todos os registros nao-cancelados e nao-deletados do mesmo employee no mesmo `acquisition_period_start`. Aplicado em create (usando periodos do ciclo ativo) e update (usando o snapshot armazenado, excluindo o proprio registro). Registros com `status = canceled` ou `deletedAt != null` nao contam.
+- **Soma de `daysEntitled` por aquisitivo nao pode exceder 30 dias** (CLT art. 130). Validado no service via `ensureAquisitivoLimit` considerando todos os registros nao-cancelados e nao-deletados do mesmo employee no mesmo `acquisition_period_start`. Aplicado em create (usando periodos do proximo ciclo) e update (usando o snapshot armazenado, excluindo o proprio registro). Registros com `status = canceled` ou `deletedAt != null` nao contam.
 - `daysUsed` deve ser >= 0 e <= `daysEntitled`
 - Periodos aquisitivo e concessivo: campos inline na tabela `vacations` (nao entidade separada)
   - `acquisitionPeriodStart` / `acquisitionPeriodEnd` / `concessivePeriodStart` / `concessivePeriodEnd`
-  - **Calculados pelo backend** via `computeActiveCycle` (helper em `src/modules/occurrences/vacations/period-calculation.ts`), que resolve o ciclo ativo do funcionario no momento da criacao.
-  - **Regra do ciclo ativo**: o sistema sempre apresenta o **primeiro ciclo** (do mais antigo ao mais recente) que satisfaz `daysUsed < 30` **E** `concessivePeriodEnd >= referenceDate`.
-    - Ciclos com concessivo vencido **E** `daysUsed < 30` sao **silenciosamente pulados** (considera-se que o cliente ja fez o pagamento de multa externamente fora do sistema).
-    - **Novos contratados** (< 1 aniversario completado) **nao sao mais bloqueados** — podem agendar ferias futuras desde que `startDate` esteja dentro do concessivo do 1o ciclo. `computePeriodsFromHireDate` retorna o ciclo 1 com `completed = 0` nesse caso (nao lanca mais erro).
-    - `computeActiveCycle` nunca retorna um ciclo sem dias disponiveis ou com concessivo vencido — esses cenarios sao tratados como `VacationActiveCycleUnresolvableError` (defensivo, nao deve ocorrer com dados reais dentro do `SAFETY_BOUND_MONTHS = 24`).
-  - **`startDate` obrigatoriamente dentro do concessivo do ciclo ativo** — caso contrario lanca `VacationStartDateOutsideConcessiveError` (422). Essa validacao substitui o antigo `VacationNoRightsError` para novos contratados.
-  - **Nao considera seed manual** no employee — tudo eh derivado de `hireDate` + `daysEntitled` das ferias existentes no mesmo aquisitivo. Suporte a ferias fracionadas (multiplos registros no mesmo aquisitivo) ja eh considerado pelo `computeActiveCycle` via soma de `daysEntitled` por `acquisitionPeriodStart`.
+  - **Calculados pelo backend** via `resolveNextCycle` (helper em `src/modules/occurrences/vacations/period-calculation.ts`), que resolve o próximo ciclo a ser cadastrado **com base no histórico de férias já registradas** — não há dependência do tempo atual.
+  - **Regra do próximo ciclo**:
+    - **Sem histórico** (funcionário ainda não tem férias cadastradas no sistema): retorna o **ciclo 1** — aquisitivo começa em `hireDate`, termina em `hireDate + 12 meses - 1 dia`. Concessivo imediatamente após.
+    - **Com histórico**: identifica o maior `acquisitionPeriodStart` registrado:
+      - Se `daysUsed < 30` nesse aquisitivo → retorna o **mesmo ciclo** (ainda tem saldo a cadastrar).
+      - Se `daysUsed === 30` → retorna o **próximo ciclo contíguo** (`lastAquisitivoStart + 12 meses`).
+    - Não há silent skip de ciclos vencidos — a sequência é contíguamente derivada do histórico.
+  - **`startDate` obrigatoriamente dentro do concessivo do ciclo retornado** — caso contrário lança `VacationStartDateOutsideConcessiveError` (422). Válido para cadastros retroativos (concessivo no passado), vigentes (concessivo contém hoje) e agendados (concessivo no futuro).
+  - **Exemplo — empresa migrando**: funcionário admitido em 15/02/2019, sem férias cadastradas → primeiro cadastro cai no ciclo 1 (aquisitivo 15/02/2019-14/02/2020). Depois de completar 30 dias nesse ciclo → próximo cadastro cai no ciclo 2 (aquisitivo 15/02/2020-14/02/2021). Assim sucessivamente até chegar ao ciclo atual. O RH preserva a história da organização no sistema.
+  - Suporte a ferias fracionadas (multiplos registros no mesmo aquisitivo) já é considerado por `resolveNextCycle` via soma de `daysEntitled` por `acquisitionPeriodStart`.
   - Regra CLT: aquisitivo = 12 meses; concessivo = 12 meses apos o fim do aquisitivo.
   - **Read-only na API**: removidos dos schemas Zod de create/update. Enviados no payload sao silenciosamente stripados. Frontend exibe em DatePickers desabilitados.
-  - **Snapshot historico do ciclo ativo** no momento da criacao — updates preservam os valores (nao recalculam). No `update()`, `validateDatesNotBeforeHire` ainda eh aplicado para registros legados cujo snapshot pode preceder as novas regras.
+  - **Snapshot histórico** do ciclo resolvido no momento da criação — updates preservam os valores (não recalculam). No `update()`, `validateDatesNotBeforeHire` ainda é aplicado para registros legados.
 - `daysEntitled`: dias (calculado pelo frontend como endDate - startDate + 1, sem default)
 - Overlap check no create/update: mesmo employee + datas sobrepostas (excluindo ferias canceladas) lanca `VacationOverlapError`
 - Employee nao pode estar desligado no create (`ensureEmployeeNotTerminated` -- ON_VACATION e esperado/permitido)
@@ -46,19 +49,19 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 
 ## Fields
 
-- `startDate`, `endDate` (datas das ferias — obrigatoriamente dentro do concessivo do ciclo ativo no momento do create)
-- `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **snapshot do ciclo ativo** resolvido pelo backend no create, read-only na API, presente na response)
-- `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **snapshot do ciclo ativo** resolvido pelo backend no create, read-only na API, presente na response)
+- `startDate`, `endDate` (datas das ferias — obrigatoriamente dentro do concessivo do proximo ciclo no momento do create)
+- `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **snapshot do proximo ciclo** resolvido pelo backend no create, read-only na API, presente na response)
+- `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **snapshot do proximo ciclo** resolvido pelo backend no create, read-only na API, presente na response)
 - `daysEntitled` (inteiro, 1 a 30 conforme CLT art. 130, obrigatorio, sem default)
 - `daysUsed` (inteiro)
 - `notes` (opcional)
 
 ## Endpoints
 
-- `POST /v1/vacations` — cria ferias. Resolve o ciclo ativo do employee e grava snapshot dos periodos aquisitivo/concessivo.
+- `POST /v1/vacations` — cria ferias. Resolve o proximo ciclo do employee e grava snapshot dos periodos aquisitivo/concessivo.
 - `GET /v1/vacations` — lista todas as ferias da organizacao.
 - `GET /v1/vacations/employee/:employeeId` — lista historico completo de ferias do employee.
-- `GET /v1/vacations/employee/:employeeId/active-cycle` — retorna o ciclo ativo atual do employee. Response:
+- `GET /v1/vacations/employee/:employeeId/next-cycle` — retorna o próximo ciclo de férias a ser cadastrado para o employee, baseado no histórico de férias registradas. Response:
   ```json
   {
     "acquisitionPeriodStart": "YYYY-MM-DD",
@@ -69,7 +72,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
     "daysRemaining": 30
   }
   ```
-  Usado pelo frontend para preencher os DatePickers desabilitados e mostrar o saldo disponivel antes da criacao.
+  Usado pelo frontend para preencher os DatePickers desabilitados e mostrar o saldo disponivel antes da criacao (ciclo 1 quando o funcionário não possui histórico, ou próximo contíguo ao último registrado).
 - `GET /v1/vacations/:id` — detalha uma ferias.
 - `PUT /v1/vacations/:id` — atualiza ferias. **Preserva o snapshot** dos periodos aquisitivo/concessivo; aplica `validateDatesNotBeforeHire` (para registros legados).
 - `DELETE /v1/vacations/:id` — soft delete.
@@ -83,9 +86,8 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `VacationInvalidDaysError` (422) -- daysEntitled != intervalo de datas, ou daysUsed > daysEntitled
 - `VacationDateBeforeHireError` (422) -- qualquer data anterior a hireDate do funcionario
 - `VacationAquisitivoExceededError` (422) -- soma de `daysEntitled` no aquisitivo excederia 30 dias. Details: `{ acquisitionPeriodStart, acquisitionPeriodEnd, currentTotal, requestedDays, daysRemaining, maxAllowed: 30 }`.
-- `VacationStartDateOutsideConcessiveError` (422) -- `startDate` fora do concessivo do ciclo ativo. Details: `{ startDate, concessivePeriodStart, concessivePeriodEnd }`. Substitui a antiga regra que bloqueava novos contratados.
-- `VacationActiveCycleUnresolvableError` (500) -- defensivo, **nao alcancavel com dados reais**. Lancado por `computeActiveCycle` se nenhum ciclo viavel for encontrado dentro do `SAFETY_BOUND_MONTHS = 24`. Details: `{ hireDate, referenceDate }`.
-- `VacationNoRightsError` (422) -- **legacy, nao mais lancado em producao**. Mantido no arquivo `errors.ts` para compatibilidade retroativa (codigos de erro ja expostos em integracoes / historicos). Novos contratados agora agendam ferias futuras livremente via ciclo ativo.
+- `VacationStartDateOutsideConcessiveError` (422) -- `startDate` fora do concessivo do proximo ciclo. Details: `{ startDate, concessivePeriodStart, concessivePeriodEnd }`. Substitui a antiga regra que bloqueava novos contratados.
+- `VacationNoRightsError` (422) -- **legacy, nao mais lancado em producao**. Mantido no arquivo `errors.ts` para compatibilidade retroativa (codigos de erro ja expostos em integracoes / historicos). Novos contratados agora agendam ferias futuras livremente via proximo ciclo.
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)
 - `EmployeeTerminatedError` (422) -- shared, from `src/modules/employees/errors.ts`
 

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -200,8 +200,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2025-01-01",
-          endDate: "2025-01-15",
+          startDate: "2021-01-01",
+          endDate: "2021-01-15",
           daysEntitled: 15,
           daysUsed: 10,
           status: "scheduled",
@@ -253,8 +253,8 @@ describe("POST /v1/vacations", () => {
         },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2025-02-01",
-          endDate: "2025-02-15",
+          startDate: "2021-02-01",
+          endDate: "2021-02-15",
           daysEntitled: 15,
           daysUsed: 0,
         }),
@@ -284,8 +284,8 @@ describe("POST /v1/vacations", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2025-03-01",
-      endDate: "2025-03-15",
+      startDate: "2021-03-01",
+      endDate: "2021-03-15",
       daysUsed: 0,
       status: "scheduled",
     });
@@ -296,8 +296,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2025-03-10",
-          endDate: "2025-03-20",
+          startDate: "2021-03-10",
+          endDate: "2021-03-20",
           daysEntitled: 11,
           daysUsed: 0,
         }),
@@ -325,8 +325,8 @@ describe("POST /v1/vacations", () => {
       organizationId,
       userId: user.id,
       employeeId: employee.id,
-      startDate: "2025-04-01",
-      endDate: "2025-04-15",
+      startDate: "2021-04-01",
+      endDate: "2021-04-15",
       daysUsed: 0,
       status: "canceled",
     });
@@ -337,8 +337,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2025-04-01",
-          endDate: "2025-04-15",
+          startDate: "2021-04-01",
+          endDate: "2021-04-15",
           daysEntitled: 15,
           daysUsed: 0,
         }),
@@ -409,8 +409,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2025-06-01",
-          endDate: "2025-06-15",
+          startDate: "2021-06-01",
+          endDate: "2021-06-15",
           daysEntitled: 15,
           daysUsed: 0,
         }),
@@ -477,8 +477,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-30",
+          startDate: "2025-07-01",
+          endDate: "2025-07-30",
           daysEntitled: 30,
           daysUsed: 30,
           status: "scheduled",
@@ -488,17 +488,13 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // startDate=2026-07-01 as reference: completed=2 (2025-06-10 and 2026-06-10 anniversaries), index=1
-    // acquisitionPeriodStart = addMonths("2024-06-10", 12) = "2025-06-10"
-    // acquisitionPeriodEnd = addDays(addMonths("2024-06-10", 24), -1) = "2026-06-09"
-    // concessivePeriodStart = "2026-06-10", concessivePeriodEnd = "2027-06-09"
-    expect(body.data.acquisitionPeriodStart).toBe("2025-06-10");
-    expect(body.data.acquisitionPeriodEnd).toBe("2026-06-09");
-    expect(body.data.concessivePeriodStart).toBe("2026-06-10");
-    expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
+    expect(body.data.acquisitionPeriodStart).toBe("2024-06-10");
+    expect(body.data.acquisitionPeriodEnd).toBe("2025-06-09");
+    expect(body.data.concessivePeriodStart).toBe("2025-06-10");
+    expect(body.data.concessivePeriodEnd).toBe("2026-06-09");
   });
 
-  test("ignores employee manual seed and computes periods from hireDate + startDate", async () => {
+  test("ignores employee manual seed and derives cycle from history (none here)", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -518,8 +514,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-10-06",
-          endDate: "2026-11-04",
+          startDate: "2025-10-06",
+          endDate: "2025-11-04",
           daysEntitled: 30,
           daysUsed: 30,
           status: "scheduled",
@@ -529,12 +525,10 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // Manual seed on employee is now ignored; periods always computed
-    // from hireDate + vacation.startDate.
-    expect(body.data.acquisitionPeriodStart).toBe("2025-06-10");
-    expect(body.data.acquisitionPeriodEnd).toBe("2026-06-09");
-    expect(body.data.concessivePeriodStart).toBe("2026-06-10");
-    expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
+    expect(body.data.acquisitionPeriodStart).toBe("2024-06-10");
+    expect(body.data.acquisitionPeriodEnd).toBe("2025-06-09");
+    expect(body.data.concessivePeriodStart).toBe("2025-06-10");
+    expect(body.data.concessivePeriodEnd).toBe("2026-06-09");
   });
 
   test("ignores period fields in payload and computes from backend", async () => {
@@ -557,8 +551,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-10-06",
-          endDate: "2026-11-04",
+          startDate: "2025-10-06",
+          endDate: "2025-11-04",
           daysEntitled: 30,
           daysUsed: 30,
           status: "scheduled",
@@ -572,11 +566,10 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    // Zod strips the 4 garbage values; backend computes from hireDate + startDate.
-    expect(body.data.acquisitionPeriodStart).toBe("2025-06-10");
-    expect(body.data.acquisitionPeriodEnd).toBe("2026-06-09");
-    expect(body.data.concessivePeriodStart).toBe("2026-06-10");
-    expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
+    expect(body.data.acquisitionPeriodStart).toBe("2024-06-10");
+    expect(body.data.acquisitionPeriodEnd).toBe("2025-06-09");
+    expect(body.data.concessivePeriodStart).toBe("2025-06-10");
+    expect(body.data.concessivePeriodEnd).toBe("2026-06-09");
   });
 
   test("rejects with 422 when vacation startDate is before first cycle's concessivo", async () => {
@@ -703,7 +696,7 @@ describe("POST /v1/vacations", () => {
     expect(body.data.concessivePeriodEnd).toBe("2027-04-21");
   });
 
-  test("silently skips cycles with expired concessivo and < 30 days used", async () => {
+  test("partial usage in past cycle keeps new registration anchored to that same cycle", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -740,8 +733,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-05-01",
-          endDate: "2026-05-10",
+          startDate: "2024-09-01",
+          endDate: "2024-09-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -751,10 +744,10 @@ describe("POST /v1/vacations", () => {
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.data.acquisitionPeriodStart).toBe("2025-04-22");
-    expect(body.data.acquisitionPeriodEnd).toBe("2026-04-21");
-    expect(body.data.concessivePeriodStart).toBe("2026-04-22");
-    expect(body.data.concessivePeriodEnd).toBe("2027-04-21");
+    expect(body.data.acquisitionPeriodStart).toBe("2023-04-22");
+    expect(body.data.acquisitionPeriodEnd).toBe("2024-04-21");
+    expect(body.data.concessivePeriodStart).toBe("2024-04-22");
+    expect(body.data.concessivePeriodEnd).toBe("2025-04-21");
   });
 
   test("rejects when startDate falls outside the selected active cycle's concessivo", async () => {
@@ -816,8 +809,8 @@ describe("POST /v1/vacations", () => {
       hireDate: "2020-01-01",
     });
 
-    const startDate = "2027-06-01";
-    const endDate = "2027-06-10";
+    const startDate = "2021-06-01";
+    const endDate = "2021-06-10";
 
     const response = await app.handle(
       new Request(`${BASE_URL}/v1/vacations`, {
@@ -895,8 +888,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-30",
+          startDate: "2025-07-01",
+          endDate: "2025-07-30",
           daysEntitled: 30,
           daysUsed: 0,
           status: "scheduled",
@@ -927,8 +920,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-20", // 20 days
+          startDate: "2025-07-01",
+          endDate: "2025-07-20",
           daysEntitled: 20,
           daysUsed: 0,
           status: "scheduled",
@@ -943,8 +936,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-08-01",
-          endDate: "2026-08-10", // 10 days, totals 30 in aquisitivo
+          startDate: "2025-08-01",
+          endDate: "2025-08-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -974,8 +967,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-20", // 20 days
+          startDate: "2025-07-01",
+          endDate: "2025-07-20",
           daysEntitled: 20,
           daysUsed: 0,
           status: "scheduled",
@@ -989,8 +982,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-08-01",
-          endDate: "2026-08-15", // 15 days, would total 35
+          startDate: "2025-08-01",
+          endDate: "2025-08-15",
           daysEntitled: 15,
           daysUsed: 0,
           status: "scheduled",
@@ -1026,8 +1019,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-29", // 29 days
+          startDate: "2025-07-01",
+          endDate: "2025-07-29",
           daysEntitled: 29,
           daysUsed: 0,
           status: "scheduled",
@@ -1041,8 +1034,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-08-05",
-          endDate: "2026-08-05", // 1 day, totals 30 exactly
+          startDate: "2025-08-05",
+          endDate: "2025-08-05",
           daysEntitled: 1,
           daysUsed: 0,
           status: "scheduled",
@@ -1121,8 +1114,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-30",
+          startDate: "2025-07-01",
+          endDate: "2025-07-30",
           daysEntitled: 30,
           daysUsed: 0,
           status: "scheduled",
@@ -1147,8 +1140,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-09-01",
-          endDate: "2026-09-30",
+          startDate: "2025-09-01",
+          endDate: "2025-09-30",
           daysEntitled: 30,
           daysUsed: 0,
           status: "scheduled",
@@ -1178,8 +1171,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-30",
+          startDate: "2025-07-01",
+          endDate: "2025-07-30",
           daysEntitled: 30,
           daysUsed: 0,
           status: "scheduled",
@@ -1203,8 +1196,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-09-01",
-          endDate: "2026-09-30",
+          startDate: "2025-09-01",
+          endDate: "2025-09-30",
           daysEntitled: 30,
           daysUsed: 0,
           status: "scheduled",
@@ -1212,5 +1205,43 @@ describe("POST /v1/vacations", () => {
       })
     );
     expect(second.status).toBe(200);
+  });
+
+  test("employer data migration: first vacation registration lands in cycle 1 derived from old hireDate", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2019-02-15",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2020-03-01",
+          endDate: "2020-03-15",
+          daysEntitled: 15,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.acquisitionPeriodStart).toBe("2019-02-15");
+    expect(body.data.acquisitionPeriodEnd).toBe("2020-02-14");
+    expect(body.data.concessivePeriodStart).toBe("2020-02-15");
+    expect(body.data.concessivePeriodEnd).toBe("2021-02-14");
   });
 });

--- a/src/modules/occurrences/vacations/__tests__/delete-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/delete-vacation.test.ts
@@ -58,7 +58,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -112,7 +112,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId: org2,
       userId: user2.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -142,7 +142,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -179,7 +179,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -217,7 +217,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -252,7 +252,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -292,7 +292,7 @@ describe("DELETE /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation1 = await createTestVacation({

--- a/src/modules/occurrences/vacations/__tests__/get-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/get-vacation.test.ts
@@ -69,13 +69,15 @@ describe("GET /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId: org2,
       userId: user2.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
       organizationId: org2,
       userId: user2.id,
       employeeId: employee.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     const response = await app.handle(
@@ -99,7 +101,7 @@ describe("GET /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -146,13 +148,15 @@ describe("GET /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
       organizationId,
       userId: user.id,
       employeeId: employee.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     const memberResult = await createTestUser({ emailVerified: true });

--- a/src/modules/occurrences/vacations/__tests__/list-vacations-by-employee.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/list-vacations-by-employee.test.ts
@@ -49,7 +49,7 @@ describe("GET /v1/vacations/employee/:employeeId", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const response = await app.handle(
@@ -73,13 +73,13 @@ describe("GET /v1/vacations/employee/:employeeId", () => {
     const { employee: employee1 } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const { employee: employee2 } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({
@@ -135,7 +135,7 @@ describe("GET /v1/vacations/employee/:employeeId", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation1 = await createTestVacation({
@@ -191,25 +191,29 @@ describe("GET /v1/vacations/employee/:employeeId", () => {
     const { employee: employee1 } = await createTestEmployee({
       organizationId: org1,
       userId: user1.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const { employee: employee2 } = await createTestEmployee({
       organizationId: org2,
       userId: user2.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({
       organizationId: org1,
       userId: user1.id,
       employeeId: employee1.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     await createTestVacation({
       organizationId: org2,
       userId: user2.id,
       employeeId: employee2.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     // org1 user tries to see employee2's vacations (from org2) -> empty
@@ -232,7 +236,7 @@ describe("GET /v1/vacations/employee/:employeeId", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({

--- a/src/modules/occurrences/vacations/__tests__/list-vacations.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/list-vacations.test.ts
@@ -70,7 +70,7 @@ describe("GET /v1/vacations", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({
@@ -119,7 +119,7 @@ describe("GET /v1/vacations", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation1 = await createTestVacation({
@@ -174,25 +174,29 @@ describe("GET /v1/vacations", () => {
     const { employee: employee1 } = await createTestEmployee({
       organizationId: org1,
       userId: user1.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const { employee: employee2 } = await createTestEmployee({
       organizationId: org2,
       userId: user2.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({
       organizationId: org1,
       userId: user1.id,
       employeeId: employee1.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     await createTestVacation({
       organizationId: org2,
       userId: user2.id,
       employeeId: employee2.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     const response = await app.handle(
@@ -222,13 +226,15 @@ describe("GET /v1/vacations", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({
       organizationId,
       userId: user.id,
       employeeId: employee.id,
+      startDate: "2025-06-01",
+      endDate: "2025-06-15",
     });
 
     const memberResult = await createTestUser({ emailVerified: true });

--- a/src/modules/occurrences/vacations/__tests__/next-cycle.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/next-cycle.test.ts
@@ -13,7 +13,7 @@ import { createTestVacation } from "@/test/helpers/vacation";
 
 const BASE_URL = env.API_URL;
 
-describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
+describe("GET /v1/vacations/employee/:employeeId/next-cycle", () => {
   let app: TestApp;
 
   beforeAll(() => {
@@ -22,10 +22,9 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
 
   test("should reject unauthenticated requests", async () => {
     const response = await app.handle(
-      new Request(
-        `${BASE_URL}/v1/vacations/employee/employee-123/active-cycle`,
-        { method: "GET" }
-      )
+      new Request(`${BASE_URL}/v1/vacations/employee/employee-123/next-cycle`, {
+        method: "GET",
+      })
     );
 
     expect(response.status).toBe(401);
@@ -35,10 +34,10 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
     const { headers } = await createTestUser({ emailVerified: true });
 
     const response = await app.handle(
-      new Request(
-        `${BASE_URL}/v1/vacations/employee/employee-123/active-cycle`,
-        { method: "GET", headers }
-      )
+      new Request(`${BASE_URL}/v1/vacations/employee/employee-123/next-cycle`, {
+        method: "GET",
+        headers,
+      })
     );
 
     expect(response.status).toBe(403);
@@ -53,7 +52,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
 
     const response = await app.handle(
       new Request(
-        `${BASE_URL}/v1/vacations/employee/employee-nonexistent/active-cycle`,
+        `${BASE_URL}/v1/vacations/employee/employee-nonexistent/next-cycle`,
         { method: "GET", headers }
       )
     );
@@ -79,7 +78,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
 
     const response = await app.handle(
       new Request(
-        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/next-cycle`,
         { method: "GET", headers: headers1 }
       )
     );
@@ -106,7 +105,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
 
     const response = await app.handle(
       new Request(
-        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/next-cycle`,
         { method: "GET", headers }
       )
     );
@@ -116,7 +115,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
     expect(body.error.code).toBe("EMPLOYEE_TERMINATED");
   });
 
-  test("returns cycle 1 for new hire with no vacations", async () => {
+  test("returns cycle 1 derived from hireDate for new hire with no history", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({ emailVerified: true });
 
@@ -130,7 +129,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
 
     const response = await app.handle(
       new Request(
-        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/next-cycle`,
         { method: "GET", headers }
       )
     );
@@ -146,7 +145,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
     expect(body.data.daysRemaining).toBe(30);
   });
 
-  test("returns active cycle with partial usage", async () => {
+  test("returns same cycle with partial usage reflected in daysRemaining", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -174,7 +173,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
 
     const response = await app.handle(
       new Request(
-        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/next-cycle`,
         { method: "GET", headers }
       )
     );
@@ -189,7 +188,7 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
     expect(body.data.daysRemaining).toBe(15);
   });
 
-  test("advances to next cycle after current cycle reaches 30 days used", async () => {
+  test("advances to next cycle after last cycle is filled with 30 days regardless of concessivo vigencia", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -199,35 +198,40 @@ describe("GET /v1/vacations/employee/:employeeId/active-cycle", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2024-06-01",
+      hireDate: "2020-06-01",
       acquisitionPeriodStart: null,
       acquisitionPeriodEnd: null,
     });
 
-    await createTestVacation({
+    await db.insert(schema.vacations).values({
+      id: `vacation-${crypto.randomUUID()}`,
       organizationId,
-      userId: user.id,
       employeeId: employee.id,
-      startDate: "2025-07-01",
-      endDate: "2025-07-30",
+      startDate: "2021-07-01",
+      endDate: "2021-07-30",
+      acquisitionPeriodStart: "2020-06-01",
+      acquisitionPeriodEnd: "2021-05-31",
+      concessivePeriodStart: "2021-06-01",
+      concessivePeriodEnd: "2022-05-31",
       daysEntitled: 30,
-      daysUsed: 0,
-      status: "scheduled",
+      daysUsed: 30,
+      status: "completed",
+      createdBy: user.id,
     });
 
     const response = await app.handle(
       new Request(
-        `${BASE_URL}/v1/vacations/employee/${employee.id}/active-cycle`,
+        `${BASE_URL}/v1/vacations/employee/${employee.id}/next-cycle`,
         { method: "GET", headers }
       )
     );
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.data.acquisitionPeriodStart).toBe("2025-06-01");
-    expect(body.data.acquisitionPeriodEnd).toBe("2026-05-31");
-    expect(body.data.concessivePeriodStart).toBe("2026-06-01");
-    expect(body.data.concessivePeriodEnd).toBe("2027-05-31");
+    expect(body.data.acquisitionPeriodStart).toBe("2021-06-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2022-05-31");
+    expect(body.data.concessivePeriodStart).toBe("2022-06-01");
+    expect(body.data.concessivePeriodEnd).toBe("2023-05-31");
     expect(body.data.daysUsed).toBe(0);
     expect(body.data.daysRemaining).toBe(30);
   });

--- a/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
   addDays,
   addMonths,
-  computeActiveCycle,
   computePeriodsFromHireDate,
   computePeriodsFromLastAcquisition,
+  resolveNextCycle,
 } from "@/modules/occurrences/vacations/period-calculation";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -146,12 +146,11 @@ describe("computePeriodsFromHireDate", () => {
   });
 });
 
-describe("computeActiveCycle", () => {
-  test("new hire (0 anniversaries) → returns cycle 1 with future concessivo", () => {
+describe("resolveNextCycle", () => {
+  test("no history → returns cycle 1 from hireDate", () => {
     expect(
-      computeActiveCycle({
+      resolveNextCycle({
         hireDate: "2026-01-01",
-        referenceDate: new Date("2026-06-01T00:00:00Z"),
         vacationsInCycles: [],
       })
     ).toEqual({
@@ -159,150 +158,90 @@ describe("computeActiveCycle", () => {
       acquisitionPeriodEnd: "2026-12-31",
       concessivePeriodStart: "2027-01-01",
       concessivePeriodEnd: "2027-12-31",
-      daysUsed: 0,
-      daysRemaining: 30,
     });
   });
 
-  test("employee with 1 anniversary and 0 vacations → cycle 1 active", () => {
+  test("partial usage in last cycle → same cycle (still has balance)", () => {
     expect(
-      computeActiveCycle({
-        hireDate: "2025-01-01",
-        referenceDate: new Date("2026-06-01T00:00:00Z"),
-        vacationsInCycles: [],
-      })
-    ).toEqual({
-      acquisitionPeriodStart: "2025-01-01",
-      acquisitionPeriodEnd: "2025-12-31",
-      concessivePeriodStart: "2026-01-01",
-      concessivePeriodEnd: "2026-12-31",
-      daysUsed: 0,
-      daysRemaining: 30,
-    });
-  });
-
-  test("employee with 1 anniversary and 30 days used in cycle 1 → cycle 2 active", () => {
-    expect(
-      computeActiveCycle({
-        hireDate: "2025-01-01",
-        referenceDate: new Date("2026-06-01T00:00:00Z"),
-        vacationsInCycles: [
-          { acquisitionPeriodStart: "2025-01-01", daysEntitled: 30 },
-        ],
-      })
-    ).toEqual({
-      acquisitionPeriodStart: "2026-01-01",
-      acquisitionPeriodEnd: "2026-12-31",
-      concessivePeriodStart: "2027-01-01",
-      concessivePeriodEnd: "2027-12-31",
-      daysUsed: 0,
-      daysRemaining: 30,
-    });
-  });
-
-  test("cycle with daysUsed < 30 but concessivo vencido → silently skipped", () => {
-    expect(
-      computeActiveCycle({
+      resolveNextCycle({
         hireDate: "2023-01-01",
-        referenceDate: new Date("2026-06-01T00:00:00Z"),
         vacationsInCycles: [
-          { acquisitionPeriodStart: "2023-01-01", daysEntitled: 15 },
-        ],
-      })
-    ).toEqual({
-      acquisitionPeriodStart: "2025-01-01",
-      acquisitionPeriodEnd: "2025-12-31",
-      concessivePeriodStart: "2026-01-01",
-      concessivePeriodEnd: "2026-12-31",
-      daysUsed: 0,
-      daysRemaining: 30,
-    });
-  });
-
-  test("multiple cycles with mixed usage → returns first viable", () => {
-    expect(
-      computeActiveCycle({
-        hireDate: "2023-01-01",
-        referenceDate: new Date("2026-06-01T00:00:00Z"),
-        vacationsInCycles: [
-          { acquisitionPeriodStart: "2023-01-01", daysEntitled: 30 },
           { acquisitionPeriodStart: "2024-01-01", daysEntitled: 15 },
-          { acquisitionPeriodStart: "2025-01-01", daysEntitled: 10 },
         ],
-      })
-    ).toEqual({
-      acquisitionPeriodStart: "2025-01-01",
-      acquisitionPeriodEnd: "2025-12-31",
-      concessivePeriodStart: "2026-01-01",
-      concessivePeriodEnd: "2026-12-31",
-      daysUsed: 10,
-      daysRemaining: 20,
-    });
-  });
-
-  test("partial days in active cycle → correct daysRemaining", () => {
-    expect(
-      computeActiveCycle({
-        hireDate: "2025-01-01",
-        referenceDate: new Date("2026-06-01T00:00:00Z"),
-        vacationsInCycles: [
-          { acquisitionPeriodStart: "2025-01-01", daysEntitled: 15 },
-        ],
-      })
-    ).toEqual({
-      acquisitionPeriodStart: "2025-01-01",
-      acquisitionPeriodEnd: "2025-12-31",
-      concessivePeriodStart: "2026-01-01",
-      concessivePeriodEnd: "2026-12-31",
-      daysUsed: 15,
-      daysRemaining: 15,
-    });
-  });
-
-  test("Geralda case: long history with no vacations → returns first cycle whose concessivo is still valid", () => {
-    expect(
-      computeActiveCycle({
-        hireDate: "2011-02-01",
-        referenceDate: new Date("2026-04-22T00:00:00Z"),
-        vacationsInCycles: [],
-      })
-    ).toEqual({
-      acquisitionPeriodStart: "2025-02-01",
-      acquisitionPeriodEnd: "2026-01-31",
-      concessivePeriodStart: "2026-02-01",
-      concessivePeriodEnd: "2027-01-31",
-      daysUsed: 0,
-      daysRemaining: 30,
-    });
-  });
-
-  test("boundary: concessivo ends exactly on referenceDate → still active", () => {
-    expect(
-      computeActiveCycle({
-        hireDate: "2024-01-01",
-        referenceDate: new Date("2025-12-31T00:00:00Z"),
-        vacationsInCycles: [],
       })
     ).toEqual({
       acquisitionPeriodStart: "2024-01-01",
       acquisitionPeriodEnd: "2024-12-31",
       concessivePeriodStart: "2025-01-01",
       concessivePeriodEnd: "2025-12-31",
-      daysUsed: 0,
-      daysRemaining: 30,
     });
   });
 
-  test("defaults referenceDate to today when omitted", () => {
-    const result = computeActiveCycle({
-      hireDate: "2020-01-01",
-      vacationsInCycles: [],
+  test("exactly 30 in last cycle → next cycle (aquisitivo +12m)", () => {
+    expect(
+      resolveNextCycle({
+        hireDate: "2023-01-01",
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2024-01-01", daysEntitled: 30 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
     });
-    expect(result.acquisitionPeriodStart).toMatch(ISO_DATE_PATTERN);
-    expect(result.acquisitionPeriodEnd).toMatch(ISO_DATE_PATTERN);
-    expect(result.concessivePeriodStart).toMatch(ISO_DATE_PATTERN);
-    expect(result.concessivePeriodEnd).toMatch(ISO_DATE_PATTERN);
-    expect(result.daysUsed).toBe(0);
-    expect(result.daysRemaining).toBe(30);
+  });
+
+  test("multiple registrations summing 30 → next cycle", () => {
+    expect(
+      resolveNextCycle({
+        hireDate: "2023-01-01",
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2024-01-01", daysEntitled: 15 },
+          { acquisitionPeriodStart: "2024-01-01", daysEntitled: 15 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+    });
+  });
+
+  test("Geralda case: 13 contiguous cycles all 30 days → cycle 14", () => {
+    const vacationsInCycles = Array.from({ length: 13 }, (_, i) => ({
+      acquisitionPeriodStart: addMonths("2011-02-01", i * 12),
+      daysEntitled: 30,
+    }));
+    expect(
+      resolveNextCycle({
+        hireDate: "2011-02-01",
+        vacationsInCycles,
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2024-02-01",
+      acquisitionPeriodEnd: "2025-01-31",
+      concessivePeriodStart: "2025-02-01",
+      concessivePeriodEnd: "2026-01-31",
+    });
+  });
+
+  test("gap in history → derives next cycle from LAST registered, not first", () => {
+    expect(
+      resolveNextCycle({
+        hireDate: "2020-01-01",
+        vacationsInCycles: [
+          { acquisitionPeriodStart: "2020-01-01", daysEntitled: 30 },
+          { acquisitionPeriodStart: "2024-01-01", daysEntitled: 30 },
+        ],
+      })
+    ).toEqual({
+      acquisitionPeriodStart: "2025-01-01",
+      acquisitionPeriodEnd: "2025-12-31",
+      concessivePeriodStart: "2026-01-01",
+      concessivePeriodEnd: "2026-12-31",
+    });
   });
 });

--- a/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/period-calculation.test.ts
@@ -244,4 +244,36 @@ describe("resolveNextCycle", () => {
       concessivePeriodEnd: "2026-12-31",
     });
   });
+
+  test("leap-year hire (Feb 29) with 30 days in cycle 1 advances to next cycle", () => {
+    const result = resolveNextCycle({
+      hireDate: "2024-02-29",
+      vacationsInCycles: [
+        { acquisitionPeriodStart: "2024-02-29", daysEntitled: 30 },
+      ],
+    });
+    expect(result.acquisitionPeriodStart).toMatch(ISO_DATE_PATTERN);
+    expect(result.acquisitionPeriodEnd).toMatch(ISO_DATE_PATTERN);
+    expect(result.concessivePeriodStart).toMatch(ISO_DATE_PATTERN);
+    expect(result.concessivePeriodEnd).toMatch(ISO_DATE_PATTERN);
+    expect(result).toEqual({
+      acquisitionPeriodStart: "2025-03-01",
+      acquisitionPeriodEnd: "2026-02-28",
+      concessivePeriodStart: "2026-03-01",
+      concessivePeriodEnd: "2027-02-28",
+    });
+  });
+
+  test("day-31 hire with no history returns cycle 1 with normalized month-end", () => {
+    const result = resolveNextCycle({
+      hireDate: "2025-01-31",
+      vacationsInCycles: [],
+    });
+    expect(result).toEqual({
+      acquisitionPeriodStart: "2025-01-31",
+      acquisitionPeriodEnd: "2026-01-30",
+      concessivePeriodStart: "2026-01-31",
+      concessivePeriodEnd: "2027-01-30",
+    });
+  });
 });

--- a/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/update-vacation.test.ts
@@ -61,7 +61,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -120,7 +120,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId: org2,
       userId: user2.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -151,7 +151,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -198,7 +198,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -233,7 +233,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -277,7 +277,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     await createTestVacation({
@@ -325,7 +325,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -401,7 +401,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -436,7 +436,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const vacation = await createTestVacation({
@@ -471,7 +471,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     // First vacation: in_progress
@@ -541,8 +541,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-10-06",
-          endDate: "2026-11-04",
+          startDate: "2025-10-06",
+          endDate: "2025-11-04",
           daysEntitled: 30,
           daysUsed: 30,
           status: "scheduled",
@@ -584,7 +584,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
     });
 
     const created = await createTestVacation({
@@ -641,8 +641,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-10",
+          startDate: "2025-07-01",
+          endDate: "2025-07-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -683,8 +683,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-20",
+          startDate: "2025-07-01",
+          endDate: "2025-07-20",
           daysEntitled: 20,
           daysUsed: 0,
           status: "scheduled",
@@ -699,8 +699,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-08-01",
-          endDate: "2026-08-05",
+          startDate: "2025-08-01",
+          endDate: "2025-08-05",
           daysEntitled: 5,
           daysUsed: 0,
           status: "scheduled",
@@ -715,8 +715,8 @@ describe("PUT /v1/vacations/:id", () => {
         method: "PUT",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
-          startDate: "2026-08-01",
-          endDate: "2026-08-15",
+          startDate: "2025-08-01",
+          endDate: "2025-08-15",
           daysEntitled: 15,
         }),
       })
@@ -751,8 +751,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-20",
+          startDate: "2025-07-01",
+          endDate: "2025-07-20",
           daysEntitled: 20,
           daysUsed: 0,
           status: "scheduled",
@@ -767,8 +767,8 @@ describe("PUT /v1/vacations/:id", () => {
         method: "PUT",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
-          startDate: "2026-07-01",
-          endDate: "2026-07-25",
+          startDate: "2025-07-01",
+          endDate: "2025-07-25",
           daysEntitled: 25,
         }),
       })
@@ -797,8 +797,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-10",
+          startDate: "2025-07-01",
+          endDate: "2025-07-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -812,8 +812,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-08-01",
-          endDate: "2026-08-10",
+          startDate: "2025-08-01",
+          endDate: "2025-08-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -828,8 +828,8 @@ describe("PUT /v1/vacations/:id", () => {
         method: "PUT",
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
-          startDate: "2026-08-01",
-          endDate: "2026-08-15",
+          startDate: "2025-08-01",
+          endDate: "2025-08-15",
           daysEntitled: 15,
         }),
       })
@@ -853,7 +853,7 @@ describe("PUT /v1/vacations/:id", () => {
     const { employee } = await createTestEmployee({
       organizationId,
       userId: user.id,
-      hireDate: "2020-01-01",
+      hireDate: "2024-01-01",
       acquisitionPeriodStart: null,
       acquisitionPeriodEnd: null,
     });
@@ -912,8 +912,8 @@ describe("PUT /v1/vacations/:id", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-07-01",
-          endDate: "2026-07-15",
+          startDate: "2025-07-01",
+          endDate: "2025-07-15",
           daysEntitled: 15,
           daysUsed: 0,
           status: "scheduled",

--- a/src/modules/occurrences/vacations/__tests__/vacation-jobs.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/vacation-jobs.test.ts
@@ -24,7 +24,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
-        hireDate: "2020-01-01",
+        hireDate: "2024-06-10",
       });
 
       const today = new Date();
@@ -75,7 +75,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
-        hireDate: "2020-01-01",
+        hireDate: "2024-06-10",
       });
 
       const future = new Date();
@@ -120,7 +120,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
-        hireDate: "2020-01-01",
+        hireDate: "2024-06-10",
       });
 
       const today = new Date();
@@ -171,7 +171,7 @@ describe("VacationJobsService", () => {
       const { employee } = await createTestEmployee({
         organizationId,
         userId,
-        hireDate: "2020-01-01",
+        hireDate: "2024-06-10",
       });
 
       const today = new Date();

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -131,15 +131,3 @@ export class VacationStartDateOutsideConcessiveError extends VacationError {
     );
   }
 }
-
-export class VacationActiveCycleUnresolvableError extends VacationError {
-  status = 500;
-
-  constructor(hireDate: string, referenceDate: string) {
-    super(
-      "Não foi possível determinar o ciclo de férias ativo dentro do intervalo de segurança",
-      "VACATION_ACTIVE_CYCLE_UNRESOLVABLE",
-      { hireDate, referenceDate }
-    );
-  }
-}

--- a/src/modules/occurrences/vacations/index.ts
+++ b/src/modules/occurrences/vacations/index.ts
@@ -14,7 +14,7 @@ import {
   createVacationSchema,
   deleteVacationResponseSchema,
   employeeIdParamSchema,
-  getActiveCycleResponseSchema,
+  getNextCycleResponseSchema,
   getVacationResponseSchema,
   idParamSchema,
   listVacationsResponseSchema,
@@ -109,10 +109,10 @@ export const vacationController = new Elysia({
     }
   )
   .get(
-    "/employee/:employeeId/active-cycle",
+    "/employee/:employeeId/next-cycle",
     async ({ session, params }) =>
       wrapSuccess(
-        await VacationService.getActiveCycle(
+        await VacationService.getNextCycle(
           params.employeeId,
           session.activeOrganizationId as string
         )
@@ -124,16 +124,16 @@ export const vacationController = new Elysia({
       },
       params: employeeIdParamSchema,
       response: {
-        200: getActiveCycleResponseSchema,
+        200: getNextCycleResponseSchema,
         401: unauthorizedErrorSchema,
         403: forbiddenErrorSchema,
         404: notFoundErrorSchema,
         422: validationErrorSchema,
       },
       detail: {
-        summary: "Get active vacation cycle by employee",
+        summary: "Obter próximo ciclo de férias do funcionário",
         description:
-          "Returns the active acquisition/concessive cycle for an employee (first cycle with daysUsed < 30 and concessive window still open) plus the remaining days balance.",
+          "Retorna o próximo período aquisitivo/concessivo a ser cadastrado, baseado no histórico de férias registradas. Sem histórico → ciclo 1 derivado da admissão. Com histórico → próximo contíguo após o último aquisitivo com 30/30 dias.",
       },
     }
   )

--- a/src/modules/occurrences/vacations/period-calculation.ts
+++ b/src/modules/occurrences/vacations/period-calculation.ts
@@ -1,5 +1,3 @@
-import { VacationActiveCycleUnresolvableError } from "./errors";
-
 export function addDays(isoDate: string, days: number): string {
   const d = new Date(`${isoDate}T00:00:00Z`);
   d.setUTCDate(d.getUTCDate() + days);
@@ -67,75 +65,52 @@ export function computePeriodsFromHireDate(
   };
 }
 
-export type ActiveCycleInput = {
+export type NextCycleInput = {
   hireDate: string;
-  referenceDate?: Date;
   vacationsInCycles: Array<{
     acquisitionPeriodStart: string;
     daysEntitled: number;
   }>;
 };
 
-export type ActiveCycle = VacationPeriods & {
-  daysUsed: number;
-  daysRemaining: number;
-};
+function buildCycleFromStart(start: string): VacationPeriods {
+  const acquisitionPeriodEnd = addDays(addMonths(start, 12), -1);
+  const concessivePeriodStart = addDays(acquisitionPeriodEnd, 1);
+  const concessivePeriodEnd = addDays(addMonths(concessivePeriodStart, 12), -1);
+  return {
+    acquisitionPeriodStart: start,
+    acquisitionPeriodEnd,
+    concessivePeriodStart,
+    concessivePeriodEnd,
+  };
+}
 
-const MAX_DAYS_PER_CYCLE = 30;
-const SAFETY_BOUND_MONTHS = 24;
-
-export function computeActiveCycle(input: ActiveCycleInput): ActiveCycle {
-  const referenceDate = input.referenceDate ?? new Date();
-  const referenceIso = referenceDate.toISOString().slice(0, 10);
-  const safetyBoundIso = addMonths(referenceIso, SAFETY_BOUND_MONTHS);
-
-  const usageByCycleStart = new Map<string, number>();
+export function resolveNextCycle(input: NextCycleInput): VacationPeriods {
+  const sumDaysByAquisitivo = new Map<string, number>();
   for (const vacation of input.vacationsInCycles) {
-    const current = usageByCycleStart.get(vacation.acquisitionPeriodStart) ?? 0;
-    usageByCycleStart.set(
+    const current =
+      sumDaysByAquisitivo.get(vacation.acquisitionPeriodStart) ?? 0;
+    sumDaysByAquisitivo.set(
       vacation.acquisitionPeriodStart,
       current + vacation.daysEntitled
     );
   }
 
-  let cycleNumber = 1;
-  while (cycleNumber < Number.MAX_SAFE_INTEGER) {
-    const acquisitionPeriodStart = addMonths(
-      input.hireDate,
-      (cycleNumber - 1) * 12
-    );
-
-    if (acquisitionPeriodStart > safetyBoundIso) {
-      break;
-    }
-
-    const acquisitionPeriodEnd = addDays(
-      addMonths(input.hireDate, cycleNumber * 12),
-      -1
-    );
-    const concessivePeriodStart = addDays(acquisitionPeriodEnd, 1);
-    const concessivePeriodEnd = addDays(
-      addMonths(concessivePeriodStart, 12),
-      -1
-    );
-
-    const daysUsed = usageByCycleStart.get(acquisitionPeriodStart) ?? 0;
-    const hasDaysAvailable = daysUsed < MAX_DAYS_PER_CYCLE;
-    const concessivoStillValid = concessivePeriodEnd >= referenceIso;
-
-    if (hasDaysAvailable && concessivoStillValid) {
-      return {
-        acquisitionPeriodStart,
-        acquisitionPeriodEnd,
-        concessivePeriodStart,
-        concessivePeriodEnd,
-        daysUsed,
-        daysRemaining: MAX_DAYS_PER_CYCLE - daysUsed,
-      };
-    }
-
-    cycleNumber += 1;
+  if (sumDaysByAquisitivo.size === 0) {
+    return buildCycleFromStart(input.hireDate);
   }
 
-  throw new VacationActiveCycleUnresolvableError(input.hireDate, referenceIso);
+  let lastStart = "";
+  for (const key of sumDaysByAquisitivo.keys()) {
+    if (key > lastStart) {
+      lastStart = key;
+    }
+  }
+
+  const total = sumDaysByAquisitivo.get(lastStart) ?? 0;
+  if (total < 30) {
+    return buildCycleFromStart(lastStart);
+  }
+
+  return buildCycleFromStart(addMonths(lastStart, 12));
 }

--- a/src/modules/occurrences/vacations/period-calculation.ts
+++ b/src/modules/occurrences/vacations/period-calculation.ts
@@ -100,12 +100,8 @@ export function resolveNextCycle(input: NextCycleInput): VacationPeriods {
     return buildCycleFromStart(input.hireDate);
   }
 
-  let lastStart = "";
-  for (const key of sumDaysByAquisitivo.keys()) {
-    if (key > lastStart) {
-      lastStart = key;
-    }
-  }
+  const starts = Array.from(sumDaysByAquisitivo.keys());
+  const lastStart = starts.reduce((a, b) => (b > a ? b : a));
 
   const total = sumDaysByAquisitivo.get(lastStart) ?? 0;
   if (total < 30) {

--- a/src/modules/occurrences/vacations/vacation.model.ts
+++ b/src/modules/occurrences/vacations/vacation.model.ts
@@ -125,7 +125,7 @@ const deletedVacationDataSchema = vacationDataSchema.extend({
 
 const vacationListDataSchema = z.array(vacationDataSchema);
 
-export const activeCycleSchema = z.object({
+export const nextCycleSchema = z.object({
   acquisitionPeriodStart: z
     .string()
     .describe("Início do período aquisitivo (YYYY-MM-DD)"),
@@ -151,8 +151,8 @@ export const activeCycleSchema = z.object({
     .describe("Dias restantes no ciclo ativo"),
 });
 
-export const getActiveCycleResponseSchema =
-  successResponseSchema(activeCycleSchema);
+export const getNextCycleResponseSchema =
+  successResponseSchema(nextCycleSchema);
 
 export const createVacationResponseSchema =
   successResponseSchema(vacationDataSchema);

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -4,8 +4,8 @@ import { schema } from "@/db/schema";
 import { calculateDaysBetween } from "@/lib/schemas/date-helpers";
 import { ensureEmployeeNotTerminated } from "@/modules/employees/status";
 import {
-  type ActiveCycle,
-  computeActiveCycle,
+  resolveNextCycle,
+  type VacationPeriods,
 } from "@/modules/occurrences/vacations/period-calculation";
 import {
   VacationAlreadyDeletedError,
@@ -24,6 +24,11 @@ import type {
   UpdateVacationInput,
   VacationData,
 } from "./vacation.model";
+
+type CycleWithBalance = VacationPeriods & {
+  daysUsed: number;
+  daysRemaining: number;
+};
 
 const MAX_VACATION_DAYS_PER_AQUISITIVO = 30;
 
@@ -237,12 +242,11 @@ export abstract class VacationService {
     }
   }
 
-  private static async computeActiveCycleFor(
+  private static async resolveCycleForEmployee(
     employeeId: string,
     organizationId: string,
-    hireDate: string,
-    referenceDate: Date
-  ): Promise<ActiveCycle> {
+    hireDate: string
+  ): Promise<CycleWithBalance> {
     const rows = await db
       .select({
         acquisitionPeriodStart: sql<string>`${schema.vacations.acquisitionPeriodStart}`,
@@ -264,18 +268,22 @@ export abstract class VacationService {
       daysEntitled: row.daysEntitled,
     }));
 
-    return computeActiveCycle({
-      hireDate,
-      referenceDate,
-      vacationsInCycles,
-    });
+    const periods = resolveNextCycle({ hireDate, vacationsInCycles });
+
+    const daysUsed = vacationsInCycles
+      .filter(
+        (row) => row.acquisitionPeriodStart === periods.acquisitionPeriodStart
+      )
+      .reduce((sum, row) => sum + row.daysEntitled, 0);
+    const daysRemaining = MAX_VACATION_DAYS_PER_AQUISITIVO - daysUsed;
+
+    return { ...periods, daysUsed, daysRemaining };
   }
 
-  static async getActiveCycle(
+  static async getNextCycle(
     employeeId: string,
-    organizationId: string,
-    referenceDate: Date = new Date()
-  ): Promise<ActiveCycle> {
+    organizationId: string
+  ): Promise<CycleWithBalance> {
     const employee = await VacationService.getEmployeeReference(
       employeeId,
       organizationId
@@ -283,11 +291,10 @@ export abstract class VacationService {
 
     await ensureEmployeeNotTerminated(employeeId, organizationId);
 
-    return VacationService.computeActiveCycleFor(
+    return VacationService.resolveCycleForEmployee(
       employeeId,
       organizationId,
-      employee.hireDate,
-      referenceDate
+      employee.hireDate
     );
   }
 
@@ -370,11 +377,10 @@ export abstract class VacationService {
 
     VacationService.validateDates(data.startDate, data.endDate);
 
-    const activeCycle = await VacationService.computeActiveCycleFor(
+    const activeCycle = await VacationService.resolveCycleForEmployee(
       data.employeeId,
       organizationId,
-      employee.hireDate,
-      new Date(`${data.startDate}T00:00:00Z`)
+      employee.hireDate
     );
 
     VacationService.validateStartDateInConcessive(data.startDate, activeCycle);

--- a/src/test/helpers/vacation.ts
+++ b/src/test/helpers/vacation.ts
@@ -1,3 +1,10 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import {
+  addDays,
+  resolveNextCycle,
+} from "@/modules/occurrences/vacations/period-calculation";
 import type { VacationData } from "@/modules/occurrences/vacations/vacation.model";
 import { VacationService } from "@/modules/occurrences/vacations/vacation.service";
 import { faker } from "./faker";
@@ -18,6 +25,52 @@ type CreateTestVacationOptions = {
   employeeId: string;
 } & VacationOverrides;
 
+async function resolveDefaultStartDate(
+  organizationId: string,
+  employeeId: string
+): Promise<string> {
+  const [employee] = await db
+    .select({ hireDate: schema.employees.hireDate })
+    .from(schema.employees)
+    .where(
+      and(
+        eq(schema.employees.id, employeeId),
+        eq(schema.employees.organizationId, organizationId)
+      )
+    )
+    .limit(1);
+
+  if (!employee) {
+    throw new Error(`Test helper: employee ${employeeId} not found`);
+  }
+
+  const rows = await db
+    .select({
+      acquisitionPeriodStart: sql<string>`${schema.vacations.acquisitionPeriodStart}`,
+      daysEntitled: schema.vacations.daysEntitled,
+    })
+    .from(schema.vacations)
+    .where(
+      and(
+        eq(schema.vacations.organizationId, organizationId),
+        eq(schema.vacations.employeeId, employeeId),
+        sql`${schema.vacations.status} != 'canceled'`,
+        isNull(schema.vacations.deletedAt),
+        sql`${schema.vacations.acquisitionPeriodStart} IS NOT NULL`
+      )
+    );
+
+  const cycle = resolveNextCycle({
+    hireDate: employee.hireDate,
+    vacationsInCycles: rows.map((row) => ({
+      acquisitionPeriodStart: row.acquisitionPeriodStart,
+      daysEntitled: row.daysEntitled,
+    })),
+  });
+
+  return addDays(cycle.concessivePeriodStart, 30);
+}
+
 export async function createTestVacation(
   options: CreateTestVacationOptions
 ): Promise<VacationData> {
@@ -25,12 +78,12 @@ export async function createTestVacation(
 
   const startDate =
     overrides.startDate ??
-    faker.date.future({ years: 1 }).toISOString().split("T")[0];
+    (await resolveDefaultStartDate(organizationId, employeeId));
   const endDate =
     overrides.endDate ??
     (() => {
       const d = new Date(startDate);
-      d.setDate(d.getDate() + faker.number.int({ min: 5, max: 29 }));
+      d.setDate(d.getDate() + faker.number.int({ min: 5, max: 14 }));
       return d.toISOString().split("T")[0];
     })();
 


### PR DESCRIPTION
## Contexto

Follow-up da PR #259 (que introduziu o modelo "ciclo ativo" time-based). Revisão com a cliente Thatiane em homologação apontou que:

- O modelo atual tempo-baseado (*silent skip* de ciclos com concessivo vencido) impede que organizações migrem o histórico dos funcionários antigos pro sistema
- A cliente quer que o RH possa **preservar a história** da organização — cadastrando ciclos passados conforme existiram
- A fala original dela já prenunciava esse modelo: *"a partir que o cliente cadastrar as férias que totalize 30 dias desse período, aí o sistema libera o novo período"* — ou seja, **histórico-baseado**, não tempo-baseado

Após brainstorming aplicando YAGNI, decidimos que:
- O sistema oferece o **próximo ciclo derivado do histórico** (não do tempo)
- Sem histórico → ciclo 1 (derivado da admissão)
- Com histórico → próximo contíguo após o último aquisitivo registrado
- Cadastro é sequencial — RH preenche ciclo-a-ciclo pra trazer a história
- Cenários de classificação fina (pago via multa / gozado / vendido) ficam pra próximas iterações conforme surgir dor real

## O que mudou

### Algoritmo (`period-calculation.ts`)
- **Removido:** `computeActiveCycle` (time-based) + `ActiveCycleInput` + `ActiveCycle` + safety bound + constantes defensivas
- **Adicionado:** `resolveNextCycle(input: NextCycleInput): VacationPeriods` — pura, determinística, sem dependência de tempo
- Sem histórico → cycle 1 (`hireDate` a `hireDate + 12m - 1d`)
- Com histórico → próximo contíguo após o `max(acquisitionPeriodStart)` com 30/30 usados, ou o mesmo se saldo < 30

### Serviço (`vacation.service.ts`)
- `computeActiveCycleFor` → `resolveCycleForEmployee` (sem `referenceDate`)
- `getActiveCycle` → `getNextCycle`
- `create()` passa a resolver o ciclo via histórico sem time awareness
- `validateStartDateInConcessive` permanece — valida que `startDate` está dentro do concessivo do ciclo retornado (pode ser passado, vigente ou futuro)

### API (`index.ts`)
- Rota `GET /v1/vacations/employee/:employeeId/active-cycle` → **`GET /v1/vacations/employee/:employeeId/next-cycle`**
- Handler, schema (`getNextCycleResponseSchema`), summary e description atualizados
- Corpo da resposta inalterado (mesmos 6 campos)

### Erros
- Removido: `VacationActiveCycleUnresolvableError` (o algoritmo novo é determinístico, sem safety bound)
- Preservados: `VacationStartDateOutsideConcessiveError`, `VacationNoRightsError` (legacy), demais

### Testes
- `__tests__/active-cycle.test.ts` → renomeado (via `git mv`) pra `next-cycle.test.ts`, URLs + cenários atualizados
- `__tests__/create-vacation.test.ts`: removido cenário "silent skip"; adicionado "empresa migrando — primeiro cadastro cai no ciclo 1 derivado da admissão 2019"
- Demais tests (`get`, `list`, `update`, `delete`, `vacation-jobs`, `last-acquisition-period`) ajustaram datas fixas pra bater com a nova semântica
- Tests unitários de `resolveNextCycle`: 8 cenários cobrindo no-history, partial, full, multiple-sum-30, long-history (Geralda), gap, leap-year Feb-29, day-31 hire

### Documentação (`CLAUDE.md`)
- Regras do módulo reescritas pro modelo history-based
- Endpoint renomeado na listagem
- Exemplo explícito de empresa migrando

### Helper de testes (`src/test/helpers/vacation.ts`)
- `createTestVacation` agora usa `resolveNextCycle` pra derivar `startDate` default (reflete a nova regra de negócio no fixture)

## Commits (7 atômicos)

```
97a9ae7 docs(vacations): update CLAUDE.md for history-based cycle model
fcddc22 test(vacations): update integration tests for history-based cycle
034e210 refactor(vacations): rename endpoint /active-cycle → /next-cycle
629770d refactor(vacations): switch service to resolveNextCycle and rename getNextCycle
19b66e2 refactor(vacations): remove unresolvable error + rename cycle schemas
75ac852 refactor(vacations): harden resolveNextCycle lastStart + add month-end tests
18b46e4 refactor(vacations): history-based next cycle in period-calculation
```

## Resultado dos testes

```
NODE_ENV=test bun test src/modules/occurrences/vacations/__tests__/ src/modules/employees/__tests__/
→ 202 pass / 0 fail (18 arquivos, 558 expect() calls)

bunx tsc --noEmit
→ clean

npx ultracite check src/modules/occurrences/vacations/
→ clean (15 files)
```

## Processo

Implementação via subagent-driven development com spec + code quality reviews onde aplicável. YAGNI aplicado conscientemente: "pago via multa", classificação de desfecho, bulk onboarding — todos ficam pra iteração futura quando surgirem dores reais em produção.

## Riscos

- **Quebra contrato do endpoint**: `/active-cycle` deixa de existir, FE precisa regenerar Kubb com `/next-cycle`. Como nada em produção consome esse endpoint ainda (só preview), é seguro. Follow-up FE em PR separada.
- **Dados em preview**: registros de férias criados em preview sob a regra "ciclo ativo" tinham snapshot imutável — permanecem válidos. A regra nova só afeta **novos** cadastros.
- **Fluxo de onboarding de funcionários antigos**: não é automatizado. RH precisa cadastrar ciclo-a-ciclo pra migrar histórico (13+ ciclos pra funcionário admitido em 2011). Esse é um fluxo **operacional** esperado — se virar dor, consideramos bulk helper depois.

## Test plan

- [ ] CI passa
- [ ] Deploy preview
- [ ] FE regenera Kubb contra preview BE
- [ ] FE PR que consome novo endpoint mergeada
- [ ] Validação manual em homologação:
  - [ ] Novo contratado (admissão recente) → ciclo 1 futuro
  - [ ] Funcionário com 30/30 em ciclo passado → sistema avança pro próximo contíguo
  - [ ] Funcionário com 15 dias num ciclo passado → sistema mantém no mesmo (15 saldo)
  - [ ] Empresa migrando (funcionário 2019 sem histórico) → ciclo 1 oferecido, RH pode cadastrar retroativo

🤖 Generated with [Claude Code](https://claude.com/claude-code)