### PR TITLE
feat(infra): Onda 6 batch — infra hardening quick wins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ USER bun
 
 EXPOSE 3333
 
-HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=30s \
-  CMD curl -f http://localhost:${PORT:-3333}/health/live || exit 1
+HEALTHCHECK --interval=10s --timeout=5s --retries=10 --start-period=30s \
+  CMD curl -fsS http://localhost:${PORT:-3333}/health | grep -q '"status":"healthy"' || exit 1
 
 CMD ["./scripts/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install dependencies
-FROM oven/bun:1-alpine AS install
+FROM oven/bun:1-alpine@sha256:4de475389889577f346c636f956b42a5c31501b654664e9ae5726f94d7bb5349 AS install
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ RUN mkdir -p /temp/prod && \
     bun install --frozen-lockfile --production --ignore-scripts
 
 # Release stage
-FROM oven/bun:1-alpine
+FROM oven/bun:1-alpine@sha256:4de475389889577f346c636f956b42a5c31501b654664e9ae5726f94d7bb5349
 
 RUN apk add --no-cache curl
 

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3",
         "react": "19.2.5",
+        "react-dom": "19.2.5",
         "zod": "~4.1.13",
       },
       "devDependencies": {

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -43,21 +43,25 @@
 
 ## Próxima ação
 
-### Ordem de execução recomendada (2026-04-24)
+### Ordem de execução recomendada (2026-04-24, revisada)
 
-Por **valor × custo × dependência** — ver tabela completa em [`roadmap.md § Ordem de execução`](./roadmap.md).
+**Sequência formal decidida** — priorizar isolamento de diagnóstico + destravar PRs grandes antes de escalar escopo. Ver [changelog 2026-04-24 "Sequência de execução revisada"](./changelog.md) para raciocínio completo.
 
-**🟡 Alta prioridade:**
+**🟡 Linha principal:**
 
-1. **CP-41** (M, Onda 3) — Workflow Pagarme integration tests. Fecha Onda 3.
-2. **Onda 6 batch** (4×S) — CP-10/11/12/49 em PR único: Docker SHA pin + HEALTHCHECK deep + wait-for-db + react/react-dom sync.
-3. **CP-17** (M, Onda 4) — Métricas básicas OTel/Prometheus. Gap operacional conhecido. Inclui #43 agregado.
+1. **Onda 6 batch** (4×S) — CP-10/11/12/49 em PR único: Docker SHA pin + HEALTHCHECK deep + wait-for-db + react/react-dom sync. ~2-3h.
+2. **Issue #269 tests 3+4** (DB state leak) — audit de factories/fixtures + cleanup explícito. **Pré-requisito de CP-47 e CP-2** (sem isso, PRs grandes reativam flakes em CI). Efforte M/L.
+3. **Onda 7 seq** (CP-48 → 47 → 46 → 50) — tooling migrations por ordem de risco crescente: Zod 4.3 → Better Auth 1.6 → Ultracite 7 → TS 6. Cada PR dedicado.
+4. **CP-2** (XL, Onda 5) — Emails consolidation. Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2 de graça. Fecha Onda 5 em 11/11.
+
+**🟡 Em paralelo (encaixa onde convier):**
+
+- **CP-41** (M, Onda 3) — Pagarme integration tests workflow. Dependência: secrets sandbox Pagar.me configurados. Fecha Onda 3.
+- **CP-17** (M, Onda 4) — Métricas OTel/Prometheus. Gap operacional conhecido. Inclui #43 agregado.
 
 **🟢 Condicional / bloqueio externo:**
 
-4. **CP-14 → 15 → 16** (Cloudflare Free Tier) — bloqueado pelo cliente (DNS registro.br).
-5. **Onda 7 seq** (CP-48 → 47 → 46 → 50) — Tooling migrations em janela dedicada.
-6. **CP-2** (XL, Onda 5) — Emails consolidation. **Bloqueado por [#269](https://github.com/tlthiago/synnerdata-api-b/issues/269)**. Último por design.
+- **CP-14 → 15 → 16** (Cloudflare Free Tier) — bloqueado pelo cliente (DNS registro.br).
 
 ### Ondas novas criadas em 2026-04-23
 

--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -13,14 +13,14 @@
 | Bucket | Total | Done | Active | Progresso |
 |---|---|---|---|---|
 | 🔴 **Urgente** (MVP-bloqueante) | 10 | 10 | 0 | ✅ **Completo** em 2026-04-22 |
-| 🟡 **Curto prazo** (hardening, 30-90d) | 50 | 33 | 13 | **66%** · 3 reclassificadas para MP (CP-18→MP-24, CP-19→MP-25 em 2026-04-23; CP-44→MP-27 em 2026-04-24) · CP-38 entregue 2026-04-24 |
+| 🟡 **Curto prazo** (hardening, 30-90d) | 50 | 37 | 9 | **74%** · 3 reclassificadas para MP (CP-18→MP-24, CP-19→MP-25 em 2026-04-23; CP-44→MP-27 em 2026-04-24) · Onda 6 batch + CP-38 entregues 2026-04-24 |
 | 🟢 **Médio prazo** (sob demanda) | 27 | 0 | 27 | +1 em 2026-04-24 (MP-27 ex-CP-44); +4 em 2026-04-23 (MP-23 + MP-24/25 ex-CP + MP-26 ex-candidato CP-51) |
 
 ### Saúde do codebase
 
 - ✅ **854 tests pass** (suíte afetada + smoke tests novos do `routes/v1/`)
 - ✅ **Ultracite clean** em 582 files
-- ✅ **63/98 débitos resolvidos** em `debts.md` (+ 2 reavaliados como não-débito) — 35 abertos (+3 fechados em CP-38: #90, #91, #93)
+- ✅ **66/98 débitos resolvidos** em `debts.md` (+ 2 reavaliados como não-débito) — 32 abertos (+3 fechados na Onda 6 batch: #87, #88, #89)
 - ✅ **Zero débito 🔴** pendente
 - ✅ **Onda 5 (refactors grandes)**: 10/11 entregues (91%) — resta apenas CP-2 (XL — bloqueado por issue [#269](https://github.com/tlthiago/synnerdata-api-b/issues/269)). CP-44 reclassificado para MP-27 em 2026-04-24
 
@@ -49,7 +49,7 @@
 
 **🟡 Linha principal:**
 
-1. **Onda 6 batch** (4×S) — CP-10/11/12/49 em PR único: Docker SHA pin + HEALTHCHECK deep + wait-for-db + react/react-dom sync. ~2-3h.
+1. ~~**Onda 6 batch**~~ ✅ Entregue 2026-04-24 — CP-10 (Docker SHA pin) + CP-11 (HEALTHCHECK deep) + CP-12 (wait-for-db) + CP-49 (react/react-dom sync).
 2. **Issue #269 tests 3+4** (DB state leak) — audit de factories/fixtures + cleanup explícito. **Pré-requisito de CP-47 e CP-2** (sem isso, PRs grandes reativam flakes em CI). Efforte M/L.
 3. **Onda 7 seq** (CP-48 → 47 → 46 → 50) — tooling migrations por ordem de risco crescente: Zod 4.3 → Better Auth 1.6 → Ultracite 7 → TS 6. Cada PR dedicado.
 4. **CP-2** (XL, Onda 5) — Emails consolidation. Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2 de graça. Fecha Onda 5 em 11/11.
@@ -70,6 +70,7 @@
 
 ### Histórico recente do bucket 🟡
 
+- ✅ **Onda 6 batch entregue** (2026-04-24) — 4 CPs em 5 commits atômicos: CP-10 (Docker SHA pin) + CP-11 (HEALTHCHECK deep com body check) + CP-12 (wait-for-db via `src/db/wait-for-db.ts`) + CP-49 (react-dom pin). Fecha débitos #87, #88, #89.
 - ✅ **CP-38 entregue** (2026-04-24) — 6 runbooks de oncall em `docs/runbooks/` + índice. Fecha débitos #90, #91, #93.
 - ~~**CP-44**~~ → **MP-27** (reclassificado 2026-04-24 — BOLA AST preventivo; solo dev + RU-9 limpo + testes cross-org já existentes tornam regressão improvável hoje)
 - ~~**CP-18/19**~~ → **MP-24/25** (reclassificados 2026-04-23 — sinal-driven, não pressing)
@@ -127,6 +128,7 @@ Detalhes completos em [roadmap.md § Metodologia de execução](./roadmap.md).
 - **2026-04-23 (CP-53 Fase 1)** — Auditoria de qualidade de 25 arquivos em `src/lib/` (8 agentes paralelos + 8 arquivos triviais auditados pelo parent). 15 Open Questions registradas. Matriz consolidada em changelog.
 - **2026-04-23 (CP-53 Fase 2 — PR #271)** — 10 commits atômicos de fixes objetivos não-bloqueados por OQs. Destaques: PII redaction em logs/Sentry (LGPD), extração de 6 callbacks do auth.ts, admin allowlist normalize (whitespace/case bug), email env vars. 707/707 tests passando. Débitos #70 e #71 fechados.
 - **2026-04-24 (CP-38 + CP-44 reclass)** — 6 runbooks de oncall em `docs/runbooks/` (db-down, app-container, pagarme-webhook, smtp-down, 5xx-surge, migration-rollback) + índice `README.md` com decision tree. Débitos #90, #91, #93 fechados. CP-44 reclassificado para MP-27 no mesmo dia → Onda 5 ficou em **10/11 entregues (91%)**.
+- **2026-04-24 (Onda 6 batch)** — 4 CPs em 5 commits atômicos: Docker SHA pin, HEALTHCHECK deep com body check, wait-for-db script, react-dom pin. Débitos #87/#88/#89 fechados. Onda 6 ✅ concluída.
 
 
 Changelog completo: [changelog.md](./changelog.md).

--- a/docs/improvements/changelog.md
+++ b/docs/improvements/changelog.md
@@ -11,6 +11,17 @@
 
 Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
 
+### 2026-04-24 — Onda 6 batch entregue (infra hardening)
+
+Primeira execução da sequência revisada. 4 CPs em 5 commits atômicos (1 de docs da sequência + 4 de CPs):
+
+- **CP-10** — `oven/bun:1-alpine` pinado com SHA digest (`sha256:4de475...`). Dependabot ecossistema docker já configurado detecta novos digests semanalmente. Fecha débito #87.
+- **CP-11** — HEALTHCHECK troca `/health/live` por `/health` com body check `grep -q '"status":"healthy"'` (endpoint sempre retorna 200, status vive no body via envelope). `retries` 5→10 (100s total). Coolify agora reinicia container se DB morrer. Fecha débito #88.
+- **CP-12** — `src/db/wait-for-db.ts` tenta `SELECT 1` com retry (30×1s, 2s connection timeout, ~30s total) antes de migrations em `scripts/entrypoint.sh`. Log estruturado via Pino. Fecha débito #89.
+- **CP-49** — `react-dom: "19.2.5"` adicionado explicitamente em `dependencies` (mesma versão pinada de `react`). Opção (a) do débito. Garante sync no lockfile + visibilidade para Dependabot. Testes de email (25 assertions) passando após mudança.
+
+**Bucket 🟡**: 37/50 concluídas (era 33). Onda 6 fechada ✅. Próximo passo: issue #269 tests 3+4 (DB state leak — pré-requisito de CP-47 e CP-2).
+
 ### 2026-04-24 — Sequência de execução revisada (Onda 6 → #269 → Onda 7 → Onda 5)
 
 Após audit de over-engineering (ver entry 2026-04-24 "reclassificação CP-44 → MP-27") e discussão sobre terminar Onda 5, **dono decidiu manter CP-2** (emails consolidation) como trabalho genuíno — refactor real de organização do módulo, facilita compreensão e manutenção.

--- a/docs/improvements/changelog.md
+++ b/docs/improvements/changelog.md
@@ -11,6 +11,23 @@
 
 Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
 
+### 2026-04-24 — Sequência de execução revisada (Onda 6 → #269 → Onda 7 → Onda 5)
+
+Após audit de over-engineering (ver entry 2026-04-24 "reclassificação CP-44 → MP-27") e discussão sobre terminar Onda 5, **dono decidiu manter CP-2** (emails consolidation) como trabalho genuíno — refactor real de organização do módulo, facilita compreensão e manutenção.
+
+**Sequência definida** (do mais rápido/isolado para o mais arriscado):
+
+1. **Onda 6 batch** (CP-10/11/12/49) — 4×S, ~2-3h. Quick wins infra sem dependência externa. PR batch único.
+2. **#269 tests 3+4** (DB state leak) — pré-requisito real de CP-2 e CP-47. Audit de factories/fixtures + cleanup explícito. Efforte M/L em PR próprio.
+3. **Onda 7 seq** (CP-48 → 47 → 46 → 50) — tooling migrations em ordem de risco crescente (Zod 4.3 → Better Auth 1.6 → Ultracite 7 → TS 6). Cada uma em PR dedicado + janela de teste. Stack atualizada antes do CP-2 evita dupla refactor.
+4. **CP-2** — emails consolidation (XL, 33 arquivos). Inclui `EmailDispatcher` wrapper que naturalmente resolve #269 tests 1+2. Fecha Onda 5 em 11/11.
+
+**Por que #269 entra explicitamente**: sem resolver tests 3+4 (DB state leak em factories), qualquer PR de escopo médio/grande daqui pra frente (CP-47 Better Auth ou CP-2 emails) vai reativar flakes no CI. Issue #269 diz isso explicitamente.
+
+**Outros CPs ativos** (CP-41 Pagarme tests, CP-17 métricas, Cloudflare CP-14/15/16) encaixam entre os passos acima conforme bandwidth e dependências externas (secrets Pagar.me, DNS registro.br com o cliente).
+
+**Raciocínio contra "Onda 6 → Onda 7 → Onda 5 direto"**: sem #269 resolvido, CP-47 (Better Auth 1.6, toca schema + hooks auth) e depois CP-2 (emails, toca hooks auth) provavelmente flakeariam no CI e mascarariam bugs reais. Melhor fazer o fix isolado antes de escalar escopo.
+
 ### 2026-04-24 — CP-38 entregue + CP-44 reclassificado (Onda 5 chega a 10/11)
 
 Duas decisões na mesma janela:

--- a/docs/improvements/debts.md
+++ b/docs/improvements/debts.md
@@ -212,14 +212,14 @@ Dimensão "Qualidade da implementação" adicionada à metodologia após o Bloco
 
 | # | Débito | Severidade | Ação |
 |---|---|---|---|
-| 87 | **Base image `oven/bun:1-alpine` sem pin de SHA** | 🟡 supply chain | Tag `1-alpine` muda. Em scan reprodutível, pinar como `oven/bun:1-alpine@sha256:<digest>` e atualizar via Dependabot. Trade-off: mais manual, mais seguro |
-| 88 | **HEALTHCHECK só chama `/health/live`** | 🟡 robustez | Liveness não detecta DB morto. Considerar trocar para `/health` (deep check) com `--retries=10` — se DB down, container marcado unhealthy, Coolify reinicia |
+| 87 | ~~**Base image `oven/bun:1-alpine` sem pin de SHA**~~ | ✅ **Resolvido em CP-10 (2026-04-24)** — Dockerfile pinado com `oven/bun:1-alpine@sha256:4de475...`. Dependabot ecossistema docker já configurado no `.github/dependabot.yml` detecta novos digests semanalmente |
+| 88 | ~~**HEALTHCHECK só chama `/health/live`**~~ | ✅ **Resolvido em CP-11 (2026-04-24)** — trocado para `/health` com body check `grep -q '"status":"healthy"'` (endpoint sempre retorna 200, status vive no body via envelope). `retries` 5→10 (100s total). Coolify reinicia container se DB morrer |
 
 **Entrypoint e runtime:**
 
 | # | Débito | Severidade | Ação |
 |---|---|---|---|
-| 89 | **Migrations rodam a cada startup sem wait-for-db** | 🟡 robustez | Se Postgres não está pronto quando container sobe, `bun run src/db/migrate.ts` falha e container morre. Adicionar `wait-for-it.sh` ou loop simples: `until pg_isready -h $DB_HOST; do sleep 1; done` antes do migrate |
+| 89 | ~~**Migrations rodam a cada startup sem wait-for-db**~~ | ✅ **Resolvido em CP-12 (2026-04-24)** — `src/db/wait-for-db.ts` tenta `SELECT 1` com retry (30 attempts × 1s delay + 2s connection timeout, ~30s total) antes de `bun run src/db/migrate.ts` em `scripts/entrypoint.sh`. Falha hard com log estruturado via Pino |
 | 90 | ~~**Sem estratégia de migration em scale**~~ | ✅ **Resolvido em CP-38 (2026-04-24)** — runbook `docs/runbooks/migration-rollback.md` documenta nota de escala: quando escalar horizontalmente (2+ instâncias), mover migration para job one-shot separado (Coolify pre-deploy hook ou Kubernetes Job). Não investir antes do sinal de escala |
 | 91 | ~~**Sem rollback de migration**~~ | ✅ **Resolvido em CP-38 (2026-04-24)** — runbook `docs/runbooks/migration-rollback.md` documenta 3 caminhos (parcial/corrupt-registry/destruído) com comandos SQL concretos e fallback para restore via `database-backup.md` |
 

--- a/docs/improvements/roadmap.md
+++ b/docs/improvements/roadmap.md
@@ -145,20 +145,28 @@ Sequência proposta para extrair valor rápido antes de atacar os refactors gran
 - **Ondas 6 e 7 criadas em 2026-04-23** durante sync de wave governance — realocam 8 CPs órfãos (CP-10/11/12/46/47/48/49/50) que nunca tinham sido mapeados em onda original.
 - Reavaliar ordem a cada 5 CPs concluídos — aprendizado do bucket 🔴 mostrou que prioridades mudam ao descobrir o escopo real.
 
-#### Ordem de execução recomendada (atualizada 2026-04-24)
+#### Ordem de execução recomendada (atualizada 2026-04-24, revisada)
 
-Sequência pragmática por **valor × custo × dependência**:
+Sequência formal decidida — priorizar isolamento de diagnóstico + destravar PRs grandes antes de escalar escopo. Ver [changelog 2026-04-24 "Sequência de execução revisada"](./changelog.md) para raciocínio completo.
+
+**Linha principal (sequencial):**
 
 | Prioridade | CP | Onda | Tamanho | Depende de | Racional |
 |---|---|---|---|---|---|
-| 🟡 1 | **CP-41** Pagarme integration tests workflow | Onda 3 | M | Secrets sandbox Pagar.me | Payments crítico; fecha Onda 3 (última ação restante) |
-| 🟡 2 | **Onda 6 batch** (CP-10/11/12/49) | Onda 6 | 4×S | — | Infra hardening quick wins em PR único |
-| 🟡 3 | **CP-17** Métricas OTel/Prometheus | Onda 4 | M | Decisão OTel vs Prometheus | Observability gap conhecido; inclui #43 agregado |
-| 🟢 4 | **CP-14 → 15 → 16** Cloudflare | Onda 4 | S→M→S | DNS do cliente (externo) | Sequencial, bloqueio externo |
-| 🟢 5 | **Onda 7 seq** (CP-48→47→46→50) | Onda 7 | M→L→L→M | Estabilidade da suíte | Tooling migrations em janela dedicada |
-| ⏸️ 6 | **CP-2** Emails consolidation | Onda 5 | XL | Issue #269 (flakes) | Último por design; worktree + plan formal obrigatórios |
+| 🟡 1 | **Onda 6 batch** (CP-10/11/12/49) | Onda 6 | 4×S | — | Infra hardening quick wins em PR único; zero dependência |
+| 🟡 2 | **Issue #269 tests 3+4** (DB state leak) | — | M/L | — | Pré-requisito de CP-47 e CP-2 — sem isso, PRs grandes reativam flakes em CI |
+| 🟡 3 | **Onda 7 seq** (CP-48 → 47 → 46 → 50) | Onda 7 | M→L→L→M | #269 resolvido | Tooling migrations por risco crescente: Zod → Better Auth → Ultracite → TS |
+| ⏸️ 4 | **CP-2** Emails consolidation | Onda 5 | XL | Onda 7 + #269 (parcialmente inline) | Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2. Fecha Onda 5 em 11/11 |
 
-**Projeção**: completando priorities 1-4 (~8-12h), bucket 🟡 fica reduzido a CP-2 (bloqueado) + sequência Cloudflare (externo) + Onda 7 (janela dedicada). Pode-se afirmar que "trabalho planejável" acabou.
+**Em paralelo (encaixa conforme bandwidth/dependências externas):**
+
+| Prioridade | CP | Onda | Tamanho | Depende de | Racional |
+|---|---|---|---|---|---|
+| 🟡 | **CP-41** Pagarme integration tests workflow | Onda 3 | M | Secrets sandbox Pagar.me | Payments crítico; fecha Onda 3 |
+| 🟡 | **CP-17** Métricas OTel/Prometheus | Onda 4 | M | Decisão OTel vs Prometheus | Observability gap conhecido; inclui #43 |
+| 🟢 | **CP-14 → 15 → 16** Cloudflare | Onda 4 | S→M→S | DNS do cliente (externo) | Sequencial, bloqueio externo |
+
+**Projeção**: completando a linha principal (1 → 4), bucket 🟡 fica reduzido a trabalho em paralelo (CP-41, CP-17, Cloudflare) conforme bandwidth + dependências externas. Onda 5 chega a 11/11 (100%) com CP-2.
 
 #### 🟢 Bucket Médio Prazo / Sob Demanda (quando houver sinal real)
 

--- a/docs/improvements/roadmap.md
+++ b/docs/improvements/roadmap.md
@@ -60,9 +60,9 @@ Organizado em **5 PRs dedicados** (refactors grandes) + ações pontuais.
 | **CP-7** | ✅ **2026-04-22** — TruffleHog `secrets-scan` job em `security.yml` (com `--only-verified`, diff por PR ou full scan em schedule) | #84 | config | S | — |
 | **CP-8** | ✅ **2026-04-22** — SBOM CycloneDX gerado via `trivy-action` format=cyclonedx no job trivy-image, upload como artifact (90d retention) | #85 | config | S | — |
 | **CP-9** | ✅ **2026-04-22** — Job `trivy-fs` em `security.yml` com `scan-type: fs`, SARIF upload categorizado separadamente do container scan | #82 | config | S | — |
-| **CP-10** | Pin SHA do `oven/bun:1-alpine` no Dockerfile + atualização via Dependabot | #87 | config | S | — |
-| **CP-11** | HEALTHCHECK deep no Dockerfile (trocar `/health/live` por `/health` com `--retries=10`) | #88 | config | S | — |
-| **CP-12** | `wait-for-db` no `scripts/entrypoint.sh` antes de rodar migrations | #89 | new | S | — |
+| **CP-10** | ✅ **2026-04-24** — Dockerfile pinado `oven/bun:1-alpine@sha256:4de475...`. Dependabot ecossistema docker (já configurado) detecta novos digests semanalmente | #87 | config | S | — |
+| **CP-11** | ✅ **2026-04-24** — HEALTHCHECK troca `/health/live` por `/health` com body check `grep -q '"status":"healthy"'`. retries 5→10 (100s). Coolify reinicia container se DB morrer | #88 | config | S | — |
+| **CP-12** | ✅ **2026-04-24** — `src/db/wait-for-db.ts` tenta `SELECT 1` com retry (30×1s, 2s timeout, ~30s total) antes de migrate em `scripts/entrypoint.sh`. Log estruturado via Pino | #89 | new | S | — |
 | **CP-13** | ✅ **2026-04-22** — 8 secrets (BETTER_AUTH_SECRET, PAGARME_*, INTERNAL_API_KEY, PII_ENCRYPTION_KEY) movidos para step-level apenas nos 3 steps que executam código do projeto (migrations, affected tests, full suite) | #95 | config | S | — |
 
 ##### Cloudflare Free Tier (decisão 7.3 #1 — etapa final do early-stage)
@@ -119,10 +119,10 @@ Organizado em **5 PRs dedicados** (refactors grandes) + ações pontuais.
 | **CP-46** | Migração ultracite 6 → 7 (Biome → Oxc) — descoberto em CP-40. Ultracite 7 trocou o engine subjacente de Biome para Oxc (`oxlint` + `oxfmt`). Requer: remover `@biomejs/biome` das devDeps, validar `biome.json`/`biome.jsonc` → config equivalente em Oxc, rodar `ultracite check` + `ultracite fix` em todo o codebase, validar que pre-commit via `lint-staged` continua funcionando. Não é tooling crítico para segurança — espera janela dedicada | Descoberto em CP-40 | refactor | L | — |
 | **CP-47** | Migração better-auth 1.4 → 1.6 — descoberto em CP-40. Envolve: (a) adicionar coluna `verified` na tabela `twoFactor` (schema migration, default `true`, sem backfill necessário — run `npx @better-auth/cli generate` + drizzle-kit generate + migrate); (b) validar mudança de semântica de `session.freshAge` (agora calculado de `createdAt` em vez de `updatedAt`); (c) rodar suíte completa de auth + 2FA para detectar regressões em hooks, permissions, api-keys; (d) revisar release notes 1.5/1.6 para features opcionais úteis (OTel instrumentation, WeChat provider, etc.). Não é CVE — CVEs de `defu`/`kysely` foram resolvidas via overrides em CP-40 | Descoberto em CP-40 | refactor | L | — |
 | **CP-48** | Migração Zod 4.1 → 4.3 — descoberto em CP-40. Zod 4.3 proíbe `.partial()` em schemas com `.refine()` (antes permitia com comportamento indefinido). Afeta ~16 `.model.ts` em `src/modules/` (employees, occurrences/*, organizations/*, payments/billing, etc.). Fix padrão: extrair objeto base (sem refine), fazer `.partial().extend()` nele, aplicar refine depois. Zod está pinado em `~4.1.13` em CP-40 como contenção | Descoberto em CP-40 | refactor | M | — |
-| **CP-49** | Sync react/react-dom versions — descoberto em CP-40. `react-dom` não está nas devDeps diretas mas é pulled por `@react-email/components`, e fica desalinhado de `react` em patches (`bun update` bumpou react → 19.2.5 enquanto react-dom ficou em 19.2.4, causando runtime mismatch). Opções: (a) adicionar `react-dom` às devDeps pinado ao mesmo patch; (b) manter `react` pinado exato (feito em CP-40 como contenção); (c) override de `react-dom` matching `react`. Decidir quando for revisar deps novamente | Descoberto em CP-40 | config | S | — |
+| **CP-49** | ✅ **2026-04-24** — `react-dom: "19.2.5"` adicionado explicitamente em `dependencies` (mesma versão pinada de `react`). Garante sync no lockfile + visibilidade para Dependabot bumpar ambos juntos. Opção (a) do débito escolhida | Descoberto em CP-40 | config | S | — |
 | **CP-50** | Migração TypeScript 5.9 → 6.x — descoberto em CP-40 quando CI falhou ao puxar TS 6.0.3 ephemerally (TS não estava em devDeps). TS 6 transforma `moduleResolution=node` em erro deprecated (antes era warning). Requer: (a) alterar `tsconfig.json` de `"moduleResolution": "node"` para `"bundler"` (recomendado Elysia/Bun) ou `"node16"`; (b) auditar imports para compatibilidade com resolução nova (extensões obrigatórias em alguns casos); (c) remover o pin `~5.9.3` após migração validada. Contenção atual: TS pinado em devDeps `~5.9.3` | Descoberto em CP-40 | refactor | M | — |
 
-**Total bucket 🟡: 50 ações registradas · 13 ativas · 33 concluídas (CP-1, CP-3, CP-4, CP-5, CP-6, CP-7, CP-8, CP-9, CP-13, CP-20, CP-21, CP-22, CP-23, CP-24, CP-25, CP-26, CP-27, CP-28, CP-29, CP-30, CP-31, CP-32, CP-33, CP-34, CP-35, CP-36, CP-37, CP-38, CP-39, CP-40, CP-42, CP-43, CP-45) · 3 reclassificadas para MP (CP-18 → MP-24, CP-19 → MP-25 em 2026-04-23; CP-44 → MP-27 em 2026-04-24) · 1 contenção temporária (CP-50).**
+**Total bucket 🟡: 50 ações registradas · 9 ativas · 37 concluídas (CP-1, CP-3, CP-4, CP-5, CP-6, CP-7, CP-8, CP-9, CP-10, CP-11, CP-12, CP-13, CP-20, CP-21, CP-22, CP-23, CP-24, CP-25, CP-26, CP-27, CP-28, CP-29, CP-30, CP-31, CP-32, CP-33, CP-34, CP-35, CP-36, CP-37, CP-38, CP-39, CP-40, CP-42, CP-43, CP-45, CP-49) · 3 reclassificadas para MP (CP-18 → MP-24, CP-19 → MP-25 em 2026-04-23; CP-44 → MP-27 em 2026-04-24) · 1 contenção temporária (CP-50).**
 
 ##### Ordem de execução sugerida
 
@@ -135,7 +135,7 @@ Sequência proposta para extrair valor rápido antes de atacar os refactors gran
 | **Onda 3 — Qualidade pontual** | 🔄 Em progresso — **PRs A/B/C entregues 2026-04-22** (9 S's + CP-25 + CP-30). Resta apenas **CP-41** (M) como PR-D standalone | CP-24✅, CP-27✅, CP-29✅, CP-31✅, CP-34✅, CP-35✅, CP-36✅, CP-37✅, CP-39✅ (todos S); CP-25✅, CP-30✅, CP-41 (M) | PR-C: 5 S's de "Qualidade geral" em 5 commits. PR-B: 3 S's de "Error handling + env" em 3 commits. PR-A: 1 S + 2 M's de "Auth hardening" em 3 commits (log unauthorized, inheritRole, dynamic→static imports). CP-41 vale PR separada (workflow novo, requer secrets sandbox Pagar.me) |
 | **Onda 4 — Cloudflare + Observabilidade** | Depende de janela com o dono (CP-14 precisa alinhar DNS) | CP-14 → CP-15 → CP-16; CP-17 (inclui #43) | Cloudflare é sequencial (CP-14 destrava CP-15 destrava CP-16). CP-17 standalone. _Ex-CP-18/19 reclassificados para MP-24/25 em 2026-04-23._ |
 | **Onda 5 — Refactors grandes** | PRs dedicados, worktree obrigatório (XL), plan formal em `docs/plans/` | CP-2 (XL, bloqueado por #269) | CP-2 é último por design (toca auth). _CP-1/3/4/5/6/26/28/32/33/38 já concluídos 2026-04-22/24. CP-44 reclassificado para MP-27 em 2026-04-24._ |
-| **Onda 6 — Infra hardening pequeno** ⭐ criada 2026-04-23 | 1 PR batch com commits atômicos | CP-10 (S, Docker SHA pin), CP-11 (S, HEALTHCHECK deep), CP-12 (S, wait-for-db), CP-49 (S, react/react-dom sync) | 4 CPs órfãos (sem wave original) agrupados. Todos S, independentes, infra-only. ~2-3h total em PR único |
+| **Onda 6 — Infra hardening pequeno** ⭐ criada 2026-04-23 | ✅ **Concluída em 2026-04-24** — 1 PR batch (4 commits atômicos) | CP-10 ✅, CP-11 ✅, CP-12 ✅, CP-49 ✅ | 4 CPs órfãos agrupados. Zero dependência externa, zero break. Testes de email (25 assertions) passando após CP-49 |
 | **Onda 7 — Tooling migrations** ⭐ criada 2026-04-23 | PRs dedicados, um por migration, risco alto | CP-48 (M, Zod 4.1→4.3) → CP-47 (L, better-auth 1.4→1.6) → CP-46 (L, ultracite 6→7) → CP-50 (M, TypeScript 5.9→6.x, contenção atual) | Seguir ordem de risco crescente. Cada migration em worktree + PR próprio + janela de teste. Follow-ups do CP-40 (triagem de deps). Bloqueio externo mínimo; mais a estabilidade da suíte |
 
 **Notas operacionais:**
@@ -153,10 +153,10 @@ Sequência formal decidida — priorizar isolamento de diagnóstico + destravar 
 
 | Prioridade | CP | Onda | Tamanho | Depende de | Racional |
 |---|---|---|---|---|---|
-| 🟡 1 | **Onda 6 batch** (CP-10/11/12/49) | Onda 6 | 4×S | — | Infra hardening quick wins em PR único; zero dependência |
-| 🟡 2 | **Issue #269 tests 3+4** (DB state leak) | — | M/L | — | Pré-requisito de CP-47 e CP-2 — sem isso, PRs grandes reativam flakes em CI |
-| 🟡 3 | **Onda 7 seq** (CP-48 → 47 → 46 → 50) | Onda 7 | M→L→L→M | #269 resolvido | Tooling migrations por risco crescente: Zod → Better Auth → Ultracite → TS |
-| ⏸️ 4 | **CP-2** Emails consolidation | Onda 5 | XL | Onda 7 + #269 (parcialmente inline) | Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2. Fecha Onda 5 em 11/11 |
+| ✅ | ~~**Onda 6 batch** (CP-10/11/12/49)~~ | Onda 6 | 4×S | — | Entregue 2026-04-24 |
+| 🟡 1 | **Issue #269 tests 3+4** (DB state leak) | — | M/L | — | Pré-requisito de CP-47 e CP-2 — sem isso, PRs grandes reativam flakes em CI |
+| 🟡 2 | **Onda 7 seq** (CP-48 → 47 → 46 → 50) | Onda 7 | M→L→L→M | #269 resolvido | Tooling migrations por risco crescente: Zod → Better Auth → Ultracite → TS |
+| ⏸️ 3 | **CP-2** Emails consolidation | Onda 5 | XL | Onda 7 + #269 (parcialmente inline) | Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2. Fecha Onda 5 em 11/11 |
 
 **Em paralelo (encaixa conforme bandwidth/dependências externas):**
 
@@ -211,7 +211,7 @@ Não investir antes do sinal. Cada item lista o **sinal que justifica investir**
 | Bucket | Ações | Esforço consolidado | Prazo alvo | Estado |
 |---|---|---|---|---|
 | 🔴 Urgente | 10 | ~7 S/M + 1 L = 2-3 semanas com foco parcial | até 30 dias | ✅ Concluído em 2026-04-22 (1 dia de execução efetiva) |
-| 🟡 Curto prazo | 50 registradas (33 done · 13 ativas · 3 reclassificadas · 1 contenção) | 4 planos XL/L + ~25 S/M | 30-90 dias | 🔄 Em execução — Ondas 1/2/3 quase completas (resta CP-41); Onda 5 em 10/11 (91%): CP-1/3/4/5/6/26/28/32/33/38 concluídos, resta apenas CP-2 (bloqueado por #269). CP-44 reclassificado para MP-27 em 2026-04-24 |
+| 🟡 Curto prazo | 50 registradas (37 done · 9 ativas · 3 reclassificadas · 1 contenção) | 4 planos XL/L + ~25 S/M | 30-90 dias | 🔄 Em execução — Ondas 1/2/3/6 concluídas; Onda 5 em 10/11 (91%). Resta: Onda 6 ✅, #269, Onda 7, CP-2, CP-41, CP-17, Cloudflare |
 | 🟢 Médio prazo | 21 | Sob demanda | indefinido (monitorar sinais) | ⏸️ Sem investimento até sinal concreto |
 
 **Princípios de execução:**

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
     "react": "19.2.5",
+    "react-dom": "19.2.5",
     "zod": "~4.1.13"
   },
   "devDependencies": {

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -2,6 +2,8 @@
 set -e
 
 if [ "$SKIP_MIGRATIONS" != "true" ]; then
+  echo "Waiting for database..."
+  bun run src/db/wait-for-db.ts
   echo "Running database migrations..."
   bun run src/db/migrate.ts
   echo "Migrations completed."

--- a/src/db/wait-for-db.ts
+++ b/src/db/wait-for-db.ts
@@ -1,0 +1,39 @@
+import { Pool } from "pg";
+import { env } from "@/env";
+import { logger } from "../lib/logger";
+
+const MAX_ATTEMPTS = 30;
+const DELAY_MS = 1000;
+const CONNECTION_TIMEOUT_MS = 2000;
+
+const pool = new Pool({
+  connectionString: env.DATABASE_URL,
+  connectionTimeoutMillis: CONNECTION_TIMEOUT_MS,
+});
+
+for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+  try {
+    await pool.query("SELECT 1");
+    logger.info({
+      type: "db:wait-for-db",
+      message: `Database ready (attempt ${attempt}/${MAX_ATTEMPTS})`,
+    });
+    await pool.end();
+    process.exit(0);
+  } catch (error) {
+    if (attempt === MAX_ATTEMPTS) {
+      logger.error({
+        type: "db:wait-for-db",
+        message: `Database unreachable after ${MAX_ATTEMPTS} attempts — server will not start`,
+        error,
+      });
+      await pool.end();
+      process.exit(1);
+    }
+    logger.info({
+      type: "db:wait-for-db",
+      message: `Waiting for database (attempt ${attempt}/${MAX_ATTEMPTS})`,
+    });
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+  }
+}


### PR DESCRIPTION
## Summary

Entrega **Onda 6** (CP-10/11/12/49) em 6 commits atômicos + documentação da sequência de execução revisada do bucket 🟡.

## Commits

| # | Commit | Tipo | Débito |
|---|---|---|---|
| 1 | `7a4c8ab` | docs | — (sequência revisada: Onda 6 → #269 → Onda 7 → Onda 5) |
| 2 | `b2661d7` | CP-10 | #87 (Docker SHA pin) |
| 3 | `c3ce6eb` | CP-11 | #88 (HEALTHCHECK deep com body check) |
| 4 | `500e631` | CP-12 | #89 (wait-for-db) |
| 5 | `0cddf2c` | CP-49 | — (react-dom pin, follow-up CP-40) |
| 6 | `b8fa649` | docs | — (marca Onda 6 completa em debts/roadmap/README/changelog) |

## Mudanças por CP

### CP-10 — Docker base image SHA pin

`oven/bun:1-alpine` → `oven/bun:1-alpine@sha256:4de475...`. Dependabot (ecossistema docker já configurado) detecta novos digests semanalmente. Zero mudança de comportamento.

### CP-11 — HEALTHCHECK deep com body check

Troca `/health/live` por `/health` (deep check que executa `SELECT 1` no DB). `/health` sempre retorna HTTP 200 (status no body via success envelope), então `curl -f` sozinho não detectaria DB down. Adiciona `grep -q '"status":"healthy"'` no body.

`retries` 5 → 10 (100s total antes de marcar unhealthy com `interval=10s`).

**Impact**: Coolify passa a reiniciar container se DB morrer (antes só reiniciava se processo crashasse).

### CP-12 — wait-for-db antes de migrations

Novo script `src/db/wait-for-db.ts` que tenta `SELECT 1` com retry (30 attempts × 1s delay + 2s connection timeout, ~30s total). Log estruturado via Pino. Chamado em `scripts/entrypoint.sh` antes de `bun run src/db/migrate.ts`.

Evita crash-loop do container quando Postgres ainda não está pronto no startup.

Smoke test local: exit 0 em attempt 1 quando DB disponível.

### CP-49 — react-dom pinado

`react-dom: "19.2.5"` adicionado explicitamente em `dependencies` (mesma versão pinada de `react`). Opção (a) do débito (de 3 opções). Garante sync no lockfile + visibilidade para Dependabot bumpar ambos juntos.

Resolve o desalinhamento que ocorre quando `react-dom` vem só transitivamente por `@react-email/components` e bun update bumpa `react` sem acompanhar.

25 testes de email passando após mudança.

## Docs

- **changelog.md**: 2 entries novas (sequência revisada + Onda 6 batch)
- **README.md**: contadores (🟡 37/50, 74%), "Onda 5 10/11 preservado", Próxima ação sem Onda 6, Histórico atualizado
- **roadmap.md**: CP-10/11/12/49 marcados ✅, Onda 6 fechada, Ordem de execução renumerada (Issue #269 promovido a #1), counters (37 done · 9 ativas)
- **debts.md**: #87/#88/#89 strikethrough

## Test plan

- [x] CP-11: `curl -fsS http://.../health | grep -q '"status":"healthy"'` sintaxe correta (bash -c validado mentalmente; será validado em deploy)
- [x] CP-12: `bun run src/db/wait-for-db.ts` exit 0 em attempt 1 (smoke test local)
- [x] CP-49: `bun pm ls react react-dom` retorna ambos em 19.2.5; testes de email (25 assertions) passando
- [ ] CI green (Lint + Build + Affected Tests + Trivy + TruffleHog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)