### PR TITLE
feat(terminations): allow scheduled future terminations

### DIFF
--- a/src/db/migrations/0042_add_termination_status.sql
+++ b/src/db/migrations/0042_add_termination_status.sql
@@ -1,0 +1,9 @@
+CREATE TYPE "public"."termination_status" AS ENUM('scheduled', 'completed', 'canceled');
+--> statement-breakpoint
+ALTER TYPE "public"."employee_status" ADD VALUE 'TERMINATION_SCHEDULED';
+--> statement-breakpoint
+ALTER TABLE "terminations" ADD COLUMN "status" "termination_status" DEFAULT 'completed' NOT NULL;
+--> statement-breakpoint
+CREATE INDEX "terminations_status_idx" ON "terminations" USING btree ("status");
+--> statement-breakpoint
+UPDATE "terminations" SET "status" = 'canceled' WHERE "deleted_at" IS NOT NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1777939200000,
       "tag": "0041_add_users_anonymized_at",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1777470556236,
+      "tag": "0042_add_termination_status",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/employees.ts
+++ b/src/db/schema/employees.ts
@@ -59,6 +59,7 @@ export const employeeStatusEnum = pgEnum("employee_status", [
   "ON_LEAVE",
   "ON_VACATION",
   "VACATION_SCHEDULED",
+  "TERMINATION_SCHEDULED",
 ]);
 
 export const disabilityTypeEnum = pgEnum("disability_type", [

--- a/src/db/schema/terminations.ts
+++ b/src/db/schema/terminations.ts
@@ -20,6 +20,12 @@ export const terminationTypeEnum = pgEnum("termination_type", [
   "CONTRACT_END",
 ]);
 
+export const terminationStatusEnum = pgEnum("termination_status", [
+  "scheduled",
+  "completed",
+  "canceled",
+]);
+
 export const terminations = pgTable(
   "terminations",
   {
@@ -41,6 +47,7 @@ export const terminations = pgTable(
       .notNull(),
     lastWorkingDay: date("last_working_day").notNull(),
     notes: text("notes"),
+    status: terminationStatusEnum("status").default("completed").notNull(),
 
     // Audit
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -60,6 +67,7 @@ export const terminations = pgTable(
     index("terminations_employee_id_idx").on(table.employeeId),
     index("terminations_termination_date_idx").on(table.terminationDate),
     index("terminations_type_idx").on(table.type),
+    index("terminations_status_idx").on(table.status),
   ]
 );
 

--- a/src/modules/employees/employee.model.ts
+++ b/src/modules/employees/employee.model.ts
@@ -35,6 +35,7 @@ const employeeStatusValues = [
   "ON_LEAVE",
   "ON_VACATION",
   "VACATION_SCHEDULED",
+  "TERMINATION_SCHEDULED",
 ] as const;
 const disabilityTypeValues = [
   "AUDITIVA",

--- a/src/modules/occurrences/CLAUDE.md
+++ b/src/modules/occurrences/CLAUDE.md
@@ -13,7 +13,7 @@ Vacations armazena periodos aquisitivo e concessivo inline (campos na propria ta
 - ID format: `<entity>-${crypto.randomUUID()}` (e.g., `absence-...`, `accident-...`)
 - Service: abstract class com métodos estáticos, private `findById`/`findByIdIncludingDeleted`
 - Listagem ordenada pelo campo de data principal de cada entidade
-- Campos de data não aceitam datas no futuro (exceções: férias `startDate`/`endDate` podem ser futuras; medical-certificates `endDate` pode ser futuro)
+- Campos de data não aceitam datas no futuro (exceções: férias `startDate`/`endDate` podem ser futuras; medical-certificates `endDate` pode ser futuro; terminations `terminationDate`/`lastWorkingDay` podem ser futuras — agendamento)
 - Ranges de data (startDate/endDate) validam que início ≤ fim
 - Updates parciais validam datas contra valores existentes no DB via service
 - Helper compartilhado: `isFutureDate` e `isFutureDatetime` em `src/lib/schemas/date-helpers.ts`
@@ -28,6 +28,8 @@ Shared helpers at `src/modules/employees/status.ts` and errors at `src/modules/e
 - No status check: terminations
 
 Shared errors: `EmployeeTerminatedError` (422), `EmployeeOnVacationError` (422).
+
+**Note on `TERMINATION_SCHEDULED`:** Ocorrências aceitam funcionários em `TERMINATION_SCHEDULED` (rescisão futura agendada — employee ainda está ativo até a data efetiva). Apenas `TERMINATED` bloqueia novas ocorrências.
 
 ## Duplicate / Overlap Prevention on Create
 

--- a/src/modules/occurrences/terminations/CLAUDE.md
+++ b/src/modules/occurrences/terminations/CLAUDE.md
@@ -1,31 +1,59 @@
 # Terminations (Desligamentos)
 
-Registro de desligamentos de funcionários.
+Registro de desligamentos de funcionários com suporte a agendamento futuro.
 
 ## Business Rules
 
-- `terminationDate` e `lastWorkingDay` não podem ser no futuro
-- `noticePeriodDays` (inteiro ≥ 0, opcional) + `noticePeriodWorked` (boolean, default false)
-- `reason` (max 1000), `notes` (max 2000) — opcionais
-- Um employee só pode ter um desligamento ativo (não deletado) — tentativa de criar segundo lança `TerminationAlreadyExistsError`
-- Criar desligamento altera automaticamente o status do funcionário para `TERMINATED`
-- Deletar (soft delete) desligamento reverte o status do funcionário para `ACTIVE`
-- Sem verificação de status do employee no create (diferente dos demais sub-módulos)
-- Permissão usa resource específico `termination`
-- Listagem ordenada por `terminationDate`
+- `terminationDate` pode ser **passada, hoje ou futura**:
+  - Se `terminationDate > hoje` → registro criado com `status = scheduled`, employee fica `TERMINATION_SCHEDULED`.
+  - Se `terminationDate <= hoje` → registro criado com `status = completed`, employee vai para `TERMINATED`.
+- `lastWorkingDay <= terminationDate` (independente de scheduled ou completed).
+- `noticePeriodDays` (inteiro ≥ 0, opcional) + `noticePeriodWorked` (boolean, default false).
+- `reason` (max 1000), `notes` (max 2000) — opcionais.
+- Um employee só pode ter um desligamento ativo (não deletado) — `TerminationAlreadyExistsError` (409).
+- Update que altera `terminationDate` flipa o `status` imediatamente (sem esperar cron).
+- Soft delete seta `status = canceled` (antecipa migração futura que removerá `deletedAt`/`deletedBy`).
+- Sem verificação de status do employee no create — `TERMINATION_SCHEDULED` não bloqueia outras ocorrências (employee em rescisão agendada ainda pode tirar férias, registrar atestado, etc., durante o aviso prévio).
+
+## Status Lifecycle
+
+- `scheduled` — `terminationDate` no futuro. Employee em `TERMINATION_SCHEDULED`.
+- `completed` — `terminationDate <= hoje`. Employee em `TERMINATED`.
+- `canceled` — soft-deleted. Employee revertido para `ACTIVE` (se não houver outras terminations ativas).
+
+Transições:
+- `scheduled` → `completed`: cron `process-scheduled-terminations` (03:00 UTC / 00:00 BRT) ou update direto da data.
+- `scheduled` ↔ `completed`: update da `terminationDate` move entre os estados imediatamente.
+- `*` → `canceled`: DELETE soft.
+
+## Employee Status Sync
+
+Helper `syncEmployeeStatusForTermination` (private, na service) consulta a única termination ativa do employee e calcula:
+
+| Termination status | Employee status |
+|---|---|
+| `completed` | `TERMINATED` |
+| `scheduled` | `TERMINATION_SCHEDULED` |
+| `canceled` ou nenhuma ativa | `ACTIVE` |
+
+Aplicado em create, update e delete. Sync no-op (mesmo status) não emite audit log.
+
+O cron job (`TerminationJobsService.processScheduledTerminations`) usa `UPDATE` direto no employee (não passa pelo helper) — segue o precedente do `vacation-jobs.service.ts`. Sem audit log para o flip do cron porque `AuditService.log` exige `userId` não-null e o cron não tem actor humano.
 
 ## Audit logging
 
-- Plugin: `auditPlugin` registered in controller
-- Resource key: `termination`
-- Mutations logged: create, update, delete (via `AuditService.log` + `buildAuditChanges`)
-- Ignored fields: `employee` (JOIN-shaped virtual nested object) + `employeeId` (immutable FK; resource identity is captured via `resourceId`)
-- Side effects on `employees.status` (TERMINATED on create, ACTIVE on delete) ARE audited as `resource: "employee"` entries — captures the cross-module status transition for compliance trails
-- **Read audit enabled** on `GET /:id` — termination records include rescission/dismissal context (LGPD-sensitive)
+- Plugin: `auditPlugin` registered in controller.
+- Resource key: `termination`.
+- Mutations logged: create, update, delete (via `AuditService.log` + `buildAuditChanges`).
+- Ignored fields: `employee` (JOIN-shaped virtual nested object) + `employeeId` (immutable FK; resource identity é capturada via `resourceId`).
+- Side effects on `employees.status` ARE audited as `resource: "employee"` quando o status efetivamente muda (no-op syncs não emitem entry).
+- Cron job NÃO audita o flip employee status (limitação atual; vacations segue o mesmo precedente).
+- **Read audit enabled** on `GET /:id` — termination records contêm contexto de rescisão/dispensa (LGPD-sensitive).
 
 ## Enums
 
 - type: `RESIGNATION` | `DISMISSAL_WITH_CAUSE` | `DISMISSAL_WITHOUT_CAUSE` | `MUTUAL_AGREEMENT` | `CONTRACT_END`
+- status: `scheduled` | `completed` | `canceled` (default DB: `completed`)
 
 ## Errors
 
@@ -33,3 +61,11 @@ Registro de desligamentos de funcionários.
 - `TerminationAlreadyDeletedError` (404)
 - `TerminationInvalidEmployeeError` (422)
 - `TerminationAlreadyExistsError` (409) — one active termination per employee
+
+## Scheduled Jobs
+
+| Job | Action |
+|---|---|
+| `process-scheduled-terminations` | `scheduled` → `completed` quando `terminationDate <= hoje`; flipa employee para `TERMINATED` |
+
+Registrado em `src/plugins/cron/cron-plugin.ts` em `0 3 * * *` (03:00 UTC / 00:00 BRT).

--- a/src/modules/occurrences/terminations/__tests__/create-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/create-termination.test.ts
@@ -166,37 +166,6 @@ describe("POST /v1/terminations", () => {
     expect(response.status).toBe(422);
   });
 
-  test("should reject future termination date", async () => {
-    const { headers, organizationId, user } =
-      await createTestUserWithOrganization({
-        emailVerified: true,
-      });
-
-    const { employee } = await createTestEmployee({
-      organizationId,
-      userId: user.id,
-    });
-
-    const futureDate = new Date();
-    futureDate.setDate(futureDate.getDate() + 10);
-    const futureDateStr = futureDate.toISOString().split("T")[0];
-
-    const response = await app.handle(
-      new Request(`${BASE_URL}/v1/terminations`, {
-        method: "POST",
-        headers: { ...headers, "Content-Type": "application/json" },
-        body: JSON.stringify({
-          employeeId: employee.id,
-          terminationDate: futureDateStr,
-          type: "RESIGNATION",
-          lastWorkingDay: futureDateStr,
-        }),
-      })
-    );
-
-    expect(response.status).toBe(422);
-  });
-
   test("should create termination successfully", async () => {
     const { headers, organizationId, user } =
       await createTestUserWithOrganization({

--- a/src/modules/occurrences/terminations/__tests__/scheduled-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/scheduled-termination.test.ts
@@ -126,3 +126,109 @@ describe("POST /v1/terminations — scheduled flow", () => {
     expect(body.data.status).toBe("completed");
   });
 });
+
+describe("PUT /v1/terminations/:id — status flip on date change", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("flips scheduled→completed when terminationDate moves to past", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const futureDate = offsetISO(30);
+
+    const createRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: futureDate,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: futureDate,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+    const created = (await createRes.json()).data;
+    expect(created.status).toBe("scheduled");
+
+    const today = todayISO();
+    const updateRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations/${created.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          terminationDate: today,
+          lastWorkingDay: today,
+        }),
+      })
+    );
+
+    expect(updateRes.status).toBe(200);
+    const body = await updateRes.json();
+    expect(body.data.status).toBe("completed");
+
+    const [empRow] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(empRow?.status).toBe("TERMINATED");
+  });
+
+  test("flips completed→scheduled when terminationDate moves to future", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const today = todayISO();
+
+    const createRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: today,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: today,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+    const created = (await createRes.json()).data;
+    expect(created.status).toBe("completed");
+
+    const futureDate = offsetISO(15);
+    const updateRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations/${created.id}`, {
+        method: "PUT",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          terminationDate: futureDate,
+          lastWorkingDay: futureDate,
+        }),
+      })
+    );
+
+    expect(updateRes.status).toBe(200);
+    const body = await updateRes.json();
+    expect(body.data.status).toBe("scheduled");
+
+    const [empRow] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(empRow?.status).toBe("TERMINATION_SCHEDULED");
+  });
+});

--- a/src/modules/occurrences/terminations/__tests__/scheduled-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/scheduled-termination.test.ts
@@ -127,6 +127,101 @@ describe("POST /v1/terminations — scheduled flow", () => {
   });
 });
 
+describe("DELETE /v1/terminations/:id — soft delete with canceled status", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("sets status=canceled and reverts employee from TERMINATION_SCHEDULED to ACTIVE when deleting scheduled", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const futureDate = offsetISO(30);
+    const createRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: futureDate,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: futureDate,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+    const created = (await createRes.json()).data;
+    expect(created.status).toBe("scheduled");
+
+    const deleteRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations/${created.id}`, {
+        method: "DELETE",
+        headers,
+      })
+    );
+
+    expect(deleteRes.status).toBe(200);
+    const body = await deleteRes.json();
+    expect(body.data.status).toBe("canceled");
+    expect(body.data.deletedAt).toBeTruthy();
+
+    const [empRow] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(empRow?.status).toBe("ACTIVE");
+  });
+
+  test("sets status=canceled and reverts employee from TERMINATED to ACTIVE when deleting completed", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const today = todayISO();
+    const createRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: today,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: today,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+    const created = (await createRes.json()).data;
+    expect(created.status).toBe("completed");
+
+    const deleteRes = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations/${created.id}`, {
+        method: "DELETE",
+        headers,
+      })
+    );
+
+    expect(deleteRes.status).toBe(200);
+    const body = await deleteRes.json();
+    expect(body.data.status).toBe("canceled");
+
+    const [empRow] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(empRow?.status).toBe("ACTIVE");
+  });
+});
+
 describe("PUT /v1/terminations/:id — status flip on date change", () => {
   let app: TestApp;
 

--- a/src/modules/occurrences/terminations/__tests__/scheduled-termination.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/scheduled-termination.test.ts
@@ -1,0 +1,128 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { env } from "@/env";
+import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { createTestEmployee } from "@/test/helpers/employee";
+import { createTestUserWithOrganization } from "@/test/helpers/user";
+
+const BASE_URL = env.API_URL;
+
+function todayISO(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function offsetISO(daysFromToday: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromToday);
+  return d.toISOString().split("T")[0];
+}
+
+describe("POST /v1/terminations — scheduled flow", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("creates termination with status=scheduled and employee TERMINATION_SCHEDULED when terminationDate > today", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const futureDate = offsetISO(30);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: futureDate,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: futureDate,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(body.data.status).toBe("scheduled");
+
+    const [empRow] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(empRow?.status).toBe("TERMINATION_SCHEDULED");
+  });
+
+  test("creates termination with status=completed and employee TERMINATED when terminationDate is today", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const today = todayISO();
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: today,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: today,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.status).toBe("completed");
+
+    const [empRow] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(empRow?.status).toBe("TERMINATED");
+  });
+
+  test("creates termination with status=completed when terminationDate is in the past", async () => {
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const pastDate = offsetISO(-30);
+
+    const response = await app.handle(
+      new Request(`${BASE_URL}/v1/terminations`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({
+          employeeId: employee.id,
+          terminationDate: pastDate,
+          type: "DISMISSAL_WITHOUT_CAUSE",
+          lastWorkingDay: pastDate,
+          noticePeriodWorked: false,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.status).toBe("completed");
+  });
+});

--- a/src/modules/occurrences/terminations/__tests__/termination-jobs.test.ts
+++ b/src/modules/occurrences/terminations/__tests__/termination-jobs.test.ts
@@ -1,0 +1,127 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { TerminationService } from "@/modules/occurrences/terminations/termination.service";
+import { TerminationJobsService } from "@/modules/occurrences/terminations/termination-jobs.service";
+import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { createTestEmployee } from "@/test/helpers/employee";
+import { createTestUserWithOrganization } from "@/test/helpers/user";
+
+function offsetISO(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+describe("TerminationJobsService.processScheduledTerminations", () => {
+  let _app: TestApp;
+
+  beforeAll(() => {
+    _app = createTestApp();
+  });
+
+  test("flips scheduled to completed when terminationDate <= today", async () => {
+    const { organizationId, user } = await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const futureDate = offsetISO(30);
+    const created = await TerminationService.create({
+      employeeId: employee.id,
+      terminationDate: futureDate,
+      type: "DISMISSAL_WITHOUT_CAUSE",
+      lastWorkingDay: futureDate,
+      noticePeriodWorked: false,
+      organizationId,
+      userId: user.id,
+    });
+    expect(created.status).toBe("scheduled");
+
+    // Backdate so the job picks it up
+    const yesterday = offsetISO(-1);
+    await db
+      .update(schema.terminations)
+      .set({ terminationDate: yesterday })
+      .where(eq(schema.terminations.id, created.id));
+
+    const result = await TerminationJobsService.processScheduledTerminations();
+    expect(result.updated).toContain(created.id);
+
+    const [refreshed] = await db
+      .select({ status: schema.terminations.status })
+      .from(schema.terminations)
+      .where(eq(schema.terminations.id, created.id));
+    expect(refreshed?.status).toBe("completed");
+
+    const [emp] = await db
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(eq(schema.employees.id, employee.id));
+    expect(emp?.status).toBe("TERMINATED");
+  });
+
+  test("ignores soft-deleted terminations", async () => {
+    const { organizationId, user } = await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const futureDate = offsetISO(30);
+    const created = await TerminationService.create({
+      employeeId: employee.id,
+      terminationDate: futureDate,
+      type: "DISMISSAL_WITHOUT_CAUSE",
+      lastWorkingDay: futureDate,
+      noticePeriodWorked: false,
+      organizationId,
+      userId: user.id,
+    });
+
+    await TerminationService.delete(created.id, organizationId, user.id);
+
+    // Backdate after soft-delete
+    const yesterday = offsetISO(-1);
+    await db
+      .update(schema.terminations)
+      .set({ terminationDate: yesterday })
+      .where(eq(schema.terminations.id, created.id));
+
+    const result = await TerminationJobsService.processScheduledTerminations();
+    expect(result.updated).not.toContain(created.id);
+  });
+
+  test("is idempotent — second run does not re-process the same record", async () => {
+    const { organizationId, user } = await createTestUserWithOrganization();
+    const { employee } = await createTestEmployee({
+      organizationId,
+      userId: user.id,
+    });
+
+    const futureDate = offsetISO(30);
+    const created = await TerminationService.create({
+      employeeId: employee.id,
+      terminationDate: futureDate,
+      type: "DISMISSAL_WITHOUT_CAUSE",
+      lastWorkingDay: futureDate,
+      noticePeriodWorked: false,
+      organizationId,
+      userId: user.id,
+    });
+
+    const yesterday = offsetISO(-1);
+    await db
+      .update(schema.terminations)
+      .set({ terminationDate: yesterday })
+      .where(eq(schema.terminations.id, created.id));
+
+    const r1 = await TerminationJobsService.processScheduledTerminations();
+    expect(r1.updated).toContain(created.id);
+
+    const r2 = await TerminationJobsService.processScheduledTerminations();
+    expect(r2.updated).not.toContain(created.id);
+  });
+});

--- a/src/modules/occurrences/terminations/termination-jobs.service.ts
+++ b/src/modules/occurrences/terminations/termination-jobs.service.ts
@@ -1,0 +1,62 @@
+import { and, eq, isNull, lte } from "drizzle-orm";
+import { db } from "@/db";
+import { schema } from "@/db/schema";
+import { logger } from "@/lib/logger";
+
+type TerminationJobResult = {
+  processed: number;
+  updated: string[];
+};
+
+export abstract class TerminationJobsService {
+  static async processScheduledTerminations(): Promise<TerminationJobResult> {
+    const today = new Date().toISOString().split("T")[0];
+
+    const toComplete = await db
+      .select({
+        id: schema.terminations.id,
+        employeeId: schema.terminations.employeeId,
+        organizationId: schema.terminations.organizationId,
+      })
+      .from(schema.terminations)
+      .where(
+        and(
+          eq(schema.terminations.status, "scheduled"),
+          lte(schema.terminations.terminationDate, today),
+          isNull(schema.terminations.deletedAt)
+        )
+      );
+
+    const updated: string[] = [];
+
+    for (const termination of toComplete) {
+      try {
+        await db
+          .update(schema.terminations)
+          .set({ status: "completed" })
+          .where(eq(schema.terminations.id, termination.id));
+
+        await db
+          .update(schema.employees)
+          .set({ status: "TERMINATED" })
+          .where(eq(schema.employees.id, termination.employeeId));
+
+        updated.push(termination.id);
+      } catch (error) {
+        logger.error({
+          type: "job:process-scheduled-termination:failed",
+          terminationId: termination.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    logger.info({
+      type: "job:process-scheduled-terminations:complete",
+      processed: toComplete.length,
+      updated: updated.length,
+    });
+
+    return { processed: toComplete.length, updated };
+  }
+}

--- a/src/modules/occurrences/terminations/termination.model.ts
+++ b/src/modules/occurrences/terminations/termination.model.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { successResponseSchema } from "@/lib/responses/response.types";
-import { isFutureDate } from "@/lib/schemas/date-helpers";
 import { entityReferenceSchema } from "@/lib/schemas/relationships";
 
 const terminationFieldsSchema = z.object({
@@ -11,9 +10,6 @@ const terminationFieldsSchema = z.object({
   terminationDate: z
     .string()
     .date("Data de demissão deve ser uma data válida")
-    .refine((val) => !isFutureDate(val), {
-      message: "Data de demissão não pode ser no futuro",
-    })
     .describe("Data de demissão"),
   type: z
     .enum([
@@ -44,9 +40,6 @@ const terminationFieldsSchema = z.object({
   lastWorkingDay: z
     .string()
     .date("Último dia trabalhado deve ser uma data válida")
-    .refine((val) => !isFutureDate(val), {
-      message: "Último dia trabalhado não pode ser no futuro",
-    })
     .describe("Último dia trabalhado"),
   notes: z
     .string()
@@ -122,6 +115,9 @@ const terminationDataSchema = z.object({
   noticePeriodWorked: z.boolean().describe("Se o aviso prévio foi cumprido"),
   lastWorkingDay: z.string().describe("Último dia trabalhado"),
   notes: z.string().nullable().describe("Observações adicionais"),
+  status: z
+    .enum(["scheduled", "completed", "canceled"])
+    .describe("Status da rescisão"),
   createdAt: z.coerce.date().describe("Data de criação"),
   updatedAt: z.coerce.date().describe("Data de atualização"),
 });

--- a/src/modules/occurrences/terminations/termination.service.ts
+++ b/src/modules/occurrences/terminations/termination.service.ts
@@ -157,6 +157,62 @@ export abstract class TerminationService {
     }
   }
 
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: wired in subsequent tasks
+  private static async syncEmployeeStatusForTermination(
+    employeeId: string,
+    organizationId: string,
+    userId: string,
+    tx?: typeof db
+  ): Promise<{ before: string | null; after: string }> {
+    const executor = tx ?? db;
+
+    const [activeTermination] = await executor
+      .select({ status: schema.terminations.status })
+      .from(schema.terminations)
+      .where(
+        and(
+          eq(schema.terminations.employeeId, employeeId),
+          eq(schema.terminations.organizationId, organizationId),
+          isNull(schema.terminations.deletedAt)
+        )
+      )
+      .limit(1);
+
+    let nextStatus: "ACTIVE" | "TERMINATED" | "TERMINATION_SCHEDULED" =
+      "ACTIVE";
+    if (activeTermination?.status === "completed") {
+      nextStatus = "TERMINATED";
+    } else if (activeTermination?.status === "scheduled") {
+      nextStatus = "TERMINATION_SCHEDULED";
+    }
+
+    const [employeeBefore] = await executor
+      .select({ status: schema.employees.status })
+      .from(schema.employees)
+      .where(
+        and(
+          eq(schema.employees.id, employeeId),
+          eq(schema.employees.organizationId, organizationId)
+        )
+      );
+
+    if (employeeBefore?.status === nextStatus) {
+      return { before: employeeBefore.status, after: nextStatus };
+    }
+
+    await executor
+      .update(schema.employees)
+      .set({ status: nextStatus, updatedBy: userId })
+      .where(
+        and(
+          eq(schema.employees.id, employeeId),
+          eq(schema.employees.organizationId, organizationId)
+        )
+      );
+
+    return { before: employeeBefore?.status ?? null, after: nextStatus };
+  }
+
   static async create(input: CreateTerminationInput): Promise<TerminationData> {
     const { organizationId, userId, employeeId, ...data } = input;
 

--- a/src/modules/occurrences/terminations/termination.service.ts
+++ b/src/modules/occurrences/terminations/termination.service.ts
@@ -356,10 +356,17 @@ export abstract class TerminationService {
       throw new TerminationNotFoundError(id);
     }
 
+    const today = new Date().toISOString().split("T")[0];
+    const nextTerminationDate =
+      data.terminationDate ?? existing.terminationDate;
+    const nextStatus: "scheduled" | "completed" =
+      nextTerminationDate > today ? "scheduled" : "completed";
+
     const [updated] = await db
       .update(schema.terminations)
       .set({
         ...data,
+        status: nextStatus,
         updatedBy: userId,
       })
       .where(
@@ -380,6 +387,26 @@ export abstract class TerminationService {
         ignoredFields: TERMINATION_IGNORED_FIELDS,
       }),
     });
+
+    const sync = await TerminationService.syncEmployeeStatusForTermination(
+      existing.employee.id,
+      organizationId,
+      userId
+    );
+
+    if (sync.before !== sync.after) {
+      await AuditService.log({
+        action: "update",
+        resource: "employee",
+        resourceId: existing.employee.id,
+        userId,
+        organizationId,
+        changes: buildAuditChanges(
+          { status: sync.before },
+          { status: sync.after }
+        ),
+      });
+    }
 
     return TerminationService.findByIdOrThrow(id, organizationId);
   }

--- a/src/modules/occurrences/terminations/termination.service.ts
+++ b/src/modules/occurrences/terminations/termination.service.ts
@@ -45,6 +45,7 @@ export abstract class TerminationService {
         noticePeriodWorked: schema.terminations.noticePeriodWorked,
         lastWorkingDay: schema.terminations.lastWorkingDay,
         notes: schema.terminations.notes,
+        status: schema.terminations.status,
         createdAt: schema.terminations.createdAt,
         updatedAt: schema.terminations.updatedAt,
       })
@@ -87,6 +88,7 @@ export abstract class TerminationService {
         noticePeriodWorked: schema.terminations.noticePeriodWorked,
         lastWorkingDay: schema.terminations.lastWorkingDay,
         notes: schema.terminations.notes,
+        status: schema.terminations.status,
         createdAt: schema.terminations.createdAt,
         updatedAt: schema.terminations.updatedAt,
         deletedAt: schema.terminations.deletedAt,
@@ -262,6 +264,7 @@ export abstract class TerminationService {
         noticePeriodWorked: schema.terminations.noticePeriodWorked,
         lastWorkingDay: schema.terminations.lastWorkingDay,
         notes: schema.terminations.notes,
+        status: schema.terminations.status,
         createdAt: schema.terminations.createdAt,
         updatedAt: schema.terminations.updatedAt,
       })

--- a/src/modules/occurrences/terminations/termination.service.ts
+++ b/src/modules/occurrences/terminations/termination.service.ts
@@ -157,7 +157,6 @@ export abstract class TerminationService {
     }
   }
 
-  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: wired in subsequent tasks
   private static async syncEmployeeStatusForTermination(
     employeeId: string,
     organizationId: string,
@@ -226,6 +225,10 @@ export abstract class TerminationService {
       employeeId
     );
 
+    const today = new Date().toISOString().split("T")[0];
+    const status: "scheduled" | "completed" =
+      data.terminationDate > today ? "scheduled" : "completed";
+
     const terminationId = `termination-${crypto.randomUUID()}`;
 
     const [termination] = await db
@@ -241,6 +244,7 @@ export abstract class TerminationService {
         noticePeriodWorked: data.noticePeriodWorked,
         lastWorkingDay: data.lastWorkingDay,
         notes: data.notes ?? null,
+        status,
         createdBy: userId,
       })
       .returning();
@@ -256,37 +260,25 @@ export abstract class TerminationService {
       }),
     });
 
-    const [employeeBefore] = await db
-      .select({ status: schema.employees.status })
-      .from(schema.employees)
-      .where(
-        and(
-          eq(schema.employees.id, employeeId),
-          eq(schema.employees.organizationId, organizationId)
-        )
-      );
-
-    await db
-      .update(schema.employees)
-      .set({ status: "TERMINATED", updatedBy: userId })
-      .where(
-        and(
-          eq(schema.employees.id, employeeId),
-          eq(schema.employees.organizationId, organizationId)
-        )
-      );
-
-    await AuditService.log({
-      action: "update",
-      resource: "employee",
-      resourceId: employeeId,
-      userId,
+    const sync = await TerminationService.syncEmployeeStatusForTermination(
+      employeeId,
       organizationId,
-      changes: buildAuditChanges(
-        { status: employeeBefore?.status ?? null },
-        { status: "TERMINATED" }
-      ),
-    });
+      userId
+    );
+
+    if (sync.before !== sync.after) {
+      await AuditService.log({
+        action: "update",
+        resource: "employee",
+        resourceId: employeeId,
+        userId,
+        organizationId,
+        changes: buildAuditChanges(
+          { status: sync.before },
+          { status: sync.after }
+        ),
+      });
+    }
 
     return {
       id: termination.id,
@@ -299,6 +291,7 @@ export abstract class TerminationService {
       noticePeriodWorked: termination.noticePeriodWorked,
       lastWorkingDay: termination.lastWorkingDay,
       notes: termination.notes,
+      status: termination.status,
       createdAt: termination.createdAt,
       updatedAt: termination.updatedAt,
     } as TerminationData;

--- a/src/modules/occurrences/terminations/termination.service.ts
+++ b/src/modules/occurrences/terminations/termination.service.ts
@@ -434,6 +434,8 @@ export abstract class TerminationService {
       .set({
         deletedAt: new Date(),
         deletedBy: userId,
+        status: "canceled",
+        updatedBy: userId,
       })
       .where(
         and(
@@ -456,40 +458,29 @@ export abstract class TerminationService {
       ),
     });
 
-    const [employeeBefore] = await db
-      .select({ status: schema.employees.status })
-      .from(schema.employees)
-      .where(
-        and(
-          eq(schema.employees.id, existing.employee.id),
-          eq(schema.employees.organizationId, organizationId)
-        )
-      );
-
-    await db
-      .update(schema.employees)
-      .set({ status: "ACTIVE", updatedBy: userId })
-      .where(
-        and(
-          eq(schema.employees.id, existing.employee.id),
-          eq(schema.employees.organizationId, organizationId)
-        )
-      );
-
-    await AuditService.log({
-      action: "update",
-      resource: "employee",
-      resourceId: existing.employee.id,
-      userId,
+    const sync = await TerminationService.syncEmployeeStatusForTermination(
+      existing.employee.id,
       organizationId,
-      changes: buildAuditChanges(
-        { status: employeeBefore?.status ?? null },
-        { status: "ACTIVE" }
-      ),
-    });
+      userId
+    );
+
+    if (sync.before !== sync.after) {
+      await AuditService.log({
+        action: "update",
+        resource: "employee",
+        resourceId: existing.employee.id,
+        userId,
+        organizationId,
+        changes: buildAuditChanges(
+          { status: sync.before },
+          { status: sync.after }
+        ),
+      });
+    }
 
     return {
       ...existing,
+      status: "canceled",
       deletedAt: deleted.deletedAt as Date,
       deletedBy: deleted.deletedBy,
     } as DeletedTerminationData;

--- a/src/plugins/cron/CLAUDE.md
+++ b/src/plugins/cron/CLAUDE.md
@@ -19,6 +19,7 @@ Orquestra jobs agendados do domínio. Composição de 7 cron jobs via `@elysiajs
 | `process-scheduled-plan-changes` | `0 12 * * *` | `JobsService.processScheduledPlanChanges` |
 | `activate-scheduled-vacations` | `0 3 * * *` (03:00 UTC = 00:00 BRT) | `VacationJobsService.activateScheduledVacations` |
 | `complete-expired-vacations` | `0 3 * * *` | `VacationJobsService.completeExpiredVacations` |
+| `process-scheduled-terminations` | `0 3 * * *` (03:00 UTC = 00:00 BRT) | `TerminationJobsService.processScheduledTerminations` |
 
 ## Hooks
 

--- a/src/plugins/cron/cron-plugin.ts
+++ b/src/plugins/cron/cron-plugin.ts
@@ -1,6 +1,7 @@
 import { cron } from "@elysiajs/cron";
 import { Elysia } from "elysia";
 import { logger } from "@/lib/logger";
+import { TerminationJobsService } from "@/modules/occurrences/terminations/termination-jobs.service";
 import { VacationJobsService } from "@/modules/occurrences/vacations/vacation-jobs.service";
 import { JobsService } from "@/modules/payments/jobs/jobs.service";
 
@@ -76,6 +77,14 @@ export const cronPlugin = new Elysia({ name: "cron-jobs" })
       name: "complete-expired-vacations",
       pattern: "0 3 * * *",
       run: () => VacationJobsService.completeExpiredVacations(),
+      log: (r) => ({ updated: r.updated.length }),
+    })
+  )
+  .use(
+    createCronJob({
+      name: "process-scheduled-terminations",
+      pattern: "0 3 * * *",
+      run: () => TerminationJobsService.processScheduledTerminations(),
       log: (r) => ({ updated: r.updated.length }),
     })
   );


### PR DESCRIPTION
## Summary

Adiciona suporte a `terminationDate` futura no módulo de rescisões. Espelha o padrão de `vacations` (status enum no DB + cron job + sync de status do funcionário), adaptado para o caso de evento pontual.

### Backend changes

- **Schema**:
  - Novo enum `termination_status` com valores `scheduled`, `completed`, `canceled` (default DB: `completed`).
  - Nova coluna `terminations.status` + índice.
  - Novo valor `TERMINATION_SCHEDULED` no `employee_status` enum.
  - Migration `0042_add_termination_status.sql` com backfill: registros soft-deleted recebem `status = 'canceled'`.

- **Service**:
  - `create` ramifica em `terminationDate <= hoje ? completed : scheduled`. Sync employee para `TERMINATED` ou `TERMINATION_SCHEDULED`.
  - `update` flipa status imediatamente quando `terminationDate` muda.
  - `delete` seta `status = canceled` (forward-compat para futura migração que removerá `deletedAt`/`deletedBy`).
  - Helper privado `syncEmployeeStatusForTermination` centraliza a resolução do employee status.

- **Cron**:
  - Novo job `process-scheduled-terminations` em `0 3 * * *` (03:00 UTC = 00:00 BRT) flipa `scheduled → completed` + employee `TERMINATED`.

- **Validation**:
  - Removido `refine(!isFutureDate)` de `terminationDate` e `lastWorkingDay`.
  - Mantida validação `lastWorkingDay <= terminationDate`.

- **Docs**: `terminations/CLAUDE.md` reescrito; `occurrences/CLAUDE.md` atualizado com a exceção de future-date e nota sobre `TERMINATION_SCHEDULED`.

### Why default 'completed' (not 'scheduled')

A maioria dos registros históricos representa rescisões já efetivadas. Default `completed` reflete o caso comum se algum código bypassar o service. Service sempre seta o status explicitamente baseado na data.

### Why include 'canceled' in the status enum now

Antecipa migração futura "remover `deletedAt`/`deletedBy`, usar apenas `updatedAt`/`updatedBy` + status". O backfill já popula `status = 'canceled'` para registros soft-deleted, então a transição futura será só remover as colunas — sem migração de dados adicional.

### Forward-compat caveat

`ensureNoActiveTermination` ainda filtra por `WHERE deletedAt IS NULL`. Quando `deletedAt` for removido, esse filtro precisará ser substituído por `status != 'canceled'`. Não é escopo desta PR — adicionar ao backlog da migração futura.

### Cron audit limitation

`AuditService.log` exige `userId` não-null. Cron não tem actor humano. Solução escolhida: cron NÃO emite audit log para o flip employee status (segue o precedente do `vacation-jobs.service.ts`). Se compliance pedir, será necessário um campo `sourceType: 'system'` no schema de audit em PR separada.

## Plano

`docs/improvements/2026-04-29-termination-scheduled-plan.md` (escrito antes da implementação, contém as 13 tasks executadas + concerns documentadas + alternativas avaliadas).

## Test plan

- [ ] CI verde (build, test, lint)
- [ ] Migration aplicada em staging
  - [ ] Verificar `termination_status` type criado com 3 valores
  - [ ] Verificar `TERMINATION_SCHEDULED` adicionado ao `employee_status`
  - [ ] Verificar registros soft-deleted existentes recebem `status = 'canceled'`
- [ ] Smoke test em staging
  - [ ] POST /v1/terminations com `terminationDate` futura → status `scheduled`, employee `TERMINATION_SCHEDULED`
  - [ ] POST /v1/terminations com `terminationDate` hoje → status `completed`, employee `TERMINATED`
  - [ ] PUT /v1/terminations/:id alterando `terminationDate` para passado → status flipa para `completed`
  - [ ] DELETE /v1/terminations/:id → status `canceled`, employee `ACTIVE`
- [ ] Cron `process-scheduled-terminations` rodado manualmente em staging — verificar registros `scheduled` com data passada são flipados

## Frontend

PR de frontend depende deste merge para regenerar o cliente kubb. Branch: `feat/scheduled-termination` em `synnerdata-web-n` (não criada ainda — Tasks 14-19 do plano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)