### PR TITLE
feat(cost-centers): expose createdBy/updatedBy as { id, name } (PRD #4)

### DIFF
--- a/src/modules/organizations/cost-centers/CLAUDE.md
+++ b/src/modules/organizations/cost-centers/CLAUDE.md
@@ -22,3 +22,65 @@ Centros de custo para alocação financeira. Referenciado por employees (FK opci
 - `CostCenterNotFoundError` (404)
 - `CostCenterAlreadyExistsError` (409)
 - `CostCenterAlreadyDeletedError` (404)
+
+## User Attribution Shape (Reference Implementation)
+
+Este módulo é a referência canônica para expor `createdBy`/`updatedBy` como `{ id, name }` na resposta da API (PRD #4 — `docs/improvements/2026-04-27-user-attribution-roadmap-design.md`). PRDs subsequentes (#5+) replicam este padrão para os 23 módulos restantes.
+
+### Padrão obrigatório
+
+- **Helper de aliases**: `auditUserAliases()` em `src/lib/schemas/audit-users.ts` retorna `{ creator, updater }` aliasados de `users`. Use sempre — não duplique `aliasedTable(schema.users, "...")` direto.
+- **Schema de resposta**: `entityReferenceSchema` em `src/lib/schemas/relationships.ts` é o `{ id, name }`. Use sempre — não introduza `auditUserSchema` ou variantes.
+- **Estilo de query**: Drizzle Core API com `select()` inline + `innerJoin` em creator e updater. **Não** use a Relational API (`db.query` + `with`) — o pattern do projeto é Core.
+- **Constraints**: `createdBy` e `updatedBy` são FKs `NOT NULL ON DELETE RESTRICT` para `users.id` (enforced pela PRD #3). `innerJoin` é seguro porque o FK target sempre existe (anonymização preserva a linha).
+- **Atribuição de deleção**: não há campo `deletedBy` no domain table nem no response — `audit_logs` é a fonte. PRD #3 removeu `deletedBy` de todas as 24 tabelas que tinham.
+
+### Forma do response data schema
+
+```ts
+import { entityReferenceSchema } from "@/lib/schemas/relationships";
+
+const costCenterDataSchema = z.object({
+  // ... campos do recurso ...
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+  createdBy: entityReferenceSchema,
+  updatedBy: entityReferenceSchema,
+});
+```
+
+### Forma da query (read paths)
+
+```ts
+import { auditUserAliases } from "@/lib/schemas/audit-users";
+
+const { creator, updater } = auditUserAliases();
+
+const [row] = await db
+  .select({
+    // ... campos do recurso ...
+    createdBy: { id: creator.id, name: creator.name },
+    updatedBy: { id: updater.id, name: updater.name },
+  })
+  .from(schema.costCenters)
+  .innerJoin(creator, eq(schema.costCenters.createdBy, creator.id))
+  .innerJoin(updater, eq(schema.costCenters.updatedBy, updater.id))
+  .where(/* ... */)
+  .limit(1);
+```
+
+### Mutation pattern
+
+- **Create**: `INSERT ... RETURNING` → `audit_logs` log → `findByIdOrThrow(id)` re-read para retornar com a forma enriquecida.
+- **Update**: `UPDATE ... RETURNING` → `audit_logs` log → `findByIdOrThrow(id)` re-read.
+- **Delete (soft)**: `findByIdIncludingDeleted` (já enriquecido) → `UPDATE ... SET deletedAt = now() RETURNING` → `audit_logs` log → retorne `{ ...existing, deletedAt }`.
+
+Sem transaction wrapper. O custo de uma read extra é negligenciável e o código fica direto.
+
+### Audit log
+
+`IGNORED_AUDIT_FIELDS` em `src/modules/audit/pii-redaction.ts` já ignora `createdBy`, `updatedBy`, `createdAt`, `updatedAt`, `deletedAt`. Logo, a mudança de forma do `existing` (objeto vs string user_id) **não vaza** para o `changes` do audit log — o diff continua minimal.
+
+### Cobertura de teste end-to-end
+
+`__tests__/anonymized-creator.test.ts` valida o path PRD #2 + PRD #3 + PRD #4: cria cost-center com manager → manager se anonimiza via `POST /v1/account/anonymize` → owner faz GET → response retorna `createdBy: { id: managerId, name: "Usuário removido" }`. Esse teste prova que o FK target sobrevive à anonymization e que o join surface o nome canônico.

--- a/src/modules/organizations/cost-centers/CLAUDE.md
+++ b/src/modules/organizations/cost-centers/CLAUDE.md
@@ -73,7 +73,9 @@ const [row] = await db
 
 - **Create**: `INSERT ... RETURNING` → `audit_logs` log → `findByIdOrThrow(id)` re-read para retornar com a forma enriquecida.
 - **Update**: `UPDATE ... RETURNING` → `audit_logs` log → `findByIdOrThrow(id)` re-read.
-- **Delete (soft)**: `findByIdIncludingDeleted` (já enriquecido) → `UPDATE ... SET deletedAt = now() RETURNING` → `audit_logs` log → retorne `{ ...existing, deletedAt }`.
+- **Delete (soft)**: `findByIdIncludingDeleted` (já enriquecido) → `UPDATE ... SET deletedAt = now(), updatedBy = userId RETURNING` → `audit_logs` log → retorne `{ ...existing, deletedAt }`.
+
+Soft-delete segue Semantic A — todo `db.update().set()` inclui `updatedBy: userId`, inclusive quando o único campo de domínio mudado é `deletedAt`. Vide convenção em `.claude/CLAUDE.md` ("Timestamps convention"). `audit_logs` permanece a fonte canônica de atribuição da deleção; `updatedBy` aqui mantém o par `(updatedAt, updatedBy)` coerente após o `$onUpdate` automático do Drizzle.
 
 Sem transaction wrapper. O custo de uma read extra é negligenciável e o código fica direto.
 

--- a/src/modules/organizations/cost-centers/__tests__/anonymized-creator.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/anonymized-creator.test.ts
@@ -1,0 +1,63 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { env } from "@/env";
+import { CostCenterService } from "@/modules/organizations/cost-centers/cost-center.service";
+import { createTestApp, type TestApp } from "@/test/helpers/app";
+import { addMemberToOrganization } from "@/test/helpers/organization";
+import {
+  createTestUser,
+  createTestUserWithOrganization,
+} from "@/test/helpers/user";
+
+const BASE_URL = env.API_URL;
+const TEST_PASSWORD = "TestPassword123!";
+const ANONYMIZED_NAME = "Usuário removido";
+
+describe("Cost-center surfaces anonymized creator", () => {
+  let app: TestApp;
+
+  beforeAll(() => {
+    app = createTestApp();
+  });
+
+  test("GET returns createdBy with anonymized name after creator self-anonymizes", async () => {
+    const owner = await createTestUserWithOrganization({ emailVerified: true });
+    const member = await createTestUser({ emailVerified: true });
+    await addMemberToOrganization(member, {
+      organizationId: owner.organizationId,
+      role: "manager",
+    });
+
+    const costCenter = await CostCenterService.create({
+      organizationId: owner.organizationId,
+      userId: member.user.id,
+      name: `Centro Anonymized ${crypto.randomUUID().slice(0, 8)}`,
+    });
+
+    const anonymizeResp = await app.handle(
+      new Request(`${BASE_URL}/v1/account/anonymize`, {
+        method: "POST",
+        headers: { ...member.headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ password: TEST_PASSWORD }),
+      })
+    );
+    expect(anonymizeResp.status).toBe(200);
+
+    const getResp = await app.handle(
+      new Request(`${BASE_URL}/v1/cost-centers/${costCenter.id}`, {
+        method: "GET",
+        headers: owner.headers,
+      })
+    );
+    expect(getResp.status).toBe(200);
+    const body = await getResp.json();
+    expect(body.success).toBe(true);
+    expect(body.data.createdBy).toEqual({
+      id: member.user.id,
+      name: ANONYMIZED_NAME,
+    });
+    expect(body.data.updatedBy).toEqual({
+      id: member.user.id,
+      name: ANONYMIZED_NAME,
+    });
+  });
+});

--- a/src/modules/organizations/cost-centers/__tests__/create-cost-center.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/create-cost-center.test.ts
@@ -121,9 +121,10 @@ describe("POST /v1/cost-centers", () => {
   });
 
   test("should create cost center successfully", async () => {
-    const { headers, organizationId } = await createTestUserWithOrganization({
-      emailVerified: true,
-    });
+    const { headers, organizationId, user } =
+      await createTestUserWithOrganization({
+        emailVerified: true,
+      });
 
     const response = await app.handle(
       new Request(`${BASE_URL}/v1/cost-centers`, {
@@ -144,6 +145,8 @@ describe("POST /v1/cost-centers", () => {
     expect(body.data.id).toStartWith("cost-center-");
     expect(body.data.organizationId).toBe(organizationId);
     expect(body.data.name).toBe(validCostCenterData.name);
+    expect(body.data.createdBy).toEqual({ id: user.id, name: user.name });
+    expect(body.data.updatedBy).toEqual({ id: user.id, name: user.name });
   });
 
   test.each([

--- a/src/modules/organizations/cost-centers/__tests__/delete-cost-center.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/delete-cost-center.test.ts
@@ -111,6 +111,8 @@ describe("DELETE /v1/cost-centers/:id", () => {
     expect(body.success).toBe(true);
     expect(body.data.id).toBe(costCenter.id);
     expect(body.data.deletedAt).toBeDefined();
+    expect(body.data.createdBy).toEqual({ id: user.id, name: user.name });
+    expect(body.data.updatedBy).toEqual({ id: user.id, name: user.name });
   });
 
   test.each([

--- a/src/modules/organizations/cost-centers/__tests__/get-cost-center.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/get-cost-center.test.ts
@@ -138,5 +138,7 @@ describe("GET /v1/cost-centers/:id", () => {
     expect(body.data.id).toBe(costCenter.id);
     expect(body.data.organizationId).toBe(organizationId);
     expect(body.data.name).toBe("Centro de Custo Financeiro");
+    expect(body.data.createdBy).toEqual({ id: user.id, name: user.name });
+    expect(body.data.updatedBy).toEqual({ id: user.id, name: user.name });
   });
 });

--- a/src/modules/organizations/cost-centers/__tests__/list-cost-centers.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/list-cost-centers.test.ts
@@ -94,6 +94,10 @@ describe("GET /v1/cost-centers", () => {
     expect(body.data.length).toBe(2);
     expect(body.data[0].organizationId).toBe(organizationId);
     expect(body.data[1].organizationId).toBe(organizationId);
+    for (const item of body.data) {
+      expect(item.createdBy).toEqual({ id: user.id, name: user.name });
+      expect(item.updatedBy).toEqual({ id: user.id, name: user.name });
+    }
   });
 
   test("should not return cost centers from other organizations", async () => {

--- a/src/modules/organizations/cost-centers/__tests__/update-cost-center.test.ts
+++ b/src/modules/organizations/cost-centers/__tests__/update-cost-center.test.ts
@@ -174,6 +174,11 @@ describe("PUT /v1/cost-centers/:id", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.data.name).toBe("Updated by Manager");
+    expect(body.data.createdBy).toEqual({ id: user.id, name: user.name });
+    expect(body.data.updatedBy).toEqual({
+      id: memberResult.user.id,
+      name: memberResult.user.name,
+    });
   });
 
   test("should return 409 when updating cost center to duplicate name", async () => {

--- a/src/modules/organizations/cost-centers/cost-center.model.ts
+++ b/src/modules/organizations/cost-centers/cost-center.model.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { successResponseSchema } from "@/lib/responses/response.types";
+import { entityReferenceSchema } from "@/lib/schemas/relationships";
 
 export const createCostCenterSchema = z.object({
   name: z
@@ -21,6 +22,12 @@ const costCenterDataSchema = z.object({
   name: z.string().describe("Nome do centro de custo"),
   createdAt: z.coerce.date().describe("Data de criação"),
   updatedAt: z.coerce.date().describe("Data de atualização"),
+  createdBy: entityReferenceSchema.describe(
+    "Usuário que criou o centro de custo"
+  ),
+  updatedBy: entityReferenceSchema.describe(
+    "Usuário que atualizou o centro de custo pela última vez"
+  ),
 });
 
 const deletedCostCenterDataSchema = costCenterDataSchema.extend({

--- a/src/modules/organizations/cost-centers/cost-center.service.ts
+++ b/src/modules/organizations/cost-centers/cost-center.service.ts
@@ -1,6 +1,7 @@
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { schema } from "@/db/schema";
+import { auditUserAliases } from "@/lib/schemas/audit-users";
 import { AuditService } from "@/modules/audit/audit.service";
 import { buildAuditChanges } from "@/modules/audit/pii-redaction";
 import type {
@@ -42,9 +43,27 @@ export abstract class CostCenterService {
     id: string,
     organizationId: string
   ): Promise<CostCenterData | null> {
+    const { creator, updater } = auditUserAliases();
+
     const [costCenter] = await db
-      .select()
+      .select({
+        id: schema.costCenters.id,
+        organizationId: schema.costCenters.organizationId,
+        name: schema.costCenters.name,
+        createdAt: schema.costCenters.createdAt,
+        updatedAt: schema.costCenters.updatedAt,
+        createdBy: {
+          id: creator.id,
+          name: creator.name,
+        },
+        updatedBy: {
+          id: updater.id,
+          name: updater.name,
+        },
+      })
       .from(schema.costCenters)
+      .innerJoin(creator, eq(schema.costCenters.createdBy, creator.id))
+      .innerJoin(updater, eq(schema.costCenters.updatedBy, updater.id))
       .where(
         and(
           eq(schema.costCenters.id, id),
@@ -54,16 +73,35 @@ export abstract class CostCenterService {
       )
       .limit(1);
 
-    return (costCenter as CostCenterData) ?? null;
+    return costCenter ?? null;
   }
 
   private static async findByIdIncludingDeleted(
     id: string,
     organizationId: string
   ): Promise<(CostCenterData & { deletedAt: Date | null }) | null> {
+    const { creator, updater } = auditUserAliases();
+
     const [costCenter] = await db
-      .select()
+      .select({
+        id: schema.costCenters.id,
+        organizationId: schema.costCenters.organizationId,
+        name: schema.costCenters.name,
+        createdAt: schema.costCenters.createdAt,
+        updatedAt: schema.costCenters.updatedAt,
+        deletedAt: schema.costCenters.deletedAt,
+        createdBy: {
+          id: creator.id,
+          name: creator.name,
+        },
+        updatedBy: {
+          id: updater.id,
+          name: updater.name,
+        },
+      })
       .from(schema.costCenters)
+      .innerJoin(creator, eq(schema.costCenters.createdBy, creator.id))
+      .innerJoin(updater, eq(schema.costCenters.updatedBy, updater.id))
       .where(
         and(
           eq(schema.costCenters.id, id),
@@ -82,7 +120,7 @@ export abstract class CostCenterService {
 
     const costCenterId = `cost-center-${crypto.randomUUID()}`;
 
-    const [costCenter] = await db
+    const [inserted] = await db
       .insert(schema.costCenters)
       .values({
         id: costCenterId,
@@ -96,19 +134,37 @@ export abstract class CostCenterService {
     await AuditService.log({
       action: "create",
       resource: "cost_center",
-      resourceId: costCenter.id,
+      resourceId: inserted.id,
       userId,
       organizationId,
-      changes: buildAuditChanges({}, costCenter),
+      changes: buildAuditChanges({}, inserted),
     });
 
-    return costCenter as CostCenterData;
+    return CostCenterService.findByIdOrThrow(inserted.id, organizationId);
   }
 
   static async findAll(organizationId: string): Promise<CostCenterData[]> {
+    const { creator, updater } = auditUserAliases();
+
     const costCenters = await db
-      .select()
+      .select({
+        id: schema.costCenters.id,
+        organizationId: schema.costCenters.organizationId,
+        name: schema.costCenters.name,
+        createdAt: schema.costCenters.createdAt,
+        updatedAt: schema.costCenters.updatedAt,
+        createdBy: {
+          id: creator.id,
+          name: creator.name,
+        },
+        updatedBy: {
+          id: updater.id,
+          name: updater.name,
+        },
+      })
       .from(schema.costCenters)
+      .innerJoin(creator, eq(schema.costCenters.createdBy, creator.id))
+      .innerJoin(updater, eq(schema.costCenters.updatedBy, updater.id))
       .where(
         and(
           eq(schema.costCenters.organizationId, organizationId),
@@ -117,7 +173,7 @@ export abstract class CostCenterService {
       )
       .orderBy(schema.costCenters.name);
 
-    return costCenters as CostCenterData[];
+    return costCenters;
   }
 
   static async findByIdOrThrow(
@@ -174,7 +230,7 @@ export abstract class CostCenterService {
       changes: buildAuditChanges(existing, updated),
     });
 
-    return updated as CostCenterData;
+    return CostCenterService.findByIdOrThrow(id, organizationId);
   }
 
   static async delete(
@@ -217,6 +273,9 @@ export abstract class CostCenterService {
       changes: buildAuditChanges(existing, {}),
     });
 
-    return deleted as DeletedCostCenterData;
+    return {
+      ...existing,
+      deletedAt: deleted.deletedAt as Date,
+    };
   }
 }

--- a/src/modules/organizations/cost-centers/cost-center.service.ts
+++ b/src/modules/organizations/cost-centers/cost-center.service.ts
@@ -255,6 +255,7 @@ export abstract class CostCenterService {
       .update(schema.costCenters)
       .set({
         deletedAt: new Date(),
+        updatedBy: userId,
       })
       .where(
         and(


### PR DESCRIPTION
## Summary

Cost-centers passa a expor `createdBy` e `updatedBy` como `{ id, name }` na resposta da API, consumindo `auditUserAliases()` e `entityReferenceSchema`. Pilot da iniciativa user-attribution-roadmap (PRD #4); referência canônica para PRD #5+ que replicará o padrão nos 23 módulos restantes.

- Service usa Drizzle Core inline `select()` + `innerJoin` em creator/updater. `create`/`update` mutate-then-re-read; `delete` (soft) spread do `existing` enriquecido.
- Schema TS de cost-centers intocado — FKs `NOT NULL ON DELETE RESTRICT` em `created_by`/`updated_by` já enforced pela migration `0043_audit_fk_not_null.sql` (PRD #3).
- Audit-log diff inalterado — `IGNORED_AUDIT_FIELDS` em `src/modules/audit/pii-redaction.ts` já ignorava `createdBy`/`updatedBy`, então a mudança de forma do `existing` (objeto vs string) não vaza para o `changes` registrado.
- Novo teste de integração `anonymized-creator.test.ts` cobre o path PRD #2 + PRD #3 + PRD #4 end-to-end: manager cria cost-center → manager se anonimiza via `POST /v1/account/anonymize` → owner faz GET → response retorna `createdBy: { id: managerId, name: "Usuário removido" }`. Validação direta da preservação do FK target pela anonymization.
- `src/modules/organizations/cost-centers/CLAUDE.md` documenta o pattern canônico (helpers, query shape, mutation pattern, audit-log).

**Frontend**: o response shape de cost-centers muda de `createdBy: string` para `createdBy: { id, name }` (e o mesmo para `updatedBy`). Sem `deletedBy` em nenhum endpoint. Regenerar tipos kubb após merge.

Refs:
- Design: `docs/improvements/2026-04-27-user-attribution-roadmap-design.md` (seção PRD #4)
- PRDs anteriores: PR #296 (PRD #1), PR #300 + PR #302 (PRD #2), PR #303 (PRD #3)

## Test plan

- [x] `bun x tsc --noEmit` clean
- [x] `npx ultracite check` clean
- [x] `bun run db:check` clean (schema TS intocado)
- [x] `NODE_ENV=test bun test --env-file .env.test src/modules/organizations/cost-centers/__tests__/` — 50/50 (49 originais + 1 anonymized-creator)
- [x] `NODE_ENV=test bun test --env-file .env.test src/modules/auth/anonymize/__tests__/` — 27/27 (sanity check cross-module)
- [x] OpenAPI spot-check via `bun run dev` + `/openapi/json`: `createdBy`/`updatedBy` aparecem como `{ id, name }` (required) em GET/LIST/POST/PUT/DELETE; nenhum endpoint expõe `deletedBy`
- [x] Spot-check semantic: assertion em `update-cost-center.test.ts` prova "Semantic A" — após manager dar PUT, `createdBy` permanece o owner original e `updatedBy` muda para o manager
- [ ] Frontend team avisado para regenerar tipos kubb (sem ação no PR)