### PR TITLE
fix(vacations): rejeitar startDate antes do concessivo do ciclo

### DIFF
--- a/src/modules/occurrences/vacations/CLAUDE.md
+++ b/src/modules/occurrences/vacations/CLAUDE.md
@@ -18,7 +18,10 @@ Gestao de ferias com periodos aquisitivo e concessivo inline e controle de dias,
       - Se `daysUsed < 30` nesse aquisitivo → retorna o **mesmo ciclo** (ainda tem saldo a cadastrar).
       - Se `daysUsed === 30` → retorna o **próximo ciclo contíguo** (`lastAquisitivoStart + 12 meses`).
     - Não há silent skip de ciclos vencidos — a sequência é contíguamente derivada do histórico.
-  - **`startDate` é livre** dentro dos limites gerais do módulo (validações de `validateDates`, `validateDaysBetweenDates`, `ensureAquisitivoLimit`, `ensureNoOverlap`). O snapshot de aquisitivo/concessivo capturado no registro é sempre o ciclo retornado por `resolveNextCycle` (derivado do histórico), **mesmo quando `startDate` cai fora do concessivo desse ciclo** — isso representa o cenário de férias pagas fora do prazo legal (pago via multa, CLT art. 137).
+  - **`startDate` é validada de forma assimétrica em relação ao concessivo do snapshot:**
+    - `startDate < concessivePeriodStart` → rejeita com `VacationStartDateBeforeConcessiveError` (422). Não há caso de uso para gozar férias antes de adquirir o direito.
+    - `cycle.concessivePeriodStart ≤ startDate ≤ cycle.concessivePeriodEnd` → aceita (regular).
+    - `startDate > concessivePeriodEnd` → aceita. A UI deriva a classificação **"Pago via Multa"** a partir dessa condição (CLT art. 137). O snapshot de aquisitivo/concessivo capturado no registro é sempre o ciclo retornado por `resolveNextCycle` (derivado do histórico), **mesmo quando `startDate` cai fora do concessivo desse ciclo** — isso representa o cenário de férias pagas fora do prazo legal.
 
     A **classificação "Pago via Multa"** é **derivada pela UI** (frontend) a partir da comparação `startDate > concessivePeriodEnd` do snapshot. Não é persistida no banco — o dado fica na combinação `(startDate, concessivePeriodEnd)`. Se futuramente precisarmos rastrear overrides manuais (ex: "gozado em data fora do prazo por acordo coletivo"), migrar pra campo persistido.
   - **Exemplo — empresa migrando**: funcionário admitido em 15/02/2019, sem férias cadastradas → primeiro cadastro cai no ciclo 1 (aquisitivo 15/02/2019-14/02/2020). Depois de completar 30 dias nesse ciclo → próximo cadastro cai no ciclo 2 (aquisitivo 15/02/2020-14/02/2021). Assim sucessivamente até chegar ao ciclo atual. O RH preserva a história da organização no sistema.
@@ -60,7 +63,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 
 ## Fields
 
-- `startDate`, `endDate` (datas das ferias — livres dentro dos limites gerais do módulo; quando `startDate > concessivePeriodEnd` do snapshot, a UI classifica como "Pago via Multa")
+- `startDate`, `endDate` (datas das ferias — `startDate` deve ser `>= concessivePeriodStart` do ciclo resolvido; pode ultrapassar `concessivePeriodEnd` (cenário "Pago via Multa", classificado pela UI). `endDate` segue as demais regras gerais do módulo)
 - `acquisitionPeriodStart`, `acquisitionPeriodEnd` (periodo aquisitivo — **snapshot do proximo ciclo** resolvido pelo backend no create, read-only na API, presente na response)
 - `concessivePeriodStart`, `concessivePeriodEnd` (periodo concessivo — **snapshot do proximo ciclo** resolvido pelo backend no create, read-only na API, presente na response)
 - `daysEntitled` (inteiro, 1 a 30 conforme CLT art. 130, obrigatorio, sem default)
@@ -96,6 +99,7 @@ Prioridade: `in_progress` > `scheduled` > `ACTIVE`. O helper consulta todas as f
 - `VacationInvalidDateRangeError` (422)
 - `VacationInvalidDaysError` (422) -- daysEntitled != intervalo de datas, ou daysUsed > daysEntitled
 - `VacationDateBeforeHireError` (422) -- qualquer data anterior a hireDate do funcionario
+- `VacationStartDateBeforeConcessiveError` (422) -- startDate anterior ao início do concessivo do ciclo retornado
 - `VacationAquisitivoExceededError` (422) -- soma de `daysEntitled` no aquisitivo excederia 30 dias. Details: `{ acquisitionPeriodStart, acquisitionPeriodEnd, currentTotal, requestedDays, daysRemaining, maxAllowed: 30 }`.
 - `VacationNoRightsError` (422) -- **legacy, nao mais lancado em producao**. Mantido no arquivo `errors.ts` para compatibilidade retroativa (codigos de erro ja expostos em integracoes / historicos). Novos contratados agora agendam ferias futuras livremente via proximo ciclo.
 - `VacationOverlapError` (409) -- same employee + overlapping dates (excluding canceled)

--- a/src/modules/occurrences/vacations/__tests__/audit-coverage.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/audit-coverage.test.ts
@@ -163,7 +163,11 @@ describe("audit coverage — vacation side effects on employee status", () => {
   test("POST /v1/vacations emits audit_logs update entry for employee status (ACTIVE → VACATION_SCHEDULED)", async () => {
     const { headers, organizationId, user, userId } =
       await createTestUserWithOrganization({ emailVerified: true });
-    const { employee } = await createTestEmployee({ organizationId, userId });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId,
+      hireDate: "2020-01-01",
+    });
     await db.delete(schema.auditLogs);
 
     const resp = await app.handle(
@@ -198,7 +202,11 @@ describe("audit coverage — vacation side effects on employee status", () => {
   test("DELETE /v1/vacations/:id emits audit_logs update entry for employee status reverting to ACTIVE", async () => {
     const { headers, organizationId, user, userId } =
       await createTestUserWithOrganization({ emailVerified: true });
-    const { employee } = await createTestEmployee({ organizationId, userId });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId,
+      hireDate: "2020-01-01",
+    });
 
     const createResp = await app.handle(
       new Request(`${BASE_URL}/v1/vacations`, {
@@ -241,7 +249,11 @@ describe("audit coverage — vacation side effects on employee status", () => {
   test("PUT /v1/vacations/:id changing status to canceled does NOT emit redundant employee audit when status doesn't change", async () => {
     const { headers, organizationId, userId } =
       await createTestUserWithOrganization({ emailVerified: true });
-    const { employee } = await createTestEmployee({ organizationId, userId });
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId,
+      hireDate: "2020-01-01",
+    });
 
     const v1Resp = await app.handle(
       new Request(`${BASE_URL}/v1/vacations`, {

--- a/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
+++ b/src/modules/occurrences/vacations/__tests__/create-vacation.test.ts
@@ -1261,6 +1261,84 @@ describe("POST /v1/vacations", () => {
     expect(second.status).toBe(200);
   });
 
+  test("rejects with 422 when startDate is before concessivePeriodStart of resolved cycle", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2025-01-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2025-06-01",
+          endDate: "2025-06-15",
+          daysEntitled: 15,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("VACATION_START_DATE_BEFORE_CONCESSIVE");
+    expect(body.error.details.startDate).toBe("2025-06-01");
+    expect(body.error.details.concessivePeriodStart).toBe("2026-01-01");
+  });
+
+  test("accepts cadastro with startDate equal to concessivePeriodStart", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
+
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+      hireDate: "2025-01-01",
+      acquisitionPeriodStart: null,
+      acquisitionPeriodEnd: null,
+    });
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/vacations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          startDate: "2026-01-01",
+          endDate: "2026-01-15",
+          daysEntitled: 15,
+          daysUsed: 0,
+          status: "scheduled",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.startDate).toBe("2026-01-01");
+    expect(body.data.endDate).toBe("2026-01-15");
+    expect(body.data.daysEntitled).toBe(15);
+    expect(body.data.acquisitionPeriodStart).toBe("2025-01-01");
+    expect(body.data.acquisitionPeriodEnd).toBe("2025-12-31");
+    expect(body.data.concessivePeriodStart).toBe("2026-01-01");
+    expect(body.data.concessivePeriodEnd).toBe("2026-12-31");
+  });
+
   test("employer data migration: first vacation registration lands in cycle 1 derived from old hireDate", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({

--- a/src/modules/occurrences/vacations/errors.ts
+++ b/src/modules/occurrences/vacations/errors.ts
@@ -74,6 +74,18 @@ export class VacationDateBeforeHireError extends VacationError {
   }
 }
 
+export class VacationStartDateBeforeConcessiveError extends VacationError {
+  status = 422;
+
+  constructor(args: { startDate: string; concessivePeriodStart: string }) {
+    super(
+      "Data de início anterior ao início do período concessivo do ciclo. Funcionário não pode gozar férias antes de adquirir o direito.",
+      "VACATION_START_DATE_BEFORE_CONCESSIVE",
+      args
+    );
+  }
+}
+
 export class VacationOverlapError extends VacationError {
   status = 409;
 

--- a/src/modules/occurrences/vacations/vacation.service.ts
+++ b/src/modules/occurrences/vacations/vacation.service.ts
@@ -21,6 +21,7 @@ import {
   VacationInvalidEmployeeError,
   VacationNotFoundError,
   VacationOverlapError,
+  VacationStartDateBeforeConcessiveError,
 } from "./errors";
 import type {
   CreateVacationInput,
@@ -236,6 +237,18 @@ export abstract class VacationService {
     }
   }
 
+  private static validateStartDateNotBeforeConcessive(
+    startDate: string,
+    cycle: { concessivePeriodStart: string }
+  ): void {
+    if (startDate < cycle.concessivePeriodStart) {
+      throw new VacationStartDateBeforeConcessiveError({
+        startDate,
+        concessivePeriodStart: cycle.concessivePeriodStart,
+      });
+    }
+  }
+
   private static async resolveCycleForEmployee(
     employeeId: string,
     organizationId: string,
@@ -399,6 +412,11 @@ export abstract class VacationService {
       data.employeeId,
       organizationId,
       employee.hireDate
+    );
+
+    VacationService.validateStartDateNotBeforeConcessive(
+      data.startDate,
+      activeCycle
     );
 
     VacationService.validateDays(


### PR DESCRIPTION
## Summary

- Reintroduz validação **assimétrica** do `startDate` em `VacationService.create`: só o lado inferior (`startDate < concessivePeriodStart`) é rejeitado. O lado superior (`startDate > concessivePeriodEnd`) continua aceito — preserva o caso "Pago via Multa" derivado pela UI (CLT art. 137).
- Adiciona `VacationStartDateBeforeConcessiveError` (422, code `VACATION_START_DATE_BEFORE_CONCESSIVE`) com `details: { startDate, concessivePeriodStart }`.
- Atualiza `CLAUDE.md` do módulo com a regra assimétrica e o novo erro.

Closes #297. Issue companheira no FE: tlthiago/synnerdata-web-n#171.

## Contexto

PR #272 removeu `validateStartDateInConcessive` por completo pra suportar Pago via Multa, mas a remoção foi simétrica quando deveria ter sido assimétrica. Resultado em homologação (cliente reportou): cadastro do João Augusto Santos com `startDate=02/12/2026` aceito mesmo com snapshot concessivo `03/03/2028→02/03/2029` — registro semanticamente inválido (funcionário gozando férias 15 meses antes de adquirir o direito).

A correção restaura **só** o lado inferior. Não há caso de uso CLT em que um funcionário goza férias antes de adquirir o direito; o lado superior é onde o Pago via Multa vive e fica intocado.

| Caso | Decisão |
|---|---|
| `startDate < cycle.concessivePeriodStart` | rejeita 422 (`VACATION_START_DATE_BEFORE_CONCESSIVE`) |
| `concessivePeriodStart ≤ startDate ≤ concessivePeriodEnd` | aceita |
| `startDate > concessivePeriodEnd` | aceita (Pago via Multa) |

## Notas de implementação

- Helper `validateStartDateNotBeforeConcessive` chamado em `create()` **depois** de `resolveCycleForEmployee` (precisa do `activeCycle`) e antes da validação de dias / aquisitivo / overlap. Falha-rápido com a checagem mais barata.
- Tipagem do helper aceita estrutura mínima `{ concessivePeriodStart: string }` — minimiza acoplamento, espelha o padrão de `validateDatesNotBeforeHire`.
- 3 testes em `audit-coverage.test.ts` foram pinados com `hireDate: "2020-01-01"`. Eles usavam `createTestEmployee` sem `hireDate` explícito, caindo no `generateHireDate()` que retorna data aleatória nos últimos 5 anos. Combinado com `startDate` hardcoded em 2027, a nova regra os tornaria estocasticamente quebrados (falham quando o random cai em 2026). Pin determiniza sem mudar intenção (status sync do funcionário).

## Test plan

- [x] `create-vacation.test.ts` — 32 → 34 pass (rejeição + boundary novos)
- [x] Todos os testes de `vacations/__tests__/` — 129/129 pass
- [x] Pago via Multa (linha 761) — não regrediu
- [x] Cross-module `last-acquisition-period.test.ts` — 7/7 pass
- [x] `npx ultracite check src/modules/occurrences/vacations/` — clean
- [ ] CI verde
- [ ] Validação manual em homologação após deploy: tentar reproduzir o caso do João Augusto → esperar 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)