### PR TITLE
test(orphaned-plans): isolate cleanup from accumulated DB state

### DIFF
--- a/src/modules/payments/pagarme/__tests__/pagarme-orphaned-plans.test.ts
+++ b/src/modules/payments/pagarme/__tests__/pagarme-orphaned-plans.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
 import { env } from "@/env";
@@ -92,6 +93,16 @@ describe("Orphaned Pagarme Plans", () => {
   });
 
   describe("POST /payments/admin/pagarme/orphaned-plans/cleanup", () => {
+    beforeAll(async () => {
+      // Reset orphan history accumulated from previous runs of this file.
+      // Cleanup iterates over every isActive=false row calling Pagar.me real
+      // for each — without isolation, hundreds of synthetic plan_test_* IDs
+      // accumulate over time and the test exceeds the 30s timeout.
+      await db
+        .delete(schema.pagarmePlanHistory)
+        .where(eq(schema.pagarmePlanHistory.isActive, false));
+    });
+
     test("should reject unauthenticated requests", async () => {
       const response = await app.handle(
         new Request(CLEANUP_URL, { method: "POST" })


### PR DESCRIPTION
## Summary

Fix de flake pré-existente identificado durante revisão pós-merge do CP-2: o test `Orphaned Pagarme Plans > cleanup > should return cleanup summary` falha localmente por timeout de 30s.

## Causa raiz

State leak no DB de test:

- Test `should return orphaned plans from history` (linha 51) **insere 1 orphan** (`pagarme_plan_history` com `isActive=false`) e **não limpa**.
- Cada run da suite acumula 1 orphan. Em 112+ runs, **112 orphans acumulados**.
- Test `cleanup` (linha 117) itera sobre **todos** os registros `isActive=false` chamando `PagarmeClient.getSubscriptions/getPlan/deactivatePlan` real para cada um. Com retry config + latência por chamada (mesmo erros 404), 112 orphans facilmente excedem os 30s.

```bash
$ psql -c "SELECT count(*) FROM pagarme_plan_history WHERE is_active = false"
 count
-------
   112
```

## Por que afeta apenas local

- **CI** seta `SKIP_INTEGRATION_TESTS=true` → test skipado via `test.skipIf(skipIntegration)`.
- **Local** sem a flag → test roda → state leak materializa o flake.

Confirma a observação registrada em `CLAUDE.md`: *"desenvolvedor que tocar em código de payments deve rodar os testes gated localmente antes da PR"*.

## Fix

`beforeAll` no describe `POST .../cleanup` que limpa orphans acumulados antes do test rodar:

```ts
describe("POST /payments/admin/pagarme/orphaned-plans/cleanup", () => {
  beforeAll(async () => {
    await db
      .delete(schema.pagarmePlanHistory)
      .where(eq(schema.pagarmePlanHistory.isActive, false));
  });
  // ...
});
```

**Por que esse fix preserva o test**:
- Não altera o que está sendo testado (shape de cleanup result).
- Não introduz mocks — continua chamando Pagar.me real (intent do `test.skipIf(skipIntegration)`).
- Resolve o root cause (state leak), não o sintoma.

## Validation

```
$ NODE_ENV=test bun test --env-file .env.test src/modules/payments/pagarme/__tests__/pagarme-orphaned-plans.test.ts
 7 pass · 0 fail · 27 expect() calls · Ran 7 tests across 1 file. [2.18s]
```

Antes do fix: timeout 30s. Após: 2.18s total para o file.

## Sobre a iniciativa de infra

Fix de hygiene não retoma a iniciativa pausada — apenas conserta flake real que estava manifestando localmente. Os 5 CPs ativos remanescentes (CP-41/17/14-16/50) continuam committed mas pausados aguardando dependências externas conforme registrado no changelog 2026-04-24 "Iniciativa pausada".

🤖 Generated with [Claude Code](https://claude.com/claude-code)