### PR TITLE
fix(auth/hooks): uniformize org effects + Sentry alerts (OQ-3)

### DIFF
--- a/docs/improvements/open-questions.md
+++ b/docs/improvements/open-questions.md
@@ -12,9 +12,12 @@
 - OQ-1 → Issue #273 (PII strategy)
 - OQ-4 → Issue #278 (Timeout.withTimeout scaffolding)
 - OQ-9 → Issue #274 (CNPJ alfanumérico)
+- OQ-10 → Issue #279 (retry jitter preventive)
 - OQ-12/OQ-13 → Issue #275 (x-error-messages shape)
 
 **✅ Resolvidas** (decisão tomada, ação registrada):
+- OQ-2 (orgStatements dead resources) — keep, inventário documental
+- OQ-3 (fire-and-forget em org effects) — try/catch await uniformizado + Sentry alerts (commit `b973dfd`)
 - OQ-5 (apiKey.rateLimit magic number) — keep hardcoded, CLAUDE.md já documenta
 - OQ-6 (super_admin vs admin idênticos) — intencional, distinção em allowlists + UI
 - OQ-7 (RateLimitedError) — keep scaffolding (PR #271 decidido)
@@ -23,10 +26,7 @@
 - OQ-14 (política de erro em emails) — 2 classes via `sendBestEffort` (commit `42699a0`)
 - OQ-15 (SMTP pool) — Hostinger pool configurado (commit `b4c5204`)
 
-**⏸️ Aguardando análise/decisão do dono** (abertas):
-- OQ-2 (orgStatements dead resources) — aguardando decisão após esclarecimento
-- OQ-3 (fire-and-forget em org effects) — dono indicou Opção A, aguardando confirmação do fallback strategy
-- OQ-10 (retry jitter default) — dono perguntou relevância, audit sugere fechar como YAGNI
+**🎉 Todas as 15 OQs endereçadas** — 5 em issues (revisitar depois), 10 resolvidas.
 
 ---
 
@@ -60,7 +60,7 @@
 
 ### OQ-2 — `member`, `invitation`, `billingProfile` em `orgStatements` são documentação viva ou futura checagem?
 
-**⏸️ Status**: Aguardando análise do dono. **Sugestão do audit**: manter — custo de remover 5 linhas agora > churn ao reintroduzir se precisar. Mas pode também argumentar pro lado oposto (menos dead declarations).
+**✅ Status**: Resolvida (2026-04-23). Decisão do dono: **manter como está**. Inventário documental das resources — se alguém expuser endpoint custom de member/invitation/billingProfile no futuro (em vez de depender do BA plugin interno), as declarações estarão prontas para uso via `permissions: {...}` no macro. Não é bug — autorização acontece (via BA internal access control para member/invitation, `requireAdmin` para billingProfile), só não passa pelo macro local.
 
 **Origem**: review de `src/lib/auth/permissions.ts` (CP-53).
 
@@ -82,7 +82,7 @@
 
 ### OQ-3 — `triggerAfterCreateOrganizationEffects` fire-and-forget em side-effects é intencional?
 
-**⏸️ Status**: Aguardando análise do dono. **Sugestão do audit**: aceitar silent-fail com log em MVP (evitar dead-letter queue / BullMQ = MP-4 YAGNI). Se aceitar, adicionar alerta Sentry para log types `organization:auto-profile:failed` e `audit:organization-create:failed` (infra operacional). Alternativa: uniformizar em `try/catch await` síncrono — bloqueia resposta mas garante consistência.
+**✅ Status**: Resolvida (2026-04-23, commit `b973dfd`). Decisão do dono: **Opção A + alerta Sentry**. Todos os 3 side-effects (createTrial, createMinimalProfile, auditOrganizationCreate) agora seguem mesmo pattern: `try/catch await + logger.error + ErrorReporter.capture`. Novo helper privado `reportOrgEffectFailure` em hooks.ts emite Sentry event com tags estruturadas (`type`, `organizationId`) para alerting. Usuário nunca trava — caminhos de recuperação manual documentados no JSDoc do helper. **Ação operacional pendente**: configurar alert rule no Sentry dashboard para `tag:type startsWith "organization:" OR "audit:organization"`.
 
 **Origem**: review de `src/lib/auth/hooks.ts` (CP-53).
 
@@ -243,7 +243,7 @@
 
 ### OQ-10 — Jitter default=true em `retry.ts` quebra determinismo dos testes existentes?
 
-**⏸️ Status**: Aguardando análise do dono. **Sugestão do audit**: não adicionar preventivamente — thundering herd não foi observado em produção, mudança quebra tests timing-based, 8 consumers internos usam config padrão. Alternativas: (a) adicionar como opcional `jitter?: boolean` default false; (b) adicionar default true + migrar tests para fake timers (esforço extra).
+**📌 Status**: Rastreada em **[issue #279](https://github.com/tlthiago/synnerdata-api-b/issues/279)** (2026-04-23). Decisão do dono: criar issue para entender melhor depois. Não adicionar agora — preventivo para problema não-observado. Issue lista triggers (crescimento de base, sinal Sentry de 429 cascata, migração BullMQ) que devem trazer a decisão de volta ao radar.
 
 **Origem**: review de `src/lib/utils/retry.ts` (CP-53).
 

--- a/src/lib/auth/hooks.ts
+++ b/src/lib/auth/hooks.ts
@@ -26,6 +26,7 @@ import {
   sendProvisionActivationEmail,
 } from "@/lib/email";
 import { logger } from "@/lib/logger";
+import { ErrorReporter } from "@/lib/sentry/reporter";
 import { OrganizationService } from "@/modules/organizations/profile/organization.service";
 import { SubscriptionService } from "@/modules/payments/subscription/subscription.service";
 
@@ -330,6 +331,37 @@ export async function validateBeforeCreateInvitation({
   }
 }
 
+/**
+ * Reports a post-organization-create side-effect failure.
+ *
+ * These side-effects are best-effort — signup must succeed even if one
+ * or more of them fail. Each failure gets logged + Sentry captured so the
+ * operator can alert on the structured `type` tag and fix manually.
+ *
+ * Recovery paths (documented for future operators):
+ * - `organization:trial-creation:failed` → org sem subscription. User vê "sem
+ *   plano". Admin pode criar trial manualmente via POST /admin/provisions/trial.
+ * - `organization:auto-profile:failed` → org sem profile. GET /organizations/
+ *   profile retorna null. Admin pode completar via UI/endpoint de update.
+ * - `audit:organization-create:failed` → sem entry de audit. Sem impacto
+ *   funcional, gap de compliance. Insert manual em audit_logs se necessário.
+ */
+function reportOrgEffectFailure(
+  error: unknown,
+  context: { type: string; organizationId: string; userId?: string }
+): void {
+  logger.error({
+    ...context,
+    error: error instanceof Error ? error.message : String(error),
+  });
+  ErrorReporter.capture(error, {
+    tags: {
+      type: context.type,
+      organizationId: context.organizationId,
+    },
+  });
+}
+
 export async function triggerAfterCreateOrganizationEffects({
   organization: org,
   member,
@@ -340,30 +372,31 @@ export async function triggerAfterCreateOrganizationEffects({
   try {
     await SubscriptionService.createTrial(org.id);
   } catch (error) {
-    logger.error({
+    reportOrgEffectFailure(error, {
       type: "organization:trial-creation:failed",
       organizationId: org.id,
       userId: member.userId,
-      error: error instanceof Error ? error.message : String(error),
     });
   }
 
-  OrganizationService.createMinimalProfile(org.id, org.name).catch((error) => {
-    logger.error({
+  try {
+    await OrganizationService.createMinimalProfile(org.id, org.name);
+  } catch (error) {
+    reportOrgEffectFailure(error, {
       type: "organization:auto-profile:failed",
       organizationId: org.id,
-      error: error instanceof Error ? error.message : String(error),
     });
-  });
+  }
 
-  auditOrganizationCreate(org, member.userId).catch((error) => {
-    logger.error({
+  try {
+    await auditOrganizationCreate(org, member.userId);
+  } catch (error) {
+    reportOrgEffectFailure(error, {
       type: "audit:organization-create:failed",
       organizationId: org.id,
       userId: member.userId,
-      error: error instanceof Error ? error.message : String(error),
     });
-  });
+  }
 }
 
 export async function onOrganizationUpdated({


### PR DESCRIPTION
## Summary

Resolve **OQ-3** — padroniza error handling dos 3 side-effects em `triggerAfterCreateOrganizationEffects` + adiciona Sentry capture para alerting dashboard.

## Mudanças

### `src/lib/auth/hooks.ts`

Antes (inconsistente):
- `createTrial` → try/catch await + logger.error
- `createMinimalProfile` → `.catch()` fire-and-forget + logger.error (sem Sentry)
- `auditOrganizationCreate` → `.catch()` fire-and-forget + logger.error (sem Sentry)

Depois (uniforme):
- Todos os 3 → try/catch await + `reportOrgEffectFailure` helper (log + Sentry capture)

Novo helper privado `reportOrgEffectFailure`:
```ts
function reportOrgEffectFailure(
  error: unknown,
  context: { type: string; organizationId: string; userId?: string }
): void {
  logger.error({ ...context, error: ... });
  ErrorReporter.capture(error, {
    tags: { type: context.type, organizationId: context.organizationId },
  });
}
```

JSDoc do helper documenta os 3 log types + caminhos de recuperação manual.

## Usuário não fica travado

Cada side-effect isolado no seu try/catch. Signup sempre sucede.

| Failure | UI impact | Recovery |
|---|---|---|
| trial-creation | User vê "sem plano" | Admin cria trial via `POST /admin/provisions/trial` |
| auto-profile | `GET /organizations/profile` retorna null | Admin completa via UI/endpoint |
| audit:organization-create | Sem audit trail da criação | Insert manual em `audit_logs` se LGPD exigir |

## Outras OQs fechadas neste commit de docs

- **OQ-2** (orgStatements dead resources) — keep, inventário documental
- **OQ-10** (retry jitter) — rastreada em issue [#279](https://github.com/tlthiago/synnerdata-api-b/issues/279)

## 🎉 Todas as 15 OQs do CP-53 endereçadas

5 em GH issues para revisitar depois (OQ-1/4/9/10/12-13), 10 resolvidas.

## Ação operacional pendente (não-código)

Configurar alert rule no **Sentry dashboard** para eventos com:
- `tag:type` começando com `organization:` (trial/profile failures)
- `tag:type` começando com `audit:organization-` (audit trail gaps)

Assim o operador recebe notificação e aplica recovery manual.

## Commits

- `b973dfd` fix(auth/hooks): uniformize try/catch + Sentry alerts in org effects (OQ-3)
- `8dd6a62` docs(open-questions): close OQ-2/3 + track OQ-10 in issue #279

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `npx ultracite check` clean (583 files)
- [x] 115/115 tests em modules/auth (signup flow, trial creation, organization lifecycle)
- [ ] Manual smoke: simular falha do createMinimalProfile em dev → signup deve completar, Sentry event deve ter tag `type:organization:auto-profile:failed`
- [ ] Pós-merge: configurar alert rule no Sentry dashboard (ação operacional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)