### PR TITLE
refactor(vacations): drop startDate-in-concessivo validation to support pago-via-multa

### DIFF
--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -18,8 +18,11 @@ Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias,
       - Se `daysUsed < 30` nesse aquisitivo → retorna o **mesmo ciclo** (ainda tem saldo a cadastrar).
       - Se `daysUsed === 30` → retorna o **próximo ciclo contíguo** (`lastAquisitivoStart + 12 meses`).
     - Não há silent skip de ciclos vencidos — a sequência é contíguamente derivada do histórico.
-  - **`startDate` obrigatoriamente dentro do concessivo do ciclo retornado** — caso contrário lança `VacationStartDateOutsideConcessiveError` (422). Válido para cadastros retroativos (concessivo no passado), vigentes (concessivo contém hoje) e agendados (concessivo no futuro).
+  - **`startDate` é livre** dentro dos limites gerais do módulo (validações de `validateDates`, `validateDaysBetweenDates`, `ensureAquisitivoLimit`, `ensureNoOverlap`). O snapshot de aquisitivo/concessivo capturado no registro é sempre o ciclo retornado por `resolveNextCycle` (derivado do histórico), **mesmo quando `startDate` cai fora do concessivo desse ciclo** — isso representa o cenário de férias pagas fora do prazo legal (pago via multa, CLT art. 137).
+
+    A **classificação "Pago via Multa"** é **derivada pela UI** (frontend) a partir da comparação `startDate > concessivePeriodEnd` do snapshot. Não é persistida no banco — o dado fica na combinação `(startDate, concessivePeriodEnd)`. Se futuramente precisarmos rastrear overrides manuais (ex: "gozado em data fora do prazo por acordo coletivo"), migrar pra campo persistido.
   - **Exemplo — empresa migrando**: funcionário admitido em 15/02/2019, sem férias cadastradas → primeiro cadastro cai no ciclo 1 (aquisitivo 15/02/2019-14/02/2020). Depois de completar 30 dias nesse ciclo → próximo cadastro cai no ciclo 2 (aquisitivo 15/02/2020-14/02/2021). Assim sucessivamente até chegar ao ciclo atual. O RH preserva a história da organização no sistema.
+  - **Exemplo — pago via multa (Maria, caso reportado em homologação)**: funcionário admitido em 02/04/2024, sem férias cadastradas → `resolveNextCycle` retorna ciclo 1 (aquisitivo 02/04/2024-01/04/2025, concessivo 02/04/2025-01/04/2026). Hoje é 23/04/2026 — concessivo já terminou há 22 dias. Cadastro com `startDate=21/05/2026, endDate=31/05/2026` → aceito, snapshot captura ciclo 1. UI compara `startDate (21/05/2026) > concessivePeriodEnd (01/04/2026)` → exibe badge "Pago via Multa".
   - Suporte a ferias fracionadas (multiplos registros no mesmo aquisitivo) já é considerado por `resolveNextCycle` via soma de `daysEntitled` por `acquisitionPeriodStart`.
   - Regra CLT: aquisitivo = 12 meses; concessivo = 12 meses apos o fim do aquisitivo.
   - **Read-only na API**: removidos dos schemas Zod de create/update. Enviados no payload sao silenciosamente stripados. Frontend exibe em DatePickers desabilitados.
@@ -49,7 +52,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 
 ## Fields
 
-- `startDate`, `endDate` (datas das ferias — obrigatoriamente dentro do concessivo do proximo ciclo no momento do create)
+- `startDate`, `endDate` (datas das ferias — livres dentro dos limites gerais do módulo; quando `startDate > concessivePeriodEnd` do snapshot, a UI classifica como "Pago via Multa")
 - `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **snapshot do proximo ciclo** resolvido pelo backend no create, read-only na API, presente na response)
 - `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **snapshot do proximo ciclo** resolvido pelo backend no create, read-only na API, presente na response)
 - `daysEntitled` (inteiro, 1 a 30 conforme CLT art. 130, obrigatorio, sem default)
@@ -86,7 +89,6 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `VacationInvalidDaysError` (422) -- daysEntitled != intervalo de datas, ou daysUsed > daysEntitled
 - `VacationDateBeforeHireError` (422) -- qualquer data anterior a hireDate do funcionario
 - `VacationAquisitivoExceededError` (422) -- soma de `daysEntitled` no aquisitivo excederia 30 dias. Details: `{ acquisitionPeriodStart, acquisitionPeriodEnd, currentTotal, requestedDays, daysRemaining, maxAllowed: 30 }`.
-- `VacationStartDateOutsideConcessiveError` (422) -- `startDate` fora do concessivo do proximo ciclo. Details: `{ startDate, concessivePeriodStart, concessivePeriodEnd }`. Substitui a antiga regra que bloqueava novos contratados.
 - `VacationNoRightsError` (422) -- **legacy, nao mais lancado em producao**. Mantido no arquivo `errors.ts` para compatibilidade retroativa (codigos de erro ja expostos em integracoes / historicos). Novos contratados agora agendam ferias futuras livremente via proximo ciclo.
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)
 - `EmployeeTerminatedError` (422) -- shared, from `src/modules/employees/errors.ts`

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -422,7 +422,7 @@ describe("POST /v1/vacations", () => {
     expect(body.success).toBe(true);
   });
 
-  test("should reject when startDate is before the active cycle's concessivo", async () => {
+  test("accepts cadastro with startDate after concessivoEnd of resolved cycle (pago via multa, no prior history)", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -440,21 +440,25 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2024-12-20",
-          endDate: "2025-01-05",
+          startDate: "2027-02-01",
+          endDate: "2027-02-17",
           daysEntitled: 17,
           daysUsed: 0,
+          status: "scheduled",
         }),
       })
     );
 
-    expect(response.status).toBe(422);
+    expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.error.code).toBe("VACATION_START_DATE_OUTSIDE_CONCESSIVE");
-    expect(body.error.details).toBeObject();
-    expect(body.error.details.startDate).toBe("2024-12-20");
-    expect(body.error.details.concessivePeriodStart).toBeString();
-    expect(body.error.details.concessivePeriodEnd).toBeString();
+    expect(body.success).toBe(true);
+    expect(body.data.startDate).toBe("2027-02-01");
+    expect(body.data.endDate).toBe("2027-02-17");
+    expect(body.data.daysEntitled).toBe(17);
+    expect(body.data.acquisitionPeriodStart).toBe("2025-01-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2025-12-31");
+    expect(body.data.concessivePeriodStart).toBe("2026-01-01");
+    expect(body.data.concessivePeriodEnd).toBe("2026-12-31");
   });
 
   test("computes periods from hireDate for employee without prior vacations", async () => {
@@ -572,7 +576,7 @@ describe("POST /v1/vacations", () => {
     expect(body.data.concessivePeriodEnd).toBe("2026-06-09");
   });
 
-  test("rejects with 422 when vacation startDate is before first cycle's concessivo", async () => {
+  test("accepts cadastro with startDate after concessivoEnd of first cycle (pago via multa for new hire)", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -592,8 +596,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2026-03-01",
-          endDate: "2026-03-10",
+          startDate: "2027-08-01",
+          endDate: "2027-08-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -601,12 +605,16 @@ describe("POST /v1/vacations", () => {
       })
     );
 
-    expect(response.status).toBe(422);
+    expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.error.code).toBe("VACATION_START_DATE_OUTSIDE_CONCESSIVE");
-    expect(body.error.details.startDate).toBe("2026-03-01");
-    expect(body.error.details.concessivePeriodStart).toBe("2026-06-10");
-    expect(body.error.details.concessivePeriodEnd).toBe("2027-06-09");
+    expect(body.success).toBe(true);
+    expect(body.data.startDate).toBe("2027-08-01");
+    expect(body.data.endDate).toBe("2027-08-10");
+    expect(body.data.daysEntitled).toBe(10);
+    expect(body.data.acquisitionPeriodStart).toBe("2025-06-10");
+    expect(body.data.acquisitionPeriodEnd).toBe("2026-06-09");
+    expect(body.data.concessivePeriodStart).toBe("2026-06-10");
+    expect(body.data.concessivePeriodEnd).toBe("2027-06-09");
   });
 
   test("allows creating vacation for new hire (< 1 anniversary) when startDate is within first future concessivo", async () => {
@@ -750,7 +758,7 @@ describe("POST /v1/vacations", () => {
     expect(body.data.concessivePeriodEnd).toBe("2025-04-21");
   });
 
-  test("rejects when startDate falls outside the selected active cycle's concessivo", async () => {
+  test("accepts cadastro with startDate after concessivoEnd of next resolved cycle (pago via multa, with history)", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({
         emailVerified: true,
@@ -782,8 +790,8 @@ describe("POST /v1/vacations", () => {
         headers: { ...headers, "Content-Type": "application/json" },
         body: JSON.stringify({
           employeeId: employee.id,
-          startDate: "2024-10-01",
-          endDate: "2024-10-10",
+          startDate: "2026-02-01",
+          endDate: "2026-02-10",
           daysEntitled: 10,
           daysUsed: 0,
           status: "scheduled",
@@ -791,12 +799,58 @@ describe("POST /v1/vacations", () => {
       })
     );
 
-    expect(response.status).toBe(422);
+    expect(response.status).toBe(200);
     const body = await response.json();
-    expect(body.error.code).toBe("VACATION_START_DATE_OUTSIDE_CONCESSIVE");
-    expect(body.error.details.startDate).toBe("2024-10-01");
-    expect(body.error.details.concessivePeriodStart).toBe("2025-01-01");
-    expect(body.error.details.concessivePeriodEnd).toBe("2025-12-31");
+    expect(body.success).toBe(true);
+    expect(body.data.startDate).toBe("2026-02-01");
+    expect(body.data.endDate).toBe("2026-02-10");
+    expect(body.data.daysEntitled).toBe(10);
+    expect(body.data.acquisitionPeriodStart).toBe("2024-01-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2024-12-31");
+    expect(body.data.concessivePeriodStart).toBe("2025-01-01");
+    expect(body.data.concessivePeriodEnd).toBe("2025-12-31");
+  });
+
+  test("accepts cadastro with startDate far in the future beyond the resolved cycle's concessivo (pago via multa scenario)", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+        skipTrialCreation: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2024-01-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-05-01",
+          endDate: "2026-05-10",
+          daysEntitled: 10,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.startDate).toBe("2026-05-01");
+    expect(body.data.endDate).toBe("2026-05-10");
+    expect(body.data.daysEntitled).toBe(10);
+    expect(body.data.acquisitionPeriodStart).toBe("2024-01-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2024-12-31");
+    expect(body.data.concessivePeriodStart).toBe("2025-01-01");
+    expect(body.data.concessivePeriodEnd).toBe("2025-12-31");
   });
 
   test("should set employee status to VACATION_SCHEDULED after creating vacation", async () => {

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -115,19 +115,3 @@ export class VacationAquisitivoExceededError extends VacationError {
     );
   }
 }
-
-export class VacationStartDateOutsideConcessiveError extends VacationError {
-  status = 422;
-
-  constructor(args: {
-    startDate: string;
-    concessivePeriodStart: string;
-    concessivePeriodEnd: string;
-  }) {
-    super(
-      "Data de início das férias deve estar dentro do período concessivo do ciclo ativo",
-      "VACATION_START_DATE_OUTSIDE_CONCESSIVE",
-      args
-    );
-  }
-}

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -16,7 +16,6 @@ import {
   VacationInvalidEmployeeError,
   VacationNotFoundError,
   VacationOverlapError,
-  VacationStartDateOutsideConcessiveError,
 } from "./errors";
 import type {
   CreateVacationInput,
@@ -226,22 +225,6 @@ export abstract class VacationService {
     }
   }
 
-  private static validateStartDateInConcessive(
-    startDate: string,
-    cycle: { concessivePeriodStart: string; concessivePeriodEnd: string }
-  ): void {
-    if (
-      startDate < cycle.concessivePeriodStart ||
-      startDate > cycle.concessivePeriodEnd
-    ) {
-      throw new VacationStartDateOutsideConcessiveError({
-        startDate,
-        concessivePeriodStart: cycle.concessivePeriodStart,
-        concessivePeriodEnd: cycle.concessivePeriodEnd,
-      });
-    }
-  }
-
   private static async resolveCycleForEmployee(
     employeeId: string,
     organizationId: string,
@@ -382,8 +365,6 @@ export abstract class VacationService {
       organizationId,
       employee.hireDate
     );
-
-    VacationService.validateStartDateInConcessive(data.startDate, activeCycle);
 
     VacationService.validateDays(
       data.startDate,


### PR DESCRIPTION
## Contexto

Durante homologação, a cliente Maria reportou um caso (admissão em 02/04/2024 com cadastro de férias para 21/05/2026) em que o backend recusava o lançamento porque `startDate` caía fora do `concessivePeriodEnd` do próximo ciclo. Feedback da cliente: "o sistema precisa permitir o cadastro de férias pagas fora do prazo (pago via multa — CLT art. 137) **sem bloquear silenciosamente**, já que isso representa uma realidade concreta de folha".

A filosofia adotada há várias ondas atrás para este módulo é **history-based + preservar história**: o `resolveNextCycle` já não depende do tempo atual e deriva o próximo ciclo contiguamente do histórico registrado. Faltava esticar essa mesma filosofia para o `startDate`: ele precisa ser **livre** dentro dos limites gerais do módulo, não travado ao concessivo do snapshot.

## O que mudou

- **Backend aceita `startDate` livre**: removido `validateStartDateInConcessive` do fluxo de create. `startDate` agora respeita apenas os limites gerais (`validateDates`, `validateDaysBetweenDates`, `ensureAquisitivoLimit`, `ensureNoOverlap`, não-anterior-a-hireDate). O snapshot de aquisitivo/concessivo continua sendo o ciclo retornado por `resolveNextCycle`, **mesmo quando `startDate` cai fora do concessivo** — representa pago via multa.
- **`VacationStartDateOutsideConcessiveError` removido** do `errors.ts`. `VacationNoRightsError` permanece marcado como legacy (já era).
- **Testes adaptados**: cadastros com `startDate` além de `concessivePeriodEnd` agora succeed; novo cenário cobre explicitamente o caso Maria (pago via multa). `121 pass / 0 fail`.
- **CLAUDE.md atualizado**: Business Rules reescreve a regra de `startDate`; novo exemplo "Maria — pago via multa"; Fields atualizado; erro removido da lista; documenta que a classificação "Pago via Multa" é derivada pela UI via `startDate > concessivePeriodEnd` do snapshot (não persistida no banco).

## O que NÃO mudou

- Snapshot de aquisitivo/concessivo continua **imutável** nos updates (preserva history-based reasoning).
- Regra CLT 30 dias por aquisitivo (`ensureAquisitivoLimit`) intacta.
- Overlap check (`VacationOverlapError`) intacto.
- Employee status sync (`syncEmployeeStatus`) intacto.
- Endpoint `/employee/:employeeId/next-cycle` inalterado.

## Fora de escopo

- **UI deriva a classificação** "Pago via Multa" via `startDate > concessivePeriodEnd` — entregue em PR separada no frontend.
- Override manual pelo user (ex: "gozado em data fora do prazo por acordo coletivo" quando o backend resolveria como pago via multa) — não requerido neste ciclo.
- Campo persistido no banco para o tipo de pagamento — se necessário no futuro, migrar pra flag explícita.
- Abono pecuniário (1/3 vendido) — fora de escopo, tratamento independente.

## Dependência

FE PR em seguida (deriva a classificação "Pago via Multa" do payload).

## Test plan

- [ ] CI verde (`test.yml`)
- [ ] Deploy preview + revalidação do caso Maria (admissão 02/04/2024, cadastro 21/05/2026-31/05/2026) deve succeed e retornar snapshot ciclo 1
- [ ] Cenários regulares (cadastro dentro do concessivo) continuam funcionando sem alteração de comportamento
- [ ] `ensureAquisitivoLimit`, `ensureNoOverlap`, `validateDatesNotBeforeHire` continuam lançando corretamente nos casos respectivos

🤖 Generated with [Claude Code](https://claude.com/claude-code)