### PR TITLE
docs(claude-md): db:generate TTY limitation + snapshot chain debt context

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,6 +40,22 @@ Drizzle migrations são fonte da verdade do schema do banco. Disciplina obrigat�
 - **Reescrita do journal/snapshots de migrations já aplicadas em prod:** permitido alterar `when` do journal (não dispara re-aplicação porque drizzle compara contra `lastDbMigration.created_at`, que é o mais recente). NUNCA renomeie `tag` ou edite o `.sql` de uma migration já mergeada — drizzle valida hash e o deploy quebra.
 - **`__drizzle_migrations` table** vive no schema `drizzle` (não `public`). Estrutura: `id` (auto-increment), `hash` (do conteúdo SQL), `created_at` (= `when` do journal no momento da aplicação).
 
+### Estado atual do snapshot chain (debt conhecido)
+
+Snapshots de metadata em `src/db/migrations/meta/` estão ausentes para `idx 35-42` (e algumas históricas como 15, 21, 22, 23, 26). Os arquivos `.sql` dessas migrations existem e são canônicos — apenas os snapshots de metadata local-only são lacunas.
+
+**Consequência para `db:generate`:** o diff é computado contra o último snapshot disponível (0034). Como schema TS evoluiu até 0042+, qualquer chamada de `db:generate` gera uma migration "catchup" enorme que tenta replicar todas as mudanças de 0035-0042. Não é o que se quer.
+
+**Em terminais interativos:** drizzle-kit prompta pra resolver column renames durante esse diff. Em ambientes não-interativos (CI, sandboxes de agentes IA, scripts), aborta com erro `Interactive prompts require a TTY terminal`.
+
+**Workaround atual:** continue escrevendo migrations manualmente com `Date.now()` para `when` (regras acima). O bug do 0042-style fica prevenido pelos validators no CI.
+
+**Solução estrutural (backlog):** upgrade pra drizzle-kit v1.0 stable quando sair (atualmente em beta). v1.0 redesigna snapshots em estrutura DAG (`prevIds: string[]`) com checks de commutatividade nativos — elimina essa classe inteira de bug.
+
+### Histórico do incidente 0042 (referência para agentes investigando)
+
+PR #305 (correção urgente do `when`), #306 (validator + governança), #307 (snapshot chain repair + drizzle-kit check no CI) cobrem a sequência completa do incidente em 2026-04-29. Plan original em `docs/improvements/2026-04-29-termination-scheduled-plan.md`. Para entender o porquê das regras desta seção, consulte os PR bodies.
+
 ### Guard-rails para agentes de IA
 
 Ao tocar em qualquer arquivo sob `src/db/`:


### PR DESCRIPTION
## Resumo

Fecha 2 lacunas em \`.claude/CLAUDE.md\` que ficaram após PRs #305-307. Identificadas em audit pós-incidente.

## Gaps

### 1. \`db:generate\` TTY limitation não documentada

Estado atual do repo: snapshots 0035-0042 ausentes (post-PR #307). Latest snapshot disponível é 0034. Consequência:

- Em terminal interativo: \`db:generate\` prompta pra resolver column renames (diff contra 0034 vs schema TS atual = grande)
- Em CI/sandbox/script: aborta com erro críptico \`Interactive prompts require a TTY terminal\`

Sem essa documentação, agentes IA futuros tentando rodar \`db:generate\` em modo autônomo vão hit o erro e perder tempo investigando.

### 2. Falta ponteiro pro contexto histórico

CLAUDE.md mencionava o incidente 0042 como justificativa das regras, mas sem apontar onde o full context vive. Adicionei referência pra PRs #305-307 + plan doc em \`docs/improvements/\`.

## Mudança

Duas subsections adicionadas em \`## Database Versioning\`:

- **\"Estado atual do snapshot chain (debt conhecido)\"** — explica latest=0034, consequência pro db:generate, workaround (manual migration), solução estrutural (drizzle-kit v1.0 quando estável)
- **\"Histórico do incidente 0042 (referência para agentes investigando)\"** — ponteiro pra PRs e plan doc

## Test plan

- [x] CI verde (lint+validator+drizzle-kit check) — só docs, sem mudanças funcionais
- [x] Lê de forma natural — confere com a estrutura existente da seção

🤖 Generated with [Claude Code](https://claude.com/claude-code)