### PR TITLE
test: fix DB state leak in 2 flaky tests (#269 tests 3+4)

### DIFF
--- a/docs/improvements/README.md
+++ b/docs/improvements/README.md
@@ -50,7 +50,7 @@
 **🟡 Linha principal:**
 
 1. ~~**Onda 6 batch**~~ ✅ Entregue 2026-04-24 — CP-10 (Docker SHA pin) + CP-11 (HEALTHCHECK deep) + CP-12 (wait-for-db) + CP-49 (react/react-dom sync).
-2. **Issue #269 tests 3+4** (DB state leak) — audit de factories/fixtures + cleanup explícito. **Pré-requisito de CP-47 e CP-2** (sem isso, PRs grandes reativam flakes em CI). Efforte M/L.
+2. ~~**Issue #269 tests 3+4**~~ ✅ Entregue 2026-04-24 — trial constraint self-contained + cpf-analyses dates explícitas. Tests 1+2 (email spy race) para CP-2.
 3. **Onda 7 seq** (CP-48 → 47 → 46 → 50) — tooling migrations por ordem de risco crescente: Zod 4.3 → Better Auth 1.6 → Ultracite 7 → TS 6. Cada PR dedicado.
 4. **CP-2** (XL, Onda 5) — Emails consolidation. Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2 de graça. Fecha Onda 5 em 11/11.
 
@@ -70,6 +70,7 @@
 
 ### Histórico recente do bucket 🟡
 
+- ✅ **Issue #269 tests 3+4 fixados** (2026-04-24) — trial constraint self-contained + cpf-analyses dates explícitas. 14/14 pass local; CI valida em escopo grande. Tests 1+2 (email spy race) para CP-2.
 - ✅ **Onda 6 batch entregue** (2026-04-24) — 4 CPs em 5 commits atômicos: CP-10 (Docker SHA pin) + CP-11 (HEALTHCHECK deep com body check) + CP-12 (wait-for-db via `src/db/wait-for-db.ts`) + CP-49 (react-dom pin). Fecha débitos #87, #88, #89.
 - ✅ **CP-38 entregue** (2026-04-24) — 6 runbooks de oncall em `docs/runbooks/` + índice. Fecha débitos #90, #91, #93.
 - ~~**CP-44**~~ → **MP-27** (reclassificado 2026-04-24 — BOLA AST preventivo; solo dev + RU-9 limpo + testes cross-org já existentes tornam regressão improvável hoje)
@@ -129,6 +130,7 @@ Detalhes completos em [roadmap.md § Metodologia de execução](./roadmap.md).
 - **2026-04-23 (CP-53 Fase 2 — PR #271)** — 10 commits atômicos de fixes objetivos não-bloqueados por OQs. Destaques: PII redaction em logs/Sentry (LGPD), extração de 6 callbacks do auth.ts, admin allowlist normalize (whitespace/case bug), email env vars. 707/707 tests passando. Débitos #70 e #71 fechados.
 - **2026-04-24 (CP-38 + CP-44 reclass)** — 6 runbooks de oncall em `docs/runbooks/` (db-down, app-container, pagarme-webhook, smtp-down, 5xx-surge, migration-rollback) + índice `README.md` com decision tree. Débitos #90, #91, #93 fechados. CP-44 reclassificado para MP-27 no mesmo dia → Onda 5 ficou em **10/11 entregues (91%)**.
 - **2026-04-24 (Onda 6 batch)** — 4 CPs em 5 commits atômicos: Docker SHA pin, HEALTHCHECK deep com body check, wait-for-db script, react-dom pin. Débitos #87/#88/#89 fechados. Onda 6 ✅ concluída.
+- **2026-04-24 (Issue #269 tests 3+4)** — DB state leak fixado em 2 tests flaky: trial constraint test agora self-contained, cpf-analyses list usa datas explícitas. Tests 1+2 (email spy race) ficam para CP-2 via EmailDispatcher wrapper.
 
 
 Changelog completo: [changelog.md](./changelog.md).

--- a/docs/improvements/changelog.md
+++ b/docs/improvements/changelog.md
@@ -11,6 +11,23 @@
 
 Registro temporal das decisões e entregas desta iniciativa. **Toda atualização do documento deve adicionar uma entrada aqui** (data ISO + resumo).
 
+### 2026-04-24 — Issue #269 tests 3+4 fixados (DB state leak)
+
+Continuação da sequência revisada — segundo passo após Onda 6. Tests 3+4 do #269 fixados; tests 1+2 (ESM named-import spy race) ficam para CP-2 (emails consolidation) via `EmailDispatcher` wrapper inline.
+
+**Tests fixados** (2 commits atômicos):
+
+- **Test 3 — trial constraint** (`yearly-discount-and-trial-constraint.test.ts > should prevent creating a second active trial plan`). Root cause: `PlanFactory.archiveActiveTrial()` arquiva seed `plan-trial` sem restaurar. Outros tests na suite rodavam factory antes e o test assumia que seed estava ativo. Fix: test agora garante estado conhecido (arquiva trials existentes + insere 1 trial como precondição) antes de assertar a constraint.
+- **Test 4 — cpf-analyses list** (`list-cpf-analyses.test.ts > should list cpf analyses for the organization`). Root cause: `createTestCpfAnalysis` helper usa `faker.date.past({years:1})` — 2 chamadas consecutivas com mesmo employeeId tinham 1/365 chance de gerar mesma data, violando unique `(employeeId, analysisDate)`. Fix mínimo: passar dates explícitas e diferentes nas duas chamadas. Helper preservado (fix-on-demand).
+
+**Tests 1+2 pendentes** (welcome email spy): rastreados no próprio issue #269. Plano: CP-2 (emails consolidation) vai introduzir `EmailDispatcher` wrapper que resolve a ESM named-import spy race naturalmente — spyable via property access em vez de capturar binding no module load.
+
+**Validação local**: 14/14 pass nos 2 arquivos afetados. CI vai validar em escopo grande se flakes realmente sumiram (local não reproduz — só CI 2 vCPUs timing).
+
+**Princípio adotado**: fix minimal + pontual. Não refatorar factories proativamente — se outros tests mostrarem flakes similar, fix-on-demand.
+
+**Destrava**: Onda 7 seq (CP-48 → 47 → 46 → 50) pode avançar após #269 tests 3+4 mergeados; CP-2 quando chegar a vez.
+
 ### 2026-04-24 — Onda 6 batch entregue (infra hardening)
 
 Primeira execução da sequência revisada. 4 CPs em 5 commits atômicos (1 de docs da sequência + 4 de CPs):

--- a/docs/improvements/roadmap.md
+++ b/docs/improvements/roadmap.md
@@ -154,9 +154,9 @@ Sequência formal decidida — priorizar isolamento de diagnóstico + destravar 
 | Prioridade | CP | Onda | Tamanho | Depende de | Racional |
 |---|---|---|---|---|---|
 | ✅ | ~~**Onda 6 batch** (CP-10/11/12/49)~~ | Onda 6 | 4×S | — | Entregue 2026-04-24 |
-| 🟡 1 | **Issue #269 tests 3+4** (DB state leak) | — | M/L | — | Pré-requisito de CP-47 e CP-2 — sem isso, PRs grandes reativam flakes em CI |
-| 🟡 2 | **Onda 7 seq** (CP-48 → 47 → 46 → 50) | Onda 7 | M→L→L→M | #269 resolvido | Tooling migrations por risco crescente: Zod → Better Auth → Ultracite → TS |
-| ⏸️ 3 | **CP-2** Emails consolidation | Onda 5 | XL | Onda 7 + #269 (parcialmente inline) | Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2. Fecha Onda 5 em 11/11 |
+| ✅ | ~~**Issue #269 tests 3+4** (DB state leak)~~ | — | M/L | — | Entregue 2026-04-24 em PR dedicado. Tests 1+2 (email spy race) ficam para CP-2 inline |
+| 🟡 1 | **Onda 7 seq** (CP-48 → 47 → 46 → 50) | Onda 7 | M→L→L→M | #269 tests 3+4 ✅ | Tooling migrations por risco crescente: Zod → Better Auth → Ultracite → TS |
+| ⏸️ 2 | **CP-2** Emails consolidation | Onda 5 | XL | Onda 7 | Inclui `EmailDispatcher` wrapper que resolve #269 tests 1+2 inline. Fecha Onda 5 em 11/11 |
 
 **Em paralelo (encaixa conforme bandwidth/dependências externas):**
 

--- a/src/modules/occurrences/cpf-analyses/__tests__/list-cpf-analyses.test.ts
+++ b/src/modules/occurrences/cpf-analyses/__tests__/list-cpf-analyses.test.ts
@@ -74,6 +74,7 @@ describe("GET /v1/cpf-analyses", () => {
       organizationId,
       userId,
       employeeId: employee.id,
+      analysisDate: "2025-06-15",
       status: "approved",
     });
 
@@ -81,6 +82,7 @@ describe("GET /v1/cpf-analyses", () => {
       organizationId,
       userId,
       employeeId: employee.id,
+      analysisDate: "2025-06-16",
       status: "pending",
     });
 

--- a/src/modules/payments/plans/__tests__/yearly-discount-and-trial-constraint.test.ts
+++ b/src/modules/payments/plans/__tests__/yearly-discount-and-trial-constraint.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { subscriptionPlans } from "@/db/schema/payments";
 
@@ -98,8 +98,32 @@ describe("yearly_discount_percent column and unique trial constraint", () => {
 
   describe("unique trial constraint", () => {
     test("should prevent creating a second active trial plan", async () => {
-      const duplicateTrialId = `plan-dup-trial-${crypto.randomUUID()}`;
+      // Self-contained precondition: ensure exactly one active public trial
+      // exists before asserting the constraint. Factories like PlanFactory
+      // may archive the seed trial and not restore it, so we reset state here.
+      await db
+        .update(subscriptionPlans)
+        .set({ archivedAt: new Date() })
+        .where(
+          and(
+            eq(subscriptionPlans.isTrial, true),
+            isNull(subscriptionPlans.archivedAt),
+            isNull(subscriptionPlans.organizationId)
+          )
+        );
 
+      const firstTrialId = `plan-first-trial-${crypto.randomUUID()}`;
+      await db.insert(subscriptionPlans).values({
+        id: firstTrialId,
+        name: `first-trial-${firstTrialId.slice(-8)}`,
+        displayName: "First Trial",
+        isActive: true,
+        isPublic: false,
+        isTrial: true,
+        sortOrder: 99,
+      });
+
+      const duplicateTrialId = `plan-dup-trial-${crypto.randomUUID()}`;
       await expect(async () => {
         await db.insert(subscriptionPlans).values({
           id: duplicateTrialId,


### PR DESCRIPTION
## Summary

Fix parcial do [issue #269](https://github.com/tlthiago/synnerdata-api-b/issues/269) — resolve tests 3+4 (DB state leak). Tests 1+2 (ESM named-import spy race em welcome email) ficam explicitamente para o CP-2 (emails consolidation), onde o `EmailDispatcher` wrapper natural resolve a race.

## Commits

| # | Commit | Escopo |
|---|---|---|
| 1 | `3e101f6` | Test 3: trial constraint self-contained |
| 2 | `ab6ce2f` | Test 4: cpf-analyses list com datas explícitas |
| 3 | `7d08f37` | Docs: #269 tests 3+4 marcados como resolvidos |

## Root causes

### Test 3 — `should prevent creating a second active trial plan`

Test assume que há exatamente 1 trial plan ativo (seed `plan-trial`) antes de tentar inserir um segundo. `PlanFactory.archiveActiveTrial()` (chamado por outros tests na suite) arquiva o seed sem restaurar. Em CI com suite grande, ordem de execução fazia com que o trial seed já estivesse arquivado quando o test rodava — INSERT passava sem violar o partial unique index `(isTrial=true AND archivedAt IS NULL AND organizationId IS NULL)`.

**Fix**: test agora garante estado conhecido — arquiva trials existentes + insere 1 trial como precondição — antes de assertar a constraint. Autocontido, independente de state prévio da suite.

### Test 4 — `should list cpf analyses for the organization`

`createTestCpfAnalysis` helper usa `faker.date.past({years:1})` para `analysisDate` por default. Duas chamadas consecutivas com mesmo `employeeId` tinham probabilidade 1/365 de gerar mesma data, violando unique `(employeeId, analysisDate)`. Em CI (2 vCPUs, timing diferente), a colisão materializava e `CpfAnalysisDuplicateDateError` era lançado durante o setup do LIST, antes mesmo da request ser feita.

**Fix mínimo**: passar dates explícitas e diferentes (`2025-06-15` e `2025-06-16`) nas duas chamadas do test. Helper preservado (fix-on-demand se outros tests apresentarem flakes similares).

## Tests 1+2 pendentes

ESM named-import spy race em `welcome email` — o test faz `spyOn(emailModule, "sendWelcomeEmail")`, mas `handleWelcomeEmail` importa via named import e captura o binding no module load. Se outro test aciona o caminho antes do `beforeAll`, spy não intercepta.

Solução análoga ao CP-6 follow-up (ErrorReporter wrapper): criar `EmailDispatcher` wrapper object que expõe senders como properties (property-access spyable sem race). Vai ser implementado inline no **CP-2** (emails consolidation) — naturalmente parte daquele refactor.

## Validation

- [x] Local: 14/14 pass nos 2 arquivos afetados.
- [ ] CI em escopo grande (affected-tests + full suite no schedule) vai validar se flakes sumiram — local não reproduz (depende de timing específico do GitHub runner 2 vCPUs).

## Docs

- `changelog.md`: entry com root causes detalhadas por test.
- `roadmap.md`: Ordem de execução atualizada — #269 tests 3+4 ✅, Onda 7 promovida para prioridade #1.
- `README.md`: Histórico recente e condensado atualizados.

## Próximo passo após merge

**Onda 7 seq** (CP-48 → 47 → 46 → 50) — tooling migrations em janela dedicada. Bloqueio interno de #269 agora resolvido para a maior parte do risco (tests 3+4). Tests 1+2 só reativam em scope que toca emails especificamente, então CP-47 (Better Auth) pode rodar sem preocupação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)