### PR TITLE
fix(migrations): correct 0042 journal timestamp (HML broken)

### DIFF
--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -299,7 +299,7 @@
     {
       "idx": 42,
       "version": "7",
-      "when": 1777470556236,
+      "when": 1778025600000,
       "tag": "0042_add_termination_status",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary

**Hotfix para HML quebrado** — `GET /v1/terminations` retorna 500 com `column terminations.status does not exist`.

### Causa raiz

A entrada da migration 0042 no `_journal.json` foi criada manualmente (drizzle-kit generate está quebrado por causa de uma colisão de snapshot pré-existente — registrado em CP/infra) com `when=1777470556236` (29-mar-2026). Isso é **anterior** ao `when` da 0041 (`1777939200000`, 04-abr-2026).

drizzle-orm's migrator filtra por `entry.when > last_applied_when`. Como 0041 já estava aplicada na HML, 0042 foi silenciosamente **pulada** em todo deploy. O log `"Database migrations completed in 56ms"` era enganoso — nenhuma DDL rodou para 0042.

### Fix

Corrigir o `when` de 0042 para `1778025600000` (29-abr-2026, posterior a 0041). Drizzle vai detectar como pendente e executar no próximo deploy.

### Impacto

- **HML:** resolve o erro 500. Coluna é criada via `ADD COLUMN ... DEFAULT 'completed' NOT NULL`. Backfill `UPDATE ... SET status='canceled' WHERE deleted_at IS NOT NULL` roda. Sem perda de dados — operação aditiva.
- **Dev local:** se algum dev aplicou DDL manualmente durante o desenvolvimento da feature (situação reportada nos task logs originais), drizzle pode flagar hash na próxima migrate. Workaround documentado no commit body.
- **Produção:** quando subir, mesmo comportamento da HML — migration aplica limpa.

## Test plan

- [ ] Merge desta PR
- [ ] Deploy em HML → verificar log `"Database migrations completed in Xms"` com X significativamente > 56ms (deve ter ~200-500ms para a migration real)
- [ ] `GET /v1/terminations` em HML → status 200 com lista (vazia ou populada)
- [ ] Verificar via psql/studio que `terminations.status` existe

## Lição aprendida

Migrations manuais (sem drizzle-kit generate) precisam usar `when=Date.now()` ou um valor garantidamente posterior ao último `when` do journal — não o timestamp do momento de criação do arquivo, que pode estar fora de ordem se o desenvolvimento aconteceu em paralelo. Vale considerar adicionar um lint/CI check que valida ordenação cronológica do journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)