### PR TITLE
feat(email): best-effort wrapper for post-op notifications (OQ-14)

### DIFF
--- a/docs/improvements/changelog.md
+++ b/docs/improvements/changelog.md
@@ -11,6 +11,36 @@
 
 Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
 
+### 2026-04-23 — OQ-14 resolvida: política de 2 classes para erros de email (commit `42699a0`)
+
+Formalizada política de erro em emails, aplicada via novo helper `sendBestEffort` em `src/lib/email.tsx`:
+
+**Críticos** (propagam erro — user espera feedback):
+- `sendVerificationEmail`, `sendPasswordResetEmail`, `sendTwoFactorOTPEmail`, `sendOrganizationInvitationEmail`, `sendContactEmail`
+- Admin actions síncronas: `sendCheckoutLinkEmail` (self-service), `sendCancellationScheduledEmail`, `sendPriceAdjustmentEmail`, `sendUpgradeConfirmationEmail`
+
+**Best-effort** (log + swallow — operação principal já commitada):
+- Listeners de payments (já tinham `try/catch` individual — sem mudança)
+- Cron jobs em `jobs.service.ts` (já tinham `try/catch` — sem mudança)
+- **4 call sites convertidos neste commit**:
+  1. `plan-change.service.ts::sendPlanChangeEmail` — cron-triggered, email falhar antes quebrava o job impedindo outros scheduled changes
+  2. `admin-provision.service.ts::createCheckoutProvision` — admin triggered, email falhar dava 500 mesmo com org+checkout persistidos
+  3. `admin-provision.service.ts::sendRegenerationEmail` — regenerate checkout, mesma lógica
+  4. `lib/auth/hooks.ts::sendPasswordResetForProvisionOrDefault` — fallback para `sendPasswordResetEmail` default se provision activation falhar (user nunca fica sem email)
+
+Helper usado com log type padronizado `<module>:<action>:failed` permitindo alerting Sentry uniforme:
+
+```ts
+await sendBestEffort(
+  () => sendPlanChangeExecutedEmail({ ... }),
+  { type: "plan-change:executed-email:failed", organizationId, ... }
+);
+```
+
+Validação: 262/262 tests afetados (auth + plan-change + admin-provision + jobs), bunx tsc + ultracite clean.
+
+**OQ-14 fechada** em `docs/improvements/open-questions.md`. Resta 7 OQs abertas aguardando análise do dono.
+
 ### 2026-04-23 — CP-53 Fase 2 entregue: 10 fixes objetivos em `src/lib/` (PR #271)
 
 Executa fixes de qualidade identificados na Fase 1 do CP-53 **que não dependem de Open Questions estratégicas**. Escopo disciplinado após pushback válido do dono:

--- a/docs/improvements/open-questions.md
+++ b/docs/improvements/open-questions.md
@@ -16,6 +16,7 @@
 **✅ Resolvidas** (decisão tomada, ação registrada):
 - OQ-7 (RateLimitedError) — keep scaffolding (PR #271 decidido)
 - OQ-8 (passwordComplexityRules export) — removed (commit `b4c5204`)
+- OQ-14 (política de erro em emails) — 2 classes implementadas via `sendBestEffort` wrapper (commit `42699a0`)
 - OQ-15 (SMTP pool) — Hostinger pool configurado (commit `b4c5204`)
 
 **⏸️ Aguardando análise/decisão do dono** (abertas, com sugestão do audit registrada):
@@ -26,7 +27,6 @@
 - OQ-6 (super_admin vs admin consolidar?)
 - OQ-10 (retry jitter default?)
 - OQ-11 (deleteUser custom endpoint?)
-- OQ-14 (política de erro em emails)
 
 ---
 
@@ -334,7 +334,7 @@
 
 ### OQ-14 — Política de erro em emails: throw em críticos (verification/passwordReset), log-e-engole em notificações (admin/cancel)?
 
-**⏸️ Status**: Aguardando decisão do dono (2026-04-23). Proposta detalhada apresentada — ver resposta no chat. Current state não é "errado", é **inconsistente**. Fix simples (wrapper `dispatchEmail({ critical: boolean })`) cabe no CP-2.
+**✅ Status**: Resolvida (2026-04-23, commit `42699a0`). Decisão do dono: aplicar política de 2 classes para consistência e UX. **Críticos** (user-initiated com feedback síncrono: verification, reset, 2FA, invitation, contact, admin checkout-link) continuam propagando erro. **Best-effort** (system/cron-initiated pós-operação: plan-change executado, provision checkout link, provision activation) ganham wrapper `sendBestEffort` que loga e não propaga. 4 call sites convertidos + fallback adicionado em `sendPasswordResetForProvisionOrDefault` para user nunca ficar sem email.
 
 **Origem**: review de `src/lib/email.tsx` (CP-53).
 

--- a/src/lib/auth/hooks.ts
+++ b/src/lib/auth/hooks.ts
@@ -68,13 +68,27 @@ export async function sendPasswordResetForProvisionOrDefault({
       .where(eq(schema.organizations.id, provision.organizationId))
       .limit(1);
 
-    await sendProvisionActivationEmail({
-      email: user.email,
-      url: activationUrl,
-      userName: user.name,
-      organizationName: org?.name ?? "sua organização",
-      isTrial: provision.type === "trial",
-    });
+    try {
+      await sendProvisionActivationEmail({
+        email: user.email,
+        url: activationUrl,
+        userName: user.name,
+        organizationName: org?.name ?? "sua organização",
+        isTrial: provision.type === "trial",
+      });
+    } catch (error) {
+      // Provision activation falhou (SMTP down ou template erro) — cai no fluxo
+      // default de reset para não deixar o user sem email. activationSentAt não
+      // é gravado nesse caso, permitindo reenvio posterior.
+      logger.error({
+        type: "admin-provision:activation:email-failed",
+        userId: user.id,
+        provisionId: provision.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await sendPasswordResetEmail({ email: user.email, url });
+      return;
+    }
     await db
       .update(schema.adminOrgProvisions)
       .set({ activationUrl, activationSentAt: new Date() })

--- a/src/lib/email.tsx
+++ b/src/lib/email.tsx
@@ -20,6 +20,7 @@ import { TrialExpiredEmail } from "@/emails/templates/payments/trial-expired";
 import { TrialExpiringEmail } from "@/emails/templates/payments/trial-expiring";
 import { UpgradeConfirmationEmail } from "@/emails/templates/payments/upgrade-confirmation";
 import { env } from "@/env";
+import { logger } from "@/lib/logger";
 
 const isProdEmail = env.NODE_ENV === "production";
 
@@ -65,6 +66,30 @@ export async function sendEmail({ to, subject, html, text }: SendEmailParams) {
     html,
     ...(text && { text }),
   });
+}
+
+/**
+ * Wraps a best-effort email send — logs failures but never propagates them.
+ * Use in system/cron-initiated flows where the primary operation (subscription
+ * cancel, plan change, provision creation, etc.) already succeeded and the
+ * email is purely a notification. Failing the email must not fail the parent.
+ *
+ * Critical user-initiated emails (verification, password reset, 2FA, invitation,
+ * contact form, user-facing admin actions like checkout link) keep throwing —
+ * user needs feedback when retries are their only recourse.
+ */
+export async function sendBestEffort(
+  send: () => Promise<void>,
+  context: { type: string; [key: string]: unknown }
+): Promise<void> {
+  try {
+    await send();
+  } catch (error) {
+    logger.error({
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 // ============================================================

--- a/src/modules/payments/admin-provision/admin-provision.service.ts
+++ b/src/modules/payments/admin-provision/admin-provision.service.ts
@@ -4,7 +4,7 @@ import type { AdminOrgProvision } from "@/db/schema";
 import { schema } from "@/db/schema";
 import { env } from "@/env";
 import { auth } from "@/lib/auth";
-import { sendProvisionCheckoutLinkEmail } from "@/lib/email";
+import { sendBestEffort, sendProvisionCheckoutLinkEmail } from "@/lib/email";
 import { logger } from "@/lib/logger";
 import { AdminCheckoutService } from "@/modules/payments/admin-checkout/admin-checkout.service";
 import { PlansService } from "@/modules/payments/plans/plans.service";
@@ -408,14 +408,26 @@ export abstract class AdminProvisionService {
         .where(eq(schema.subscriptionPlans.id, basePlanId))
         .limit(1);
 
-      await sendProvisionCheckoutLinkEmail({
-        to: ownerEmail,
-        userName: ownerName,
-        organizationName: organization.name,
-        planName: plan?.displayName ?? "Plano Customizado",
-        checkoutUrl: checkoutResult.checkoutUrl,
-        expiresAt,
-      });
+      // Admin-triggered provision já persistida em DB — email falhar não pode
+      // reverter a criação da org+user. Admin vê 200 e pode reenviar o email
+      // via /admin/provisions/:id/resend-activation.
+      await sendBestEffort(
+        () =>
+          sendProvisionCheckoutLinkEmail({
+            to: ownerEmail,
+            userName: ownerName,
+            organizationName: organization.name,
+            planName: plan?.displayName ?? "Plano Customizado",
+            checkoutUrl: checkoutResult.checkoutUrl,
+            expiresAt,
+          }),
+        {
+          type: "admin-provision:checkout-link-email:failed",
+          organizationId: createdOrg.id,
+          provisionId,
+          ownerEmail,
+        }
+      );
 
       // 11. Return provision data (show contracted plan, not interim trial)
       const [provision] = await db
@@ -841,14 +853,25 @@ export abstract class AdminProvisionService {
       .where(eq(schema.organizations.id, provision.organizationId))
       .limit(1);
 
-    await sendProvisionCheckoutLinkEmail({
-      to: user.email,
-      userName: user.name,
-      organizationName: org?.name ?? "",
-      planName: planDisplayName,
-      checkoutUrl,
-      expiresAt,
-    });
+    // Regenerate checkout — admin action de retry. Checkout link já foi gerado
+    // e salvo; email falhar não pode reverter a regeneração. Admin pode chamar
+    // resend-activation se precisar.
+    await sendBestEffort(
+      () =>
+        sendProvisionCheckoutLinkEmail({
+          to: user.email,
+          userName: user.name,
+          organizationName: org?.name ?? "",
+          planName: planDisplayName,
+          checkoutUrl,
+          expiresAt,
+        }),
+      {
+        type: "admin-provision:regenerate-email:failed",
+        provisionId: provision.id,
+        userEmail: user.email,
+      }
+    );
   }
 
   private static async fetchProvisionData(

--- a/src/modules/payments/plan-change/plan-change.service.ts
+++ b/src/modules/payments/plan-change/plan-change.service.ts
@@ -2,6 +2,7 @@ import { and, eq, isNotNull, isNull, lte } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import {
+  sendBestEffort,
   sendCheckoutLinkEmail,
   sendPlanChangeExecutedEmail,
 } from "@/lib/email";
@@ -1465,13 +1466,26 @@ export abstract class PlanChangeService {
     const emailData =
       await PlanChangeService.getOrganizationOwnerEmail(organizationId);
 
-    if (emailData) {
-      await sendPlanChangeExecutedEmail({
-        to: emailData.email,
-        organizationName: emailData.organizationName,
+    if (!emailData) {
+      return;
+    }
+
+    // Cron-triggered (executeScheduledChange) — plan change já foi persistido.
+    // Email falhar não pode quebrar o job e impedir outros scheduled changes.
+    await sendBestEffort(
+      () =>
+        sendPlanChangeExecutedEmail({
+          to: emailData.email,
+          organizationName: emailData.organizationName,
+          previousPlanName,
+          newPlanName,
+        }),
+      {
+        type: "plan-change:executed-email:failed",
+        organizationId,
         previousPlanName,
         newPlanName,
-      });
-    }
+      }
+    );
   }
 }


### PR DESCRIPTION
## Summary

Resolve **OQ-14** — política de erro em emails. Implementa 2 classes:

- **Críticos** (user espera feedback) propagam erro: verification, password-reset, 2FA, invitation, contact, admin actions síncronas. Status quo preservado.
- **Best-effort** (operação principal já commitada) agora usam wrapper `sendBestEffort` que loga e não propaga. 4 call sites convertidos.

## Mudanças

### Novo helper em `src/lib/email.tsx`

```ts
async function sendBestEffort(
  send: () => Promise<void>,
  context: { type: string; [key: string]: unknown }
): Promise<void> {
  try {
    await send();
  } catch (error) {
    logger.error({
      ...context,
      error: error instanceof Error ? error.message : String(error),
    });
  }
}
```

### 4 call sites convertidos

1. **`plan-change.service.ts::sendPlanChangeEmail`** — chamado de `executeScheduledChange` (cron). Antes: email falhar quebrava o job inteiro, impedindo outros scheduled changes naquele tick.

2. **`admin-provision.service.ts::createCheckoutProvision`** (linha ~414) — admin cria provision. Antes: email falhar dava 500 mesmo com org+user+checkout persistidos. Admin pode reenviar via `/admin/provisions/:id/resend-activation`.

3. **`admin-provision.service.ts::sendRegenerationEmail`** (linha ~855) — admin regenera checkout expirado. Mesma lógica.

4. **`lib/auth/hooks.ts::sendPasswordResetForProvisionOrDefault`** — quando user é provision, se `sendProvisionActivationEmail` falhar, fall back para `sendPasswordResetEmail` default. User nunca fica sem email. `activationSentAt` não é gravado no fallback, permitindo reenvio da ativação depois via admin UI.

### Log types padronizados

`<module>:<action>:failed` permite alerting Sentry uniforme por categoria.

## Commits

- `42699a0` feat(email): best-effort wrapper para notifications pós-operação (OQ-14)
- `537fd1f` docs(improvements): register OQ-14 resolution (email error policy)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npx ultracite check` clean (583 files)
- [x] 262/262 tests afetados passam (auth + plan-change + admin-provision + jobs)
- [ ] Manual smoke em dev: simular SMTP offline durante plan-change cron → job deve completar + log error estruturado
- [ ] Manual smoke: admin-provision checkout com SMTP offline → provision criada, admin vê 200, log error

## Decisões documentadas

- **Não criou wrapper `dispatchEmail({ critical: boolean })` agora** — over-engineering pra 4 call sites. Se CP-2 chegar a refatorar `email.tsx` em `lib/emails/senders/*.tsx`, o padrão `sendBestEffort` migra naturalmente.
- **Não adicionou retry queue (BullMQ/Redis)** — MP-4 YAGNI. Log + Sentry alert é suficiente para MVP.
- **Alerting Sentry dos log types `*:failed`** — infra operacional (não-código), deixado como próximo passo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)